### PR TITLE
Documentation fixes

### DIFF
--- a/docs/source/examples/basic_usage.rst
+++ b/docs/source/examples/basic_usage.rst
@@ -2,7 +2,7 @@ Basic Usage
 ===========
 
 
-This example shows how to use torchjd to perform an iteration of Jacobian Descent on a regression
+This example shows how to use TorchJD to perform an iteration of Jacobian Descent on a regression
 model. In this example, a batch of inputs is forwarded through the model and the corresponding batch
 of labels is used to compute a batch of losses. These losses are then backwarded through the model.
 The obtained Jacobian matrix, consisting of the gradients of the losses, is then aggregated using

--- a/docs/source/examples/basic_usage.rst
+++ b/docs/source/examples/basic_usage.rst
@@ -8,7 +8,7 @@ of labels is used to compute a batch of losses. These losses are then backwarded
 The obtained Jacobian matrix, consisting of the gradients of the losses, is then aggregated using
 UPGrad, and the parameters are updated using the resulting aggregation.
 
-Import several classes from torch and torchjd:
+Import several classes from ``torch`` and ``torchjd``:
 
 >>> import torch
 >>> from torch.nn import MSELoss, Sequential, Linear, ReLU
@@ -43,7 +43,7 @@ We can now compute the losses associated to each element of the batch.
 >>> output = model(input)
 >>> losses = loss_fn(output, target)
 
-Note that setting `reduction='none'` is necessary to obtain the element-wise loss vector.
+Note that setting ``reduction='none'`` is necessary to obtain the element-wise loss vector.
 
 The last steps are similar to gradient descent-based optimization.
 

--- a/docs/source/examples/basic_usage.rst
+++ b/docs/source/examples/basic_usage.rst
@@ -26,8 +26,9 @@ Define the aggregator that will be used to combine the Jacobian matrix:
 
 >>> A = UPGrad()
 
-In essence, UPGrad projects each gradient onto the dual cone of the rows of the Jacobian and
-averages the results. This ensures that locally, no loss will be negatively affected by the update.
+In essence, :doc:`UPGrad <../docs/aggregation/upgrad>` projects each gradient onto the dual cone of
+the rows of the Jacobian and averages the results. This ensures that locally, no loss will be
+negatively affected by the update.
 
 Now that everything is defined, we can train the model. Define the input and the associated target:
 

--- a/src/torchjd/backward.py
+++ b/src/torchjd/backward.py
@@ -49,7 +49,7 @@ def backward(
     :param retain_graph: If ``False``, the graph used to compute the grad will be freed. Defaults to
         ``False``.
     :param parallel_chunk_size: The number of scalars to differentiate simultaneously in the
-        backward pass. If set to ``None``, all coordinates of ``tensor`` will be differentiated in
+        backward pass. If set to ``None``, all coordinates of ``tensors`` will be differentiated in
         parallel at once. If set to `1`, all coordinates will be differentiated sequentially. A
         larger value results in faster differentiation, but also higher memory usage. Defaults to
         ``None``.

--- a/tests/unit/aggregation/utils/property_testers.py
+++ b/tests/unit/aggregation/utils/property_testers.py
@@ -14,7 +14,7 @@ from torchjd.aggregation import Aggregator
 
 class ExpectedShapeProperty:
     """
-    This class tests that the vector returned by the `__call__` method of an `Aggregator` have the
+    This class tests that the vector returned by the `__call__` method of an `Aggregator` has the
     expected shape. Note that this property implies that the `__call__` method does not raise any
     exception.
     """
@@ -32,12 +32,7 @@ class ExpectedShapeProperty:
 
 class NonConflictingProperty:
     """
-    This class tests empirically that a given `Aggregator` has the `Non-conflicting property` (as
-    defined in `docs/source/aggregation_properties/non_conflicting.rst`).
-
-    .. info:
-        Due to numerical approximation in some `Aggregator`s, it may be that the output direction
-        has negligible negative elements. This test is lenient for such cases.
+    This class tests empirically that a given `Aggregator` satisfies the non-conflicting property.
     """
 
     @classmethod
@@ -63,7 +58,7 @@ class NonConflictingProperty:
 class PermutationInvarianceProperty:
     """
     This class tests empirically that for a given `Aggregator`, randomly permuting rows of the input
-    matrix doesn't change the aggregated vector.
+    matrix doesn't change the aggregation.
     """
 
     N_PERMUTATIONS = 5


### PR DESCRIPTION
- **Rename torchjd to TorchJD**
- **Improve formatting in basic_usage.rst**
- **Fix typo in backward docstring**
- **Add link to UPGrad in basic usage example**
- **Update docstrings of property testers**
