### PR TITLE
[Waiting] Add docformatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,13 @@ repos:
     hooks:
     -   id: black  # Format code.
         args: [--line-length=100]
+
+-   repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.5
+    hooks:
+    -   id: docformatter
+        additional_dependencies: [tomli]
+        args: [
+            '--in-place',
+            '--config=./pyproject.toml'
+        ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,10 @@ plot = [
     "dash>=2.16.0",  # Recent version to avoid problems, could be relaxed
     "kaleido==0.2.1",  # Only works with locked version
 ]
+
+[tool.docformatter]
+recursive = true
+wrap-summaries = 100
+wrap-descriptions = 100
+pre-summary-newline = true
+force-wrap = true


### PR DESCRIPTION
Fixes #77 
- **Add docformatter pre-commit hook**

Currently a bug in `docformatter` prevents us from using it.

TODO:
- [ ] Update rev of `docformatter` in `.pre-commit-config.yaml` whenever the [bug](https://github.com/PyCQA/docformatter/issues/263) is fixed and the fix is released. There is an open [PR](https://github.com/PyCQA/docformatter/pull/284) for this already.
- [ ] Run `pdm run pre-commit run --all-files` and commit the changes to apply the new formatting.