### PR TITLE
Fix unreliable relative import in interactive_plotter.py

### DIFF
--- a/tests/plots/interactive_plotter.py
+++ b/tests/plots/interactive_plotter.py
@@ -7,6 +7,7 @@ import numpy as np
 import torch
 from dash import Dash, Input, Output, callback, dcc, html
 from dash.html import Figure
+from plots._utils import Plotter, angle_to_coord, coord_to_angle
 
 from torchjd.aggregation import (
     IMTLG,
@@ -23,8 +24,6 @@ from torchjd.aggregation import (
     TrimmedMean,
     UPGrad,
 )
-
-from ._utils import Plotter, angle_to_coord, coord_to_angle
 
 MIN_LENGTH = 0.01
 MAX_LENGTH = 25.0


### PR DESCRIPTION
Relative imports have a drawback compared to absolute imports: they don't work (unless some special options are provided) if the file that contains them is executed as a script. When we moved from absolute imports to relative imports in most of torchjd, we forgot about `interactive_plotter.py`, which is an executable python script (it contains `if __name__ == "__main__":`). This PR fixes the issue by turning the relative import back to absolute in `interactive_plotter.py`.
