### PR TITLE
Add explicit venv creation in actions

### DIFF
--- a/.github/workflows/build_deploy_documentation.yml
+++ b/.github/workflows/build_deploy_documentation.yml
@@ -38,7 +38,10 @@ jobs:
       - name: Setup PDM
         uses: pdm-project/setup-pdm@v4
       - name: Install default and doc dependencies
-        run: pdm install --group doc --frozen-lockfile
+        run: |
+          pdm venv create 3.12.3
+          pdm use .venv/bin/python
+          pdm install --group doc --frozen-lockfile
       - name: Build HTML
         run: |
           cd docs/

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,10 @@ jobs:
       - name: Setup PDM
         uses: pdm-project/setup-pdm@v4
       - name: Install check dependencies
-        run: pdm install --no-default --group check --frozen-lockfile
+        run: |
+          pdm venv create 3.12.3
+          pdm use .venv/bin/python
+          pdm install --no-default --group check --frozen-lockfile
       - name: Cache pre-commit hooks
         uses: actions/cache@v2
         with:
@@ -44,7 +47,10 @@ jobs:
       - name: Setup PDM
         uses: pdm-project/setup-pdm@v4
       - name: Install default and test dependencies
-        run: pdm install --group test --frozen-lockfile
+        run: |
+          pdm venv create 3.12.3
+          pdm use .venv/bin/python
+          pdm install --group test --frozen-lockfile
       - name: Run unit tests
         run: pdm run pytest tests/unit
       - name: Run doc tests


### PR DESCRIPTION
Somehow, the pre-commit action failed recently, only once. Re-running the action lead to a success.

I think the fail was because pdm tried to create a python 3.12.4 environment while we only installed 3.12.3. I think its better to explicitly specify to pdm how it should create the venv to avoid such problems.

Note that this corresponds to the CONTRIBUTING.md steps.