### PR TITLE
Add cuda tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ changes that do not affect the user.
   adapted.
 - Improved documentation of `backward`.
 
+### Fixed
+
+- Fixed wrong tensor device with `IMTLG` in some rare cases.
+
 
 ## [0.1.0] - 2024-06-22
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,11 @@ before implementing major changes to torchjd.
      pdm run pytest tests/unit
      ```
 
+   - If you have access to a cuda-enabled GPU, you should also check that the unit tests pass on it:
+     ```bash
+     CUBLAS_WORKSPACE_CONFIG=:4096:8 PYTEST_TORCH_DEVICE=cuda pdm run pytest tests/unit
+     ```
+
    - To check that the usage examples from docstrings and `.rst` files are correct, we test their
    behavior in `tests/doc`. To run these tests, do:
      ```bash

--- a/src/torchjd/aggregation/_gramian_utils.py
+++ b/src/torchjd/aggregation/_gramian_utils.py
@@ -32,8 +32,7 @@ def _compute_normalized_gramian(matrix: Tensor, norm_eps: float) -> Tensor:
     except LinAlgError as error:  # Not sure if this can happen
         raise ValueError(
             f"Unexpected failure of the svd computation on matrix {matrix}. Please open an "
-            "issue on https://github.com/ValerianRey/torchjd and paste this error message in "
-            "it."
+            "issue on https://github.com/TorchJD/torchjd/issues and paste this error message in it."
         ) from error
     max_singular_value = torch.max(singular_values)
     if max_singular_value < norm_eps:

--- a/src/torchjd/aggregation/imtl_g.py
+++ b/src/torchjd/aggregation/imtl_g.py
@@ -44,7 +44,7 @@ class _IMTLGWeighting(_Weighting):
         try:
             raw_weights = torch.linalg.pinv(matrix @ matrix.T) @ d
         except LinAlgError:  # This can happen when the matrix has extremely large values
-            raw_weights = torch.ones(matrix.shape[0])
+            raw_weights = torch.ones(matrix.shape[0], device=matrix.device, dtype=matrix.dtype)
 
         weights = raw_weights / raw_weights.sum()
         return weights

--- a/src/torchjd/autojac/_transform/grad.py
+++ b/src/torchjd/autojac/_transform/grad.py
@@ -46,7 +46,9 @@ def _grad(
         return tuple()
 
     if len(outputs) == 0:
-        return tuple([torch.empty(input.shape) for input in inputs])
+        return tuple(
+            [torch.empty(input.shape, device=input.device, dtype=input.dtype) for input in inputs]
+        )
 
     optional_grads = torch.autograd.grad(
         outputs,

--- a/src/torchjd/autojac/_transform/jac.py
+++ b/src/torchjd/autojac/_transform/jac.py
@@ -45,8 +45,8 @@ def _jac(
     """
     Wraps the call to `autograd.grad` to compute the jacobian with respect to each input, in an
     optimized way. The first dimension of the jacobians is equal to the length of the sequence of
-    `outputs`, which should be the same as the length of the sequence of `grad_outputs`. This should
-    be equivalent to calling `_grad(outputs[i], inputs, grad_outputs[i], ...)` for all i
+    `outputs`, which should be the same as the length of the sequence of `jac_outputs`. This should
+    be equivalent to calling `_grad(outputs[i], inputs, jac_outputs[i], ...)` for all i
     sequentially, and stacking the elements of each resulting tuple.
     """
 

--- a/src/torchjd/autojac/_transform/jac.py
+++ b/src/torchjd/autojac/_transform/jac.py
@@ -61,7 +61,12 @@ def _jac(
         )
 
     if n_outputs == 0:
-        return tuple([torch.empty((0,) + input.shape) for input in inputs])
+        return tuple(
+            [
+                torch.empty((0,) + input.shape, device=input.device, dtype=input.dtype)
+                for input in inputs
+            ]
+        )
 
     def get_vjp(v):
         optional_grads = torch.autograd.grad(

--- a/tests/doc/test_backward.py
+++ b/tests/doc/test_backward.py
@@ -1,4 +1,5 @@
 from torch.testing import assert_close
+from unit.conftest import DEVICE
 
 
 def test_backward():
@@ -7,11 +8,11 @@ def test_backward():
     from torchjd import backward
     from torchjd.aggregation import UPGrad
 
-    param = torch.tensor([1.0, 2.0], requires_grad=True)
+    param = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
     # Compute arbitrary quantities that are function of param
-    y1 = torch.tensor([-1.0, 1.0]) @ param
+    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ param
     y2 = (param**2).sum()
 
     backward([y1, y2], [param], A=UPGrad())
 
-    assert_close(param.grad, torch.tensor([0.5000, 2.5000]), rtol=0.0, atol=1e-04)
+    assert_close(param.grad, torch.tensor([0.5000, 2.5000], device=DEVICE), rtol=0.0, atol=1e-04)

--- a/tests/unit/aggregation/_property_testers.py
+++ b/tests/unit/aggregation/_property_testers.py
@@ -22,6 +22,7 @@ class ExpectedShapeProperty:
 
     @staticmethod
     def _assert_expected_shape_property(aggregator: Aggregator, matrix: Tensor) -> None:
+        # matrix = matrix.to(device=DEVICE)
         vector = aggregator(matrix)  # Will fail if the call raises an exception
         assert vector.shape == matrix.shape[1:]
 
@@ -45,6 +46,7 @@ class NonConflictingProperty:
         aggregator: Aggregator,
         matrix: Tensor,
     ) -> None:
+        # matrix = matrix.to(device=DEVICE)
         vector = aggregator(matrix)
         output_direction = matrix @ vector
         positive_directions = output_direction[output_direction >= 0]
@@ -66,6 +68,7 @@ class PermutationInvarianceProperty:
 
     @staticmethod
     def _assert_permutation_invariance_property(aggregator: Aggregator, matrix: Tensor) -> None:
+        # matrix = matrix.to(DEVICE)
         vector = aggregator(matrix)
 
         for _ in range(PermutationInvarianceProperty.N_PERMUTATIONS):

--- a/tests/unit/aggregation/test_base.py
+++ b/tests/unit/aggregation/test_base.py
@@ -3,6 +3,7 @@ from typing import ContextManager, Sequence
 
 import pytest
 import torch
+from unit.conftest import DEVICE
 
 from torchjd.aggregation import Aggregator
 
@@ -19,4 +20,4 @@ from torchjd.aggregation import Aggregator
 )
 def test_check_is_matrix(shape: Sequence[int], expectation: ContextManager):
     with expectation:
-        Aggregator._check_is_matrix(torch.randn(shape))
+        Aggregator._check_is_matrix(torch.randn(shape, device=DEVICE))

--- a/tests/unit/aggregation/test_constant.py
+++ b/tests/unit/aggregation/test_constant.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 from torch import Tensor
+from unit.conftest import DEVICE
 
 from torchjd.aggregation import Constant
 
@@ -15,7 +16,8 @@ from ._property_testers import ExpectedShapeProperty
 
 def _make_aggregator(matrix: Tensor) -> Constant:
     n_rows = matrix.shape[0]
-    return Constant(torch.tensor([1.0 / n_rows] * n_rows))
+    weights = torch.tensor([1.0 / n_rows] * n_rows, device=DEVICE)
+    return Constant(weights)
 
 
 _matrices_1 = scaled_matrices + zero_rank_matrices

--- a/tests/unit/aggregation/test_mgda.py
+++ b/tests/unit/aggregation/test_mgda.py
@@ -30,7 +30,7 @@ class TestMGDA(ExpectedShapeProperty, NonConflictingProperty, PermutationInvaria
 )
 def test_mgda_satisfies_kkt_conditions(shape: tuple[int, int]):
     matrix = torch.randn(shape, device=DEVICE)
-    weighting = _MGDAWeighting(epsilon=1e-05, max_iters=10000)
+    weighting = _MGDAWeighting(epsilon=1e-05, max_iters=1000)
 
     gramian = matrix @ matrix.T
 
@@ -49,7 +49,7 @@ def test_mgda_satisfies_kkt_conditions(shape: tuple[int, int]):
 
     # Dual feasibility
     positive_mu = mu[mu >= 0]
-    assert_close(positive_mu.norm(), mu.norm(), atol=3e-04, rtol=0.0)
+    assert_close(positive_mu.norm(), mu.norm(), atol=1e-02, rtol=0.0)
 
 
 def test_representations():

--- a/tests/unit/aggregation/test_mgda.py
+++ b/tests/unit/aggregation/test_mgda.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 from torch.testing import assert_close
+from unit.conftest import DEVICE
 
 from torchjd.aggregation import MGDA
 from torchjd.aggregation.mgda import _MGDAWeighting
@@ -28,7 +29,7 @@ class TestMGDA(ExpectedShapeProperty, NonConflictingProperty, PermutationInvaria
     ],
 )
 def test_mgda_satisfies_kkt_conditions(shape: tuple[int, int]):
-    matrix = torch.randn(shape)
+    matrix = torch.randn(shape, device=DEVICE)
     weighting = _MGDAWeighting(epsilon=1e-05, max_iters=10000)
 
     gramian = matrix @ matrix.T
@@ -44,7 +45,7 @@ def test_mgda_satisfies_kkt_conditions(shape: tuple[int, int]):
     assert_close(positive_weights.norm(), weights.norm())
 
     weights_sum = weights.sum()
-    assert_close(weights_sum, torch.ones([]))
+    assert_close(weights_sum, torch.ones([], device=DEVICE))
 
     # Dual feasibility
     positive_mu = mu[mu >= 0]

--- a/tests/unit/aggregation/test_pcgrad.py
+++ b/tests/unit/aggregation/test_pcgrad.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 from torch.testing import assert_close
+from unit.conftest import DEVICE
 
 from torchjd.aggregation import PCGrad
 from torchjd.aggregation.pcgrad import _PCGradWeighting
@@ -36,7 +37,7 @@ def test_equivalence_upgrad_sum_two_rows(shape: tuple[int, int]):
     rows.
     """
 
-    matrix = torch.randn(shape)
+    matrix = torch.randn(shape, device=DEVICE)
 
     pc_grad_weighting = _PCGradWeighting()
     upgrad_sum_weighting = _UPGradWrapper(

--- a/tests/unit/aggregation/test_upgrad.py
+++ b/tests/unit/aggregation/test_upgrad.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 from torch.testing import assert_close
+from unit.conftest import DEVICE
 
 from torchjd.aggregation import UPGrad
 from torchjd.aggregation.mean import _MeanWeighting
@@ -20,8 +21,8 @@ class TestUPGrad(ExpectedShapeProperty, NonConflictingProperty, PermutationInvar
 
 @pytest.mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100)])
 def test_upgrad_lagrangian_satisfies_kkt_conditions(shape: tuple[int, int]):
-    matrix = torch.randn(shape)
-    weights = torch.rand(shape[0])
+    matrix = torch.randn(shape, device=DEVICE)
+    weights = torch.rand(shape[0], device=DEVICE)
 
     gramian = matrix @ matrix.T
 
@@ -40,7 +41,7 @@ def test_upgrad_lagrangian_satisfies_kkt_conditions(shape: tuple[int, int]):
     assert_close(positive_constraint.norm(), constraint.norm(), atol=1e-04, rtol=0)
 
     slackness = torch.trace(lagrange_multiplier @ constraint)
-    assert_close(slackness, torch.zeros_like(slackness), atol=3e-03, rtol=0)
+    assert_close(slackness, torch.zeros_like(slackness, device=DEVICE), atol=3e-03, rtol=0)
 
 
 def test_representations():

--- a/tests/unit/autojac/_transform/test_aggregate.py
+++ b/tests/unit/autojac/_transform/test_aggregate.py
@@ -47,7 +47,6 @@ def test_aggregate_matrices_output_structure(jacobian_matrices: JacobianMatrices
     Tests that applying _AggregateMatrices to various dictionaries of jacobian matrices gives an
     output of the desired structure.
     """
-    print(jacobian_matrices)
 
     aggregate_matrices = _AggregateMatrices(Random(), key_order=_keys)
     gradient_vectors = aggregate_matrices(jacobian_matrices)

--- a/tests/unit/autojac/_transform/test_aggregate.py
+++ b/tests/unit/autojac/_transform/test_aggregate.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 import pytest
 import torch
 from torch import Tensor
+from unit.conftest import DEVICE
 
 from torchjd.aggregation import Random
 from torchjd.autojac._transform import GradientVectors, JacobianMatrices, Jacobians
@@ -14,7 +15,7 @@ from ._dict_assertions import assert_tensor_dicts_are_close
 
 def _make_jacobian_matrices(n_outputs: int, rng: torch.Generator) -> JacobianMatrices:
     jacobian_shapes = [[n_outputs, math.prod(shape)] for shape in _param_shapes]
-    jacobian_list = [torch.rand(shape, generator=rng) for shape in jacobian_shapes]
+    jacobian_list = [torch.rand(shape, generator=rng, device=DEVICE) for shape in jacobian_shapes]
     jacobian_matrices = JacobianMatrices({key: jac for key, jac in zip(_keys, jacobian_list)})
     return jacobian_matrices
 
@@ -34,9 +35,9 @@ _param_shapes = [
     [2, 3, 4, 5],
     [5, 5, 5, 5],
 ]
-_keys = [torch.zeros(shape) for shape in _param_shapes]
+_keys = [torch.zeros(shape, device=DEVICE) for shape in _param_shapes]
 
-_rng = torch.Generator()
+_rng = torch.Generator(device=DEVICE)
 _rng.manual_seed(0)
 _jacobian_matrix_dicts = [_make_jacobian_matrices(n_outputs, _rng) for n_outputs in [1, 2, 5]]
 
@@ -71,18 +72,18 @@ def test_aggregate_matrices_empty_dict():
     ["united_gradient_vector", "jacobian_matrices"],
     [
         (
-            torch.ones(10),
+            torch.ones(10, device=DEVICE),
             {  # Total number of parameters according to the united gradient vector: 10
-                torch.ones(5): torch.ones(2, 5),
-                torch.ones(4): torch.ones(2, 4),
+                torch.ones(5, device=DEVICE): torch.ones(2, 5, device=DEVICE),
+                torch.ones(4, device=DEVICE): torch.ones(2, 4, device=DEVICE),
             },
         ),  # Total number of parameters according to the jacobian matrices: 9
         (
-            torch.ones(10),
+            torch.ones(10, device=DEVICE),
             {  # Total number of parameters according to the united gradient vector: 10
-                torch.ones(5): torch.ones(2, 5),
-                torch.ones(3): torch.ones(2, 3),
-                torch.ones(3): torch.ones(2, 3),
+                torch.ones(5, device=DEVICE): torch.ones(2, 5, device=DEVICE),
+                torch.ones(3, device=DEVICE): torch.ones(2, 3, device=DEVICE),
+                torch.ones(3, device=DEVICE): torch.ones(2, 3, device=DEVICE),
             },
         ),  # Total number of parameters according to the jacobian matrices: 11
     ],
@@ -102,21 +103,21 @@ def test_matrixify():
     """Tests that the Matrixify transform correctly creates matrices from the jacobians."""
 
     n_outputs = 5
-    key1 = torch.zeros([])
-    key2 = torch.zeros([1])
-    key3 = torch.zeros([2, 3])
-    value1 = torch.tensor([1.0] * n_outputs)
-    value2 = torch.tensor([[2.0]] * n_outputs)
-    value3 = torch.tensor([[[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]] * n_outputs)
+    key1 = torch.zeros([], device=DEVICE)
+    key2 = torch.zeros([1], device=DEVICE)
+    key3 = torch.zeros([2, 3], device=DEVICE)
+    value1 = torch.tensor([1.0] * n_outputs, device=DEVICE)
+    value2 = torch.tensor([[2.0]] * n_outputs, device=DEVICE)
+    value3 = torch.tensor([[[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]] * n_outputs, device=DEVICE)
     input = Jacobians({key1: value1, key2: value2, key3: value3})
 
     matrixify = _Matrixify([key1, key2, key3])
 
     output = matrixify(input)
     expected_output = {
-        key1: torch.tensor([[1.0]] * n_outputs),
-        key2: torch.tensor([[2.0]] * n_outputs),
-        key3: torch.tensor([[3.0, 4.0, 5.0, 6.0, 7.0, 8.0]] * n_outputs),
+        key1: torch.tensor([[1.0]] * n_outputs, device=DEVICE),
+        key2: torch.tensor([[2.0]] * n_outputs, device=DEVICE),
+        key3: torch.tensor([[3.0, 4.0, 5.0, 6.0, 7.0, 8.0]] * n_outputs, device=DEVICE),
     }
 
     assert_tensor_dicts_are_close(output, expected_output)
@@ -125,21 +126,21 @@ def test_matrixify():
 def test_reshape():
     """Tests that the Reshape transform correctly creates gradients from gradient vectors."""
 
-    key1 = torch.zeros([])
-    key2 = torch.zeros([1])
-    key3 = torch.zeros([2, 3])
-    value1 = torch.tensor([1.0])
-    value2 = torch.tensor([2.0])
-    value3 = torch.tensor([3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+    key1 = torch.zeros([], device=DEVICE)
+    key2 = torch.zeros([1], device=DEVICE)
+    key3 = torch.zeros([2, 3], device=DEVICE)
+    value1 = torch.tensor([1.0], device=DEVICE)
+    value2 = torch.tensor([2.0], device=DEVICE)
+    value3 = torch.tensor([3.0, 4.0, 5.0, 6.0, 7.0, 8.0], device=DEVICE)
     input = GradientVectors({key1: value1, key2: value2, key3: value3})
 
     reshape = _Reshape([key1, key2, key3])
 
     output = reshape(input)
     expected_output = {
-        key1: torch.tensor(1.0),
-        key2: torch.tensor([2.0]),
-        key3: torch.tensor([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]),
+        key1: torch.tensor(1.0, device=DEVICE),
+        key2: torch.tensor([2.0], device=DEVICE),
+        key3: torch.tensor([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]], device=DEVICE),
     }
 
     assert_tensor_dicts_are_close(output, expected_output)

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -3,6 +3,7 @@ import typing
 import pytest
 import torch
 from torch import Tensor
+from unit.conftest import DEVICE
 
 from torchjd.autojac._transform._utils import _B, _C
 from torchjd.autojac._transform.base import Conjunction, Transform
@@ -24,7 +25,7 @@ class FakeTransform(Transform[_B, _C]):
     def _compute(self, input: _B) -> _C:
         # ignore the input, create a dictionary with the right keys as an output.
         # cast the type for the purpose of type-checking.
-        output_dict = {key: torch.empty(0) for key in self._output_keys}
+        output_dict = {key: torch.empty(0, device=DEVICE) for key in self._output_keys}
         return typing.cast(_C, output_dict)
 
     @property
@@ -42,8 +43,8 @@ def test_apply_keys():
     contains keys that correspond exactly to `required_keys`.
     """
 
-    t1 = torch.randn([2])
-    t2 = torch.randn([3])
+    t1 = torch.randn([2], device=DEVICE)
+    t2 = torch.randn([3], device=DEVICE)
     transform = FakeTransform({t1}, {t1, t2})
 
     transform(TensorDict({t1: t2}))
@@ -64,8 +65,8 @@ def test_compose_keys_match():
     match with the outer transform's `required_keys`.
     """
 
-    t1 = torch.randn([2])
-    t2 = torch.randn([3])
+    t1 = torch.randn([2], device=DEVICE)
+    t2 = torch.randn([3], device=DEVICE)
     transform1 = FakeTransform({t1}, {t1, t2})
     transform2 = FakeTransform({t2}, {t1})
 
@@ -81,8 +82,8 @@ def test_conjunct_required_keys():
     same `required_keys`.
     """
 
-    t1 = torch.randn([2])
-    t2 = torch.randn([3])
+    t1 = torch.randn([2], device=DEVICE)
+    t2 = torch.randn([3], device=DEVICE)
 
     transform1 = FakeTransform({t1}, set())
     transform2 = FakeTransform({t1}, set())
@@ -103,8 +104,8 @@ def test_conjunct_wrong_output_keys():
     disjoint.
     """
 
-    t1 = torch.randn([2])
-    t2 = torch.randn([3])
+    t1 = torch.randn([2], device=DEVICE)
+    t2 = torch.randn([3], device=DEVICE)
 
     transform1 = FakeTransform(set(), {t1, t2})
     transform2 = FakeTransform(set(), {t1})

--- a/tests/unit/autojac/_transform/test_diagonalize.py
+++ b/tests/unit/autojac/_transform/test_diagonalize.py
@@ -1,4 +1,5 @@
 import torch
+from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import Diagonalize, Gradients
 
@@ -8,14 +9,16 @@ from ._dict_assertions import assert_tensor_dicts_are_close
 def test_diagonalize_single_input():
     """Tests that the Diagonalize transform works when given a single input."""
 
-    key = torch.tensor([1.0, 2.0, 3.0])
+    key = torch.tensor([1.0, 2.0, 3.0], device=DEVICE)
     value = torch.ones_like(key)
     input = Gradients({key: value})
 
     diag = Diagonalize([key])
 
     output = diag(input)
-    expected_output = {key: torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])}
+    expected_output = {
+        key: torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], device=DEVICE)
+    }
 
     assert_tensor_dicts_are_close(output, expected_output)
 
@@ -23,9 +26,9 @@ def test_diagonalize_single_input():
 def test_diagonalize_multiple_inputs():
     """Tests that the Diagonalize transform works when given multiple inputs."""
 
-    key1 = torch.tensor([[1.0, 2.0], [4.0, 5.0]])
-    key2 = torch.tensor([1.0, 3.0, 5.0])
-    key3 = torch.tensor(1.0)
+    key1 = torch.tensor([[1.0, 2.0], [4.0, 5.0]], device=DEVICE)
+    key2 = torch.tensor([1.0, 3.0, 5.0], device=DEVICE)
+    key3 = torch.tensor(1.0, device=DEVICE)
     value1 = torch.ones_like(key1)
     value2 = torch.ones_like(key2)
     value3 = torch.ones_like(key3)
@@ -45,7 +48,8 @@ def test_diagonalize_multiple_inputs():
                 [[0.0, 0.0], [0.0, 0.0]],
                 [[0.0, 0.0], [0.0, 0.0]],
                 [[0.0, 0.0], [0.0, 0.0]],
-            ]
+            ],
+            device=DEVICE,
         ),
         key2: torch.tensor(
             [
@@ -57,7 +61,8 @@ def test_diagonalize_multiple_inputs():
                 [0.0, 1.0, 0.0],
                 [0.0, 0.0, 1.0],
                 [0.0, 0.0, 0.0],
-            ]
+            ],
+            device=DEVICE,
         ),
         key3: torch.tensor(
             [
@@ -69,7 +74,8 @@ def test_diagonalize_multiple_inputs():
                 0.0,
                 0.0,
                 1.0,
-            ]
+            ],
+            device=DEVICE,
         ),
     }
 
@@ -81,8 +87,8 @@ def test_diagonalize_permute_order():
     Tests that the Diagonalize transform outputs a permuted mapping when its keys are permuted.
     """
 
-    key1 = torch.tensor(2.0)
-    key2 = torch.tensor(1.0)
+    key1 = torch.tensor(2.0, device=DEVICE)
+    key2 = torch.tensor(1.0, device=DEVICE)
     value1 = torch.ones_like(key1)
     value2 = torch.ones_like(key2)
     input = Gradients({key1: value1, key2: value2})

--- a/tests/unit/autojac/_transform/test_grad.py
+++ b/tests/unit/autojac/_transform/test_grad.py
@@ -1,4 +1,5 @@
 import torch
+from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import Grad, Gradients
 
@@ -12,8 +13,8 @@ def test_single_input():
     respect to the parameter `a`. This derivative should be equal to `x`.
     """
 
-    x = torch.tensor(5.0)
-    a = torch.tensor(2.0, requires_grad=True)
+    x = torch.tensor(5.0, device=DEVICE)
+    a = torch.tensor(2.0, requires_grad=True, device=DEVICE)
     y = a * x
     input = Gradients({y: torch.ones_like(y)})
 
@@ -31,7 +32,7 @@ def test_empty_inputs_1():
     `Iterable`.
     """
 
-    y = torch.tensor(1.0, requires_grad=True)
+    y = torch.tensor(1.0, requires_grad=True, device=DEVICE)
     input = Gradients({y: torch.ones_like(y)})
 
     grad = Grad(outputs=[y], inputs=[])
@@ -48,8 +49,8 @@ def test_empty_inputs_2():
     `Iterable`.
     """
 
-    x = torch.tensor(5.0)
-    a = torch.tensor(1.0, requires_grad=True)
+    x = torch.tensor(5.0, device=DEVICE)
+    a = torch.tensor(1.0, requires_grad=True, device=DEVICE)
     y = a * x
     input = Gradients({y: torch.ones_like(y)})
 
@@ -69,9 +70,9 @@ def test_single_input_two_levels():
     using chain rule. This derivative should be equal to `x1 * x2`.
     """
 
-    x1 = torch.tensor(5.0)
-    x2 = torch.tensor(6.0)
-    a = torch.tensor(2.0, requires_grad=True)
+    x1 = torch.tensor(5.0, device=DEVICE)
+    x2 = torch.tensor(6.0, device=DEVICE)
+    a = torch.tensor(2.0, requires_grad=True, device=DEVICE)
     y = a * x1
     z = y * x2
     input = Gradients({z: torch.ones_like(z)})
@@ -92,9 +93,9 @@ def test_empty_inputs_two_levels():
     `Iterable`, with 2 composed Grad transforms.
     """
 
-    x1 = torch.tensor(5.0)
-    x2 = torch.tensor(6.0)
-    a = torch.tensor(2.0, requires_grad=True)
+    x1 = torch.tensor(5.0, device=DEVICE)
+    x2 = torch.tensor(6.0, device=DEVICE)
+    a = torch.tensor(2.0, requires_grad=True, device=DEVICE)
     y = a * x1
     z = y * x2
     input = Gradients({z: torch.ones_like(z)})
@@ -115,10 +116,10 @@ def test_composition_of_grads_is_grad():
     a single transform.
     """
 
-    x1 = torch.tensor(5.0)
-    x2 = torch.tensor(6.0)
-    a = torch.tensor(2.0, requires_grad=True)
-    b = torch.tensor(1.0, requires_grad=True)
+    x1 = torch.tensor(5.0, device=DEVICE)
+    x2 = torch.tensor(6.0, device=DEVICE)
+    a = torch.tensor(2.0, requires_grad=True, device=DEVICE)
+    b = torch.tensor(1.0, requires_grad=True, device=DEVICE)
     y1 = a * x1
     y2 = a * x2
     z1 = y1 + x2
@@ -142,10 +143,10 @@ def test_conjunction_of_grads_is_grad():
     a single transform.
     """
 
-    x1 = torch.tensor(5.0)
-    x2 = torch.tensor(6.0)
-    a1 = torch.tensor(2.0, requires_grad=True)
-    a2 = torch.tensor(3.0, requires_grad=True)
+    x1 = torch.tensor(5.0, device=DEVICE)
+    x2 = torch.tensor(6.0, device=DEVICE)
+    a1 = torch.tensor(2.0, requires_grad=True, device=DEVICE)
+    a2 = torch.tensor(3.0, requires_grad=True, device=DEVICE)
     y1 = a1 * x1
     y2 = a2 * x2
     y = torch.stack([y1, y2])

--- a/tests/unit/autojac/_transform/test_init.py
+++ b/tests/unit/autojac/_transform/test_init.py
@@ -1,4 +1,5 @@
 import torch
+from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import EmptyTensorDict, Init
 
@@ -11,13 +12,13 @@ def test_init_single_input():
     whose value is a tensor full of ones, of the same shape as its key.
     """
 
-    key = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    key = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device=DEVICE)
     input = EmptyTensorDict()
 
     init = Init([key])
 
     output = init(input)
-    expected_output = {key: torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])}
+    expected_output = {key: torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], device=DEVICE)}
 
     assert_tensor_dicts_are_close(output, expected_output)
 
@@ -28,16 +29,16 @@ def test_init_multiple_input():
     whose values are tensors full of ones, of the same shape as their corresponding keys.
     """
 
-    key1 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-    key2 = torch.tensor([1.0, 3.0, 5.0])
+    key1 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device=DEVICE)
+    key2 = torch.tensor([1.0, 3.0, 5.0], device=DEVICE)
     input = EmptyTensorDict()
 
     init = Init([key1, key2])
 
     output = init(input)
     expected = {
-        key1: torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]),
-        key2: torch.tensor([1.0, 1.0, 1.0]),
+        key1: torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], device=DEVICE),
+        key2: torch.tensor([1.0, 1.0, 1.0], device=DEVICE),
     }
     assert_tensor_dicts_are_close(output, expected)
 
@@ -48,8 +49,8 @@ def test_conjunction_of_inits_is_init():
     multiple keys.
     """
 
-    x1 = torch.tensor(5.0)
-    x2 = torch.tensor(6.0)
+    x1 = torch.tensor(5.0, device=DEVICE)
+    x2 = torch.tensor(6.0, device=DEVICE)
     input = EmptyTensorDict()
 
     init1 = Init([x1])

--- a/tests/unit/autojac/_transform/test_init.py
+++ b/tests/unit/autojac/_transform/test_init.py
@@ -17,7 +17,7 @@ def test_init_single_input():
     init = Init([key])
 
     output = init(input)
-    expected_output = {key: torch.Tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])}
+    expected_output = {key: torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])}
 
     assert_tensor_dicts_are_close(output, expected_output)
 
@@ -36,8 +36,8 @@ def test_init_multiple_input():
 
     output = init(input)
     expected = {
-        key1: torch.Tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]),
-        key2: torch.Tensor([1.0, 1.0, 1.0]),
+        key1: torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]),
+        key2: torch.tensor([1.0, 1.0, 1.0]),
     }
     assert_tensor_dicts_are_close(output, expected)
 

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -85,8 +85,8 @@ def test_multiple_differentiation_with_grad():
 
     output = transform(input)
     expected_output = {
-        a1: torch.Tensor([[2.0, 2.0, 2.0], [2.0, 2.0, 2.0]]),
-        a2: torch.Tensor([3.0, 3.0, 3.0]),
+        a1: torch.tensor([[2.0, 2.0, 2.0], [2.0, 2.0, 2.0]]),
+        a2: torch.tensor([3.0, 3.0, 3.0]),
     }
 
     assert_tensor_dicts_are_close(output, expected_output)

--- a/tests/unit/autojac/_transform/test_select.py
+++ b/tests/unit/autojac/_transform/test_select.py
@@ -1,4 +1,5 @@
 import torch
+from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import Select, TensorDict
 
@@ -11,9 +12,9 @@ def test_select_partition():
     TensorDict, whose keys form a partition of the keys of the TensorDict.
     """
 
-    key1 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-    key2 = torch.tensor([1.0, 3.0, 5.0])
-    key3 = torch.tensor(2.0)
+    key1 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device=DEVICE)
+    key2 = torch.tensor([1.0, 3.0, 5.0], device=DEVICE)
+    key3 = torch.tensor(2.0, device=DEVICE)
     value1 = torch.ones_like(key1)
     value2 = torch.ones_like(key2)
     value3 = torch.ones_like(key3)
@@ -39,9 +40,9 @@ def test_conjunction_of_selects_is_select():
     the union of the keys of the 2 Selects.
     """
 
-    x1 = torch.tensor(5.0)
-    x2 = torch.tensor(6.0)
-    x3 = torch.tensor(7.0)
+    x1 = torch.tensor(5.0, device=DEVICE)
+    x2 = torch.tensor(6.0, device=DEVICE)
+    x3 = torch.tensor(7.0, device=DEVICE)
     input = TensorDict({x1: torch.ones_like(x1), x2: torch.ones_like(x2), x3: torch.ones_like(x3)})
 
     select1 = Select([x1], [x1, x2, x3])

--- a/tests/unit/autojac/_transform/test_stack.py
+++ b/tests/unit/autojac/_transform/test_stack.py
@@ -2,6 +2,7 @@ from typing import Iterable
 
 import torch
 from torch import Tensor
+from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import EmptyTensorDict, Gradients, Stack, Transform
 
@@ -35,14 +36,14 @@ def test_stack_single_key():
     example with 2 transforms sharing the same key.
     """
 
-    key = torch.zeros([3, 4])
+    key = torch.zeros([3, 4], device=DEVICE)
     input = EmptyTensorDict()
 
     transform = FakeGradientsTransform([key])
     stack = Stack([transform, transform])
 
     output = stack(input)
-    expected_output = {key: torch.ones([2, 3, 4])}
+    expected_output = {key: torch.ones([2, 3, 4], device=DEVICE)}
 
     assert_tensor_dicts_are_close(output, expected_output)
 
@@ -54,8 +55,8 @@ def test_stack_disjoint_key_sets():
     by zeros.
     """
 
-    key1 = torch.zeros([1, 2])
-    key2 = torch.zeros([3])
+    key1 = torch.zeros([1, 2], device=DEVICE)
+    key2 = torch.zeros([3], device=DEVICE)
     input = EmptyTensorDict()
 
     transform1 = FakeGradientsTransform([key1])
@@ -64,8 +65,8 @@ def test_stack_disjoint_key_sets():
 
     output = stack(input)
     expected_output = {
-        key1: torch.tensor([[[1.0, 1.0]], [[0.0, 0.0]]]),
-        key2: torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]),
+        key1: torch.tensor([[[1.0, 1.0]], [[0.0, 0.0]]], device=DEVICE),
+        key2: torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]], device=DEVICE),
     }
 
     assert_tensor_dicts_are_close(output, expected_output)
@@ -78,9 +79,9 @@ def test_stack_overlapping_key_sets():
     equal). The missing values should be replaced by zeros.
     """
 
-    key1 = torch.zeros([1, 2])
-    key2 = torch.zeros([3])
-    key3 = torch.zeros([4])
+    key1 = torch.zeros([1, 2], device=DEVICE)
+    key2 = torch.zeros([3], device=DEVICE)
+    key3 = torch.zeros([4], device=DEVICE)
     input = EmptyTensorDict()
 
     transform12 = FakeGradientsTransform([key1, key2])
@@ -89,9 +90,9 @@ def test_stack_overlapping_key_sets():
 
     output = stack(input)
     expected_output = {
-        key1: torch.tensor([[[1.0, 1.0]], [[0.0, 0.0]]]),
-        key2: torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]),
-        key3: torch.tensor([[0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0]]),
+        key1: torch.tensor([[[1.0, 1.0]], [[0.0, 0.0]]], device=DEVICE),
+        key2: torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], device=DEVICE),
+        key3: torch.tensor([[0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0]], device=DEVICE),
     }
 
     assert_tensor_dicts_are_close(output, expected_output)

--- a/tests/unit/autojac/_transform/test_store.py
+++ b/tests/unit/autojac/_transform/test_store.py
@@ -1,4 +1,5 @@
 import torch
+from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import Gradients, Store
 
@@ -8,12 +9,12 @@ from ._dict_assertions import assert_tensor_dicts_are_close
 def test_store():
     """Tests that the Store transform correctly stores gradients in .grad fields."""
 
-    key1 = torch.zeros([], requires_grad=True)
-    key2 = torch.zeros([1], requires_grad=True)
-    key3 = torch.zeros([2, 3], requires_grad=True)
-    value1 = torch.ones([])
-    value2 = torch.ones([1])
-    value3 = torch.ones([2, 3])
+    key1 = torch.zeros([], requires_grad=True, device=DEVICE)
+    key2 = torch.zeros([1], requires_grad=True, device=DEVICE)
+    key3 = torch.zeros([2, 3], requires_grad=True, device=DEVICE)
+    value1 = torch.ones([], device=DEVICE)
+    value2 = torch.ones([1], device=DEVICE)
+    value3 = torch.ones([2, 3], device=DEVICE)
     input = Gradients({key1: value1, key2: value2, key3: value3})
 
     store = Store([key1, key2, key3])

--- a/tests/unit/autojac/_transform/test_tensor_dict.py
+++ b/tests/unit/autojac/_transform/test_tensor_dict.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from pytest import raises
 from torch import Tensor
+from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import (
     EmptyTensorDict,
@@ -109,4 +110,7 @@ def _assert_class_checks_properly(
 
 
 def _make_tensor_dict(value_shapes: list[list[int]]) -> dict[Tensor, Tensor]:
-    return {torch.zeros(key): torch.zeros(value) for key, value in zip(_key_shapes, value_shapes)}
+    return {
+        torch.zeros(key, device=DEVICE): torch.zeros(value, device=DEVICE)
+        for key, value in zip(_key_shapes, value_shapes)
+    }

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from pytest import raises
 from torch.testing import assert_close
+from unit.conftest import DEVICE
 
 from torchjd import backward
 from torchjd.aggregation import MGDA, Aggregator, Mean, Random, UPGrad
@@ -13,11 +14,11 @@ from torchjd.aggregation import MGDA, Aggregator, Mean, Random, UPGrad
 def test_backward_various_aggregators(A: Aggregator):
     """Tests that backward works for various aggregators."""
 
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
     params = [p1, p2]
 
-    y1 = torch.tensor([-1.0, 1.0]) @ p1 + p2.sum()
+    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p1 + p2.sum()
     y2 = (p1**2).sum() + p2.norm()
 
     backward([y1, y2], params, A)
@@ -34,8 +35,8 @@ def test_backward_value_is_correct(A: Aggregator, shape: tuple[int]):
     product.
     """
 
-    J = torch.randn(shape)
-    input = torch.randn([shape[1]], requires_grad=True)
+    J = torch.randn(shape, device=DEVICE)
+    input = torch.randn([shape[1]], requires_grad=True, device=DEVICE)
     output = J @ input  # Note that the Jacobian of output w.r.t. input is J.
 
     backward([output], [input], A)
@@ -48,11 +49,11 @@ def test_backward_empty_inputs():
 
     A = Mean()
 
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
     params = [p1, p2]
 
-    y1 = torch.tensor([-1.0, 1.0]) @ p1 + p2.sum()
+    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p1 + p2.sum()
     y2 = (p1**2).sum() + p2.norm()
 
     backward([y1, y2], [], A)
@@ -69,10 +70,10 @@ def test_backward_partial_inputs():
 
     A = Mean()
 
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    y1 = torch.tensor([-1.0, 1.0]) @ p1 + p2.sum()
+    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p1 + p2.sum()
     y2 = (p1**2).sum() + p2.norm()
 
     backward([y1, y2], [p1], A)
@@ -86,8 +87,8 @@ def test_backward_empty_tensors():
 
     A = UPGrad()
 
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
     with pytest.raises(ValueError):
         backward([], [p1, p2], A)
@@ -101,11 +102,11 @@ def test_backward_multiple_tensors():
 
     A = UPGrad()
 
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
     params = [p1, p2]
 
-    y1 = torch.tensor([-1.0, 1.0]) @ p1 + p2.sum()
+    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p1 + p2.sum()
     y2 = (p1**2).sum() + p2.norm()
 
     backward([y1, y2], params, A, retain_graph=True)
@@ -126,11 +127,11 @@ def test_backward_valid_chunk_size(chunk_size):
 
     A = UPGrad()
 
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
     params = [p1, p2]
 
-    y1 = torch.tensor([-1.0, 1.0]) @ p1 + p2.sum()
+    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p1 + p2.sum()
     y2 = (p1**2).sum() + p2.norm()
 
     backward([y1, y2], params, A, parallel_chunk_size=chunk_size, retain_graph=True)
@@ -145,11 +146,11 @@ def test_backward_non_positive_chunk_size(chunk_size: int):
 
     A = UPGrad()
 
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
     params = [p1, p2]
 
-    y1 = torch.tensor([-1.0, 1.0]) @ p1 + p2.sum()
+    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p1 + p2.sum()
     y2 = (p1**2).sum() + p2.norm()
 
     with pytest.raises(ValueError):
@@ -168,11 +169,11 @@ def test_backward_no_retain_graph_small_chunk_size(chunk_size: int, expectation)
 
     A = UPGrad()
 
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
     params = [p1, p2]
 
-    y1 = torch.tensor([-1.0, 1.0]) @ p1 + p2.sum()
+    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p1 + p2.sum()
     y2 = (p1**2).sum() + p2.norm()
 
     with expectation:

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from pytest import raises
 from torch.testing import assert_close
+from unit.conftest import DEVICE
 
 from torchjd import mtl_backward
 from torchjd.aggregation import MGDA, Aggregator, Mean, Random, UPGrad
@@ -13,11 +14,11 @@ from torchjd.aggregation import MGDA, Aggregator, Mean, Random, UPGrad
 def test_mtl_backward_various_aggregators(A: Aggregator):
     """Tests that mtl_backward works for various aggregators."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    r1 = torch.tensor([-1.0, 1.0]) @ p0
+    r1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
     r2 = (p0**2).sum() + p0.norm()
     y1 = r1 * p1[0] + r2 * p1[1]
     y2 = r1 * p2[0] + r2 * p2[1]
@@ -43,12 +44,12 @@ def test_mtl_backward_value_is_correct(A: Aggregator, shape: tuple[int]):
     inner product of the shared representation with the task parameter.
     """
 
-    p0 = torch.randn([shape[1]], requires_grad=True)
-    p1 = torch.randn(shape[0], requires_grad=True)
-    p2 = torch.randn(shape[0], requires_grad=True)
-    p3 = torch.randn(shape[0], requires_grad=True)
+    p0 = torch.randn([shape[1]], requires_grad=True, device=DEVICE)
+    p1 = torch.randn(shape[0], requires_grad=True, device=DEVICE)
+    p2 = torch.randn(shape[0], requires_grad=True, device=DEVICE)
+    p3 = torch.randn(shape[0], requires_grad=True, device=DEVICE)
 
-    J = torch.randn(shape)
+    J = torch.randn(shape, device=DEVICE)
     r = J @ p0
     y1 = p1 @ r
     y2 = p2 @ r
@@ -75,9 +76,9 @@ def test_mtl_backward_value_is_correct(A: Aggregator, shape: tuple[int]):
 def test_mtl_backward_empty_tasks():
     """Tests that mtl_backward raises an error when called with an empty list of tasks."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
 
-    r1 = torch.tensor([-1.0, 1.0]) @ p0
+    r1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
     r2 = (p0**2).sum() + p0.norm()
 
     with pytest.raises(ValueError):
@@ -93,10 +94,10 @@ def test_mtl_backward_empty_tasks():
 def test_mtl_backward_single_task():
     """Tests that mtl_backward works correctly with a single task."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p1 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p1 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    r1 = torch.tensor([-1.0, 1.0]) @ p0
+    r1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
     r2 = (p0**2).sum() + p0.norm()
     y1 = r1 * p1[0] + r2 * p1[1]
 
@@ -118,11 +119,11 @@ def test_mtl_backward_incoherent_task_number():
     from the number of tasks parameters.
     """
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    r1 = torch.tensor([-1.0, 1.0]) @ p0
+    r1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
     r2 = (p0**2).sum() + p0.norm()
     y1 = r1 * p1[0] + r2 * p1[1]
     y2 = r1 * p2[0] + r2 * p2[1]
@@ -148,11 +149,11 @@ def test_mtl_backward_incoherent_task_number():
 def test_mtl_backward_empty_params():
     """Tests that mtl_backward does not fill the .grad values if no parameter is specified."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    r1 = torch.tensor([-1.0, 1.0]) @ p0
+    r1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
     r2 = (p0**2).sum() + p0.norm()
     y1 = r1 * p1[0] + r2 * p1[1]
     y2 = r1 * p2[0] + r2 * p2[1]
@@ -172,14 +173,14 @@ def test_mtl_backward_empty_params():
 def test_mtl_backward_multiple_params_per_task():
     """Tests that mtl_backward works correctly when the tasks each have several parameters."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p1_a = torch.tensor(1.0, requires_grad=True)
-    p1_b = torch.tensor([2.0, 3.0], requires_grad=True)
-    p1_c = torch.tensor([[4.0, 5.0], [6.0, 7.0]], requires_grad=True)
-    p2_a = torch.tensor(8.0, requires_grad=True)
-    p2_b = torch.tensor([9.0, 10.0], requires_grad=True)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p1_a = torch.tensor(1.0, requires_grad=True, device=DEVICE)
+    p1_b = torch.tensor([2.0, 3.0], requires_grad=True, device=DEVICE)
+    p1_c = torch.tensor([[4.0, 5.0], [6.0, 7.0]], requires_grad=True, device=DEVICE)
+    p2_a = torch.tensor(8.0, requires_grad=True, device=DEVICE)
+    p2_b = torch.tensor([9.0, 10.0], requires_grad=True, device=DEVICE)
 
-    r1 = torch.tensor([-1.0, 1.0]) @ p0
+    r1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
     r2 = (p0**2).sum() + p0.norm()
     y1 = r1 * p1_a + (r2 * p1_b).sum() + (r1 * p1_c).sum()
     y2 = r1 * p2_a * (r2 * p2_b).sum()
@@ -212,9 +213,11 @@ def test_mtl_backward_multiple_params_per_task():
 def test_mtl_backward_various_shared_params(shared_params_shapes: list[tuple[int]]):
     """Tests that mtl_backward works correctly with various kinds of shared_params."""
 
-    shared_params = [torch.rand(shape, requires_grad=True) for shape in shared_params_shapes]
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    shared_params = [
+        torch.rand(shape, requires_grad=True, device=DEVICE) for shape in shared_params_shapes
+    ]
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
     representations = [shared_param.sum(dim=-1) for shared_param in shared_params]
     y1 = torch.stack([r.sum() for r in representations]).sum()
@@ -238,11 +241,11 @@ def test_mtl_backward_partial_params():
     specified as inputs.
     """
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    r1 = torch.tensor([-1.0, 1.0]) @ p0
+    r1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
     r2 = (p0**2).sum() + p0.norm()
     y1 = r1 * p1[0] + r2 * p1[1]
     y2 = r1 * p2[0] + r2 * p2[1]
@@ -263,11 +266,11 @@ def test_mtl_backward_partial_params():
 def test_mtl_backward_empty_features():
     """Tests that mtl_backward expectedly raises an error when no there is no feature."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    r1 = torch.tensor([-1.0, 1.0]) @ p0
+    r1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
     r2 = (p0**2).sum() + p0.norm()
     y1 = r1 * p1[0] + r2 * p1[1]
     y2 = r1 * p2[0] + r2 * p2[1]
@@ -294,11 +297,11 @@ def test_mtl_backward_empty_features():
 def test_mtl_backward_various_single_features(shape: tuple[int]):
     """Tests that mtl_backward works correctly with various kinds of feature tensors."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p1 = torch.tensor([3.0, 4.0], requires_grad=True)
-    p2 = torch.tensor([5.0, 6.0], requires_grad=True)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p1 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([5.0, 6.0], requires_grad=True, device=DEVICE)
 
-    r = torch.rand(shape) @ p0
+    r = torch.rand(shape, device=DEVICE) @ p0
 
     y1 = (r * p1[0]).sum() + (r * p1[1]).sum()
     y2 = (r * p2[0]).sum() * (r * p2[1]).sum()
@@ -331,11 +334,11 @@ def test_mtl_backward_various_single_features(shape: tuple[int]):
 def test_mtl_backward_various_feature_lists(shapes: list[tuple[int]]):
     """Tests that mtl_backward works correctly with various kinds of feature lists."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p1 = torch.arange(len(shapes), dtype=torch.float32, requires_grad=True)
-    p2 = torch.tensor(5.0, requires_grad=True)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p1 = torch.arange(len(shapes), dtype=torch.float32, requires_grad=True, device=DEVICE)
+    p2 = torch.tensor(5.0, requires_grad=True, device=DEVICE)
 
-    representations = [torch.rand(shape) @ p0 for shape in shapes]
+    representations = [torch.rand(shape, device=DEVICE) @ p0 for shape in shapes]
 
     y1 = sum([(r * p).sum() for r, p in zip(representations, p1)])
     y2 = (representations[0] * p2).sum()
@@ -355,11 +358,11 @@ def test_mtl_backward_various_feature_lists(shapes: list[tuple[int]]):
 def test_mtl_backward_non_scalar_loss():
     """Tests that mtl_backward raises an error when used with a non-scalar loss."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    r1 = torch.tensor([-1.0, 1.0]) @ p0
+    r1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
     r2 = (p0**2).sum() + p0.norm()
     y1 = torch.stack([r1 * p1[0], r2 * p1[1]])  # Non-scalar
     y2 = r1 * p2[0] + r2 * p2[1]
@@ -378,11 +381,11 @@ def test_mtl_backward_non_scalar_loss():
 def test_mtl_backward_valid_chunk_size(chunk_size):
     """Tests that mtl_backward works for various valid values of parallel_chunk_size."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    r1 = torch.tensor([-1.0, 1.0]) @ p0
+    r1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
     r2 = (p0**2).sum() + p0.norm()
     y1 = r1 * p1[0] + r2 * p1[1]
     y2 = r1 * p2[0] + r2 * p2[1]
@@ -405,11 +408,11 @@ def test_mtl_backward_valid_chunk_size(chunk_size):
 def test_mtl_backward_non_positive_chunk_size(chunk_size: int):
     """Tests that mtl_backward raises an error when using invalid chunk sizes."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    r1 = torch.tensor([-1.0, 1.0]) @ p0
+    r1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
     r2 = (p0**2).sum() + p0.norm()
     y1 = r1 * p1[0] + r2 * p1[1]
     y2 = r1 * p2[0] + r2 * p2[1]
@@ -435,11 +438,11 @@ def test_mtl_backward_no_retain_graph_small_chunk_size(chunk_size: int, expectat
     not large enough to allow differentiation of all tensors are once.
     """
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    r1 = torch.tensor([-1.0, 1.0]) @ p0
+    r1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
     r2 = (p0**2).sum() + p0.norm()
     y1 = r1 * p1[0] + r2 * p1[1]
     y2 = r1 * p2[0] + r2 * p2[1]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,7 +1,19 @@
+import os
 import random as rand
 
 import pytest
 import torch
+
+try:
+    DEVICE = os.environ["PYTEST_TORCH_DEVICE"]
+except KeyError:
+    DEVICE = "cpu"  # Default to cpu if environment variable not set
+
+if DEVICE != "cuda" and DEVICE != "cpu":
+    raise ValueError(f"Invalid value of environment variable PYTEST_TORCH_DEVICE: {DEVICE}")
+
+if DEVICE == "cuda" and not torch.cuda.is_available():
+    raise ValueError('Requested device "cuda" but cuda is not available.')
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
This PR adds the possibility to run unit tests on cuda (fixes #97).
- 7284c0b2aa850174ef6cf0703f0da9a5415d3484 Add DEVICE constant in conftest.py
- e505a393ebc3335eb7820d6321512b051ed3f364 Change unit tests to move tensors to DEVICE
- 40701b2c1066d68846c3529cd45e61dd938b8888 Add command for cuda unit tests in CONTRIBUTING.md

As a result, a test that was already slow became even slower on cuda, so this PR also changes this test:
- 231cb004b8c427889945928521343fae6c214217 Make `test_mgda_satisfies_kkt_conditions` faster

Lastly, while developing this PR, I found several small issues (sometimes unrelated to the device):
- fe16544e88a142092df5428a5a1672c6fdad7986 Fix leftover print in test
- fd1e501a48ecb3e8d5f6d1fa1f55f1e68ff99bbd Fix wrong device and dtype in exceptional case in IMTL-G
- cf3a5ac2fcc93b522d63537a67364194f8601663 Fix wrong github link in error message
- 0ad72de5ae214e3f5ac244173ccc0bb12fb56321 Fix usage of legacy torch.Tensor constructor
- f68ada8b04be7c2fb70a94f09d80aae82826392a Fix wrong parameter name in _jac docstring
- da92580df016fbad4e723036bb76153eb4da2ab5 Fix not specifying the device and dtype when `n_outputs==0` in `_grad` and `_jac`

In my opinion the only commit worth a changelog entry is fd1e501a48ecb3e8d5f6d1fa1f55f1e68ff99bbd, so for me the changelog is ready.