### PR TITLE
Fix `Transform`s' representations

### DIFF
--- a/src/torchjd/autojac/_transform/aggregate.py
+++ b/src/torchjd/autojac/_transform/aggregate.py
@@ -26,9 +26,6 @@ class Aggregate(Transform[Jacobians, Gradients]):
     def _compute(self, input: Jacobians) -> Gradients:
         return self.transform(input)
 
-    def __str__(self) -> str:
-        raise f"Aggregate {self._aggregator_str}"
-
     @property
     def required_keys(self) -> set[Tensor]:
         return self.transform.required_keys
@@ -55,9 +52,6 @@ class _AggregateMatrices(Transform[JacobianMatrices, GradientVectors]):
         """
         ordered_matrices = self._select_ordered_subdict(jacobian_matrices, self.key_order)
         return self._aggregate_group(ordered_matrices, self.aggregator)
-
-    def __str__(self) -> str:
-        return f"Unifying {self.aggregator}"
 
     @property
     def required_keys(self) -> set[Tensor]:

--- a/src/torchjd/autojac/_transform/base.py
+++ b/src/torchjd/autojac/_transform/base.py
@@ -36,7 +36,7 @@ class Transform(Generic[_B, _C], ABC):
     def conjunct(self, other: Transform[_B, _C]) -> Transform[_B, _C]:
         return Conjunction([self, other])
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         return type(self).__name__
 
     @abstractmethod
@@ -71,8 +71,8 @@ class Composition(Transform[_A, _C]):
         self.outer = outer
         self.inner = inner
 
-    def __repr__(self) -> str:
-        return repr(self.outer) + " ∘ " + repr(self.inner)
+    def __str__(self) -> str:
+        return str(self.outer) + " ∘ " + str(self.inner)
 
     def _compute(self, input: _A) -> _C:
         intermediate = self.inner(input)

--- a/src/torchjd/autojac/_transform/base.py
+++ b/src/torchjd/autojac/_transform/base.py
@@ -104,6 +104,16 @@ class Conjunction(Transform[_A, _B]):
         if len(self._output_keys) != len(output_keys_with_duplicates):
             raise ValueError("The sets of output keys of transforms should be disjoint.")
 
+    def __str__(self) -> str:
+        strings = []
+        for t in self.transforms:
+            s = str(t)
+            if isinstance(t, Conjunction):
+                strings.append(s[1:-1])  # Remove parentheses
+            else:
+                strings.append(s)
+        return "(" + " | ".join(strings) + ")"
+
     def _compute(self, tensor_dict: _A) -> _B:
         output = _union([transform(tensor_dict) for transform in self.transforms])
         return output

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -18,6 +18,9 @@ class FakeTransform(Transform[_B, _C]):
         self._required_keys = required_keys
         self._output_keys = output_keys
 
+    def __str__(self):
+        return "T"
+
     def _compute(self, input: _B) -> _C:
         # ignore the input, create a dictionary with the right keys as an output.
         # cast the type for the purpose of type-checking.
@@ -125,3 +128,15 @@ def test_conjunction_empty_transforms():
     conjunction = Conjunction([])
 
     assert len(conjunction(TensorDict({}))) == 0
+
+
+def test_str():
+    """
+    Tests that the __str__ method works correctly even for transform involving compositions and
+    conjunctions.
+    """
+
+    t = FakeTransform(set(), set())
+    transform = (t | t << t << t | t) << t << (t | t)
+
+    assert str(transform) == "(T | T ∘ T ∘ T | T) ∘ T ∘ (T | T)"

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -92,14 +92,14 @@ def test_multiple_differentiation_with_grad():
     assert_tensor_dicts_are_close(output, expected_output)
 
 
-def test_repr():
-    """Tests that the repr method works correctly even for a complex transform."""
+def test_str():
+    """Tests that the __str__ method works correctly even for a complex transform."""
     init = Init([])
     diag = Diagonalize([])
     jac = Jac([], [], chunk_size=None)
     transform = jac << diag << init
 
-    assert repr(transform) == "Jac ∘ Diagonalize ∘ Init"
+    assert str(transform) == "Jac ∘ Diagonalize ∘ Init"
 
 
 def test_simple_conjunction():


### PR DESCRIPTION
* Override `__str__` instead of `__repr__` in `Transform`
* Add `Conjunction.__str__`
* Add `test_str` and `FakeTransform.__str__`
* Remove `__str__` override in `Aggregate` and `_AggregateMatrices`

We never discussed this last change so I'll give more details about it:
Currently, when we have an `Aggregate` transform and call `str` on it, it calls the `__str__` method of `Transform`, which returns the class name:
```python
>>> from torchjd.autojac._transform.aggregate import Aggregate
>>> from torchjd.aggregation import Mean
>>> A = Mean()
>>> t = Aggregate(A, set())
>>> str(t)
'Aggregate'
```

This does not indicate that the aggregator is `Mean()`, and I think it's fine like this for two reasons. We will rarely ever use several different aggregators in the same `Transform`, and this is in line with having `Transform` strings quite minimalist: for instance they do not contain the arguments of the `Grad`, `Jac` or even `Select` transforms.

So instead of overriding `_AggregateMatrices.__str__` and `Aggregate.__str__` to add the contained aggregator's string, we just use the inherited `Transform.__str__` which just returns the class name.

By the way, I think that having `str(t) == "Aggregate"` is much better than having `str(t) == "_Reshape ° _AggregateMatrices ° _Matrixify`, which doesn't give any more information and is much longer.