### PR TITLE
Improve documentation of parallel_chunk_size

### DIFF
--- a/src/torchjd/autojac/backward.py
+++ b/src/torchjd/autojac/backward.py
@@ -34,7 +34,8 @@ def backward(
         backward pass. If set to ``None``, all coordinates of ``tensors`` will be differentiated in
         parallel at once. If set to ``1``, all coordinates will be differentiated sequentially. A
         larger value results in faster differentiation, but also higher memory usage. Defaults to
-        ``None``.
+        ``None``. If ``parallel_chunk_size`` is not large enough to differentiate all tensors
+        simultaneously, ``retain_graph`` has to be set to ``True``.
 
     .. admonition::
         Example

--- a/src/torchjd/autojac/mtl_backward.py
+++ b/src/torchjd/autojac/mtl_backward.py
@@ -56,7 +56,8 @@ def mtl_backward(
         backward pass. If set to ``None``, all coordinates of ``tensors`` will be differentiated in
         parallel at once. If set to ``1``, all coordinates will be differentiated sequentially. A
         larger value results in faster differentiation, but also higher memory usage. Defaults to
-        ``None``.
+        ``None``. If ``parallel_chunk_size`` is not large enough to differentiate all tensors
+        simultaneously, ``retain_graph`` has to be set to ``True``.
 
     .. admonition::
         Example


### PR DESCRIPTION
Very small improvement to the documentation that states explicitly the current limitation of the `retain_graph` parameter (corresponding to case D in the table of [this issue](https://github.com/TorchJD/torchjd/issues/32#issuecomment-2319190095)).

You can merge if you agree.