### PR TITLE
Change title of documentation to "TorchJD"

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,3 +67,5 @@ html_theme_options = {
 html_js_files = [
     ("https://stats.torchjd.org/js/script.js", {"data-domain": "torchjd.org", "defer": "defer"}),
 ]
+
+html_title = "TorchJD"


### PR DESCRIPTION
![Screenshot from 2024-07-13 19-23-46](https://github.com/user-attachments/assets/c4e09059-8053-4d4f-ae7a-b6d02d1a33e0)

- Left: before
- Middle: after
- Right: what PyTorch does

Note: base is `main` (so that we can directly see if it works after building the doc).