### PR TITLE
Remove unused test dependency contexttimer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ doc = [
 
 test = [
 	"pytest>=7.3",  # Before version 7.3, not all tests are run
-	"contexttimer>=0.3.3, <0.3.4",  # The test requiring contexttimer is not often run, so it could silently break if we uncap this library
 ]
 
 plot = [


### PR DESCRIPTION
We used contexttimer a while ago for speed tests, which have been removed in d88c6db3d4dc892c86851bc8417358d9d2afe29e. Now, contexttimer is completely unused.
