### PR TITLE
Fix types

### DIFF
--- a/src/torchjd/aggregation/bases.py
+++ b/src/torchjd/aggregation/bases.py
@@ -29,6 +29,10 @@ class Aggregator(nn.Module, ABC):
     def forward(self, matrix: Tensor) -> Tensor:
         raise NotImplementedError
 
+    # Override to make type hints more specific
+    def __call__(self, matrix: Tensor) -> Tensor:
+        return super().__call__(matrix)
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}()"
 
@@ -44,6 +48,10 @@ class _Weighting(nn.Module, ABC):
 
     def forward(self, matrix: Tensor) -> Tensor:
         raise NotImplementedError
+
+    # Override to make type hints more specific
+    def __call__(self, matrix: Tensor) -> Tensor:
+        return super().__call__(matrix)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}()"

--- a/src/torchjd/aggregation/graddrop.py
+++ b/src/torchjd/aggregation/graddrop.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 import torch
 from torch import Tensor
 
@@ -34,7 +36,7 @@ class GradDrop(Aggregator):
         tensor([6., 2., 2.])
     """
 
-    def __init__(self, f: callable = _identity, leak: Tensor | None = None):
+    def __init__(self, f: Callable = _identity, leak: Tensor | None = None):
         if leak is not None and leak.dim() != 1:
             raise ValueError(
                 "Parameter `leak` should be a 1-dimensional tensor. Found `weights.shape = "

--- a/src/torchjd/aggregation/nash_mtl.py
+++ b/src/torchjd/aggregation/nash_mtl.py
@@ -138,7 +138,7 @@ class _NashMTLWeighting(_Weighting):
             or (np.linalg.norm(self.alpha_param.value - self.prvs_alpha_param.value) < 1e-6)
         )
 
-    def _solve_optimization(self, gtg: np.array):
+    def _solve_optimization(self, gtg: np.ndarray):
         self.G_param.value = gtg
         self.normalization_factor_param.value = self.normalization_factor
 

--- a/src/torchjd/aggregation/nash_mtl.py
+++ b/src/torchjd/aggregation/nash_mtl.py
@@ -27,6 +27,7 @@
 import cvxpy as cp
 import numpy as np
 import torch
+from cvxpy import Expression
 from torch import Tensor
 
 from .bases import _WeightedAggregator, _Weighting
@@ -88,7 +89,7 @@ class NashMTL(_WeightedAggregator):
             )
         )
 
-    def reset(self):
+    def reset(self) -> None:
         """Resets the internal state of the algorithm."""
         self.weighting.reset()
 
@@ -131,14 +132,14 @@ class _NashMTLWeighting(_Weighting):
         self.step = 0.0
         self.prvs_alpha = np.ones(self.n_tasks, dtype=np.float32)
 
-    def _stop_criteria(self, gtg, alpha_t):
+    def _stop_criteria(self, gtg: np.ndarray, alpha_t: np.ndarray) -> bool:
         return (
             (self.alpha_param.value is None)
             or (np.linalg.norm(gtg @ alpha_t - 1 / (alpha_t + 1e-10)) < 1e-3)
             or (np.linalg.norm(self.alpha_param.value - self.prvs_alpha_param.value) < 1e-6)
         )
 
-    def _solve_optimization(self, gtg: np.ndarray):
+    def _solve_optimization(self, gtg: np.ndarray) -> np.ndarray:
         self.G_param.value = gtg
         self.normalization_factor_param.value = self.normalization_factor
 
@@ -162,13 +163,13 @@ class _NashMTLWeighting(_Weighting):
 
         return self.prvs_alpha
 
-    def _calc_phi_alpha_linearization(self):
+    def _calc_phi_alpha_linearization(self) -> Expression:
         G_prvs_alpha = self.G_param @ self.prvs_alpha_param
         prvs_phi_tag = 1 / self.prvs_alpha_param + (1 / G_prvs_alpha) @ self.G_param
         phi_alpha = prvs_phi_tag @ (self.alpha_param - self.prvs_alpha_param)
         return phi_alpha
 
-    def _init_optim_problem(self):
+    def _init_optim_problem(self) -> None:
         self.alpha_param = cp.Variable(shape=(self.n_tasks,), nonneg=True)
         self.prvs_alpha_param = cp.Parameter(shape=(self.n_tasks,), value=self.prvs_alpha)
         self.G_param = cp.Parameter(shape=(self.n_tasks, self.n_tasks), value=self.init_gtg)
@@ -211,7 +212,7 @@ class _NashMTLWeighting(_Weighting):
 
         return alpha
 
-    def reset(self):
+    def reset(self) -> None:
         """Resets the internal state of the algorithm."""
 
         self.prvs_alpha_param = None

--- a/src/torchjd/autojac/_transform/grad.py
+++ b/src/torchjd/autojac/_transform/grad.py
@@ -20,8 +20,8 @@ class Grad(_Differentiate[Gradients]):
 
     def _differentiate(self, grad_outputs: Sequence[Tensor]) -> tuple[Tensor, ...]:
         return _grad(
-            outputs=self.outputs,
-            inputs=self.inputs,
+            outputs=list(self.outputs),
+            inputs=list(self.inputs),
             grad_outputs=grad_outputs,
             retain_graph=self.retain_graph,
             create_graph=False,

--- a/src/torchjd/autojac/_transform/jac.py
+++ b/src/torchjd/autojac/_transform/jac.py
@@ -68,7 +68,7 @@ def _jac(
             ]
         )
 
-    def get_vjp(v):
+    def get_vjp(v: Sequence[Tensor]) -> Tensor:
         optional_grads = torch.autograd.grad(
             outputs,
             inputs,

--- a/src/torchjd/autojac/_transform/jac.py
+++ b/src/torchjd/autojac/_transform/jac.py
@@ -23,8 +23,8 @@ class Jac(_Differentiate[Jacobians]):
 
     def _differentiate(self, jac_outputs: Sequence[Tensor]) -> tuple[Tensor, ...]:
         return _jac(
-            outputs=self.outputs,
-            inputs=self.inputs,
+            outputs=list(self.outputs),
+            inputs=list(self.inputs),
             jac_outputs=jac_outputs,
             chunk_size=self.chunk_size,
             retain_graph=self.retain_graph,

--- a/src/torchjd/autojac/_transform/jac.py
+++ b/src/torchjd/autojac/_transform/jac.py
@@ -68,11 +68,11 @@ def _jac(
             ]
         )
 
-    def get_vjp(v: Sequence[Tensor]) -> Tensor:
+    def get_vjp(grad_outputs: Sequence[Tensor]) -> Tensor:
         optional_grads = torch.autograd.grad(
             outputs,
             inputs,
-            grad_outputs=v,
+            grad_outputs=grad_outputs,
             retain_graph=retain_graph,
             create_graph=create_graph,
             allow_unused=allow_unused,

--- a/src/torchjd/autojac/_transform/tensor_dict.py
+++ b/src/torchjd/autojac/_transform/tensor_dict.py
@@ -14,7 +14,7 @@ class TensorDict(dict[Tensor, Tensor]):
         self._check_all_pairs(tensor_dict)
         super().__init__(tensor_dict)
 
-    def check_keys_are(self, keys: set[Tensor]):
+    def check_keys_are(self, keys: set[Tensor]) -> None:
         """
         Checks that the keys in the mapping are the same as the provided ``keys``.
 
@@ -43,7 +43,7 @@ class TensorDict(dict[Tensor, Tensor]):
     # Make TensorDict immutable, following answer in
     # https://stackoverflow.com/questions/11014262/how-to-create-an-immutable-dictionary-in-python
     # coming from https://peps.python.org/pep-0351/
-    def _raise_immutable_error(self, *args, **kwargs):
+    def _raise_immutable_error(self, *args, **kwargs) -> None:
         raise TypeError(f"{self.__class__.__name__} is immutable.")
 
     __setitem__ = _raise_immutable_error

--- a/src/torchjd/autojac/_utils.py
+++ b/src/torchjd/autojac/_utils.py
@@ -15,7 +15,7 @@ def _as_tensor_list(tensors: Sequence[Tensor] | Tensor) -> list[Tensor]:
     if isinstance(tensors, Tensor):
         output = [tensors]
     else:
-        output = tensors
+        output = list(tensors)
     return output
 
 

--- a/tests/plots/interactive_plotter.py
+++ b/tests/plots/interactive_plotter.py
@@ -29,7 +29,7 @@ MIN_LENGTH = 0.01
 MAX_LENGTH = 25.0
 
 
-def main():
+def main() -> None:
     log = logging.getLogger("werkzeug")
     log.setLevel(logging.CRITICAL)
 
@@ -173,7 +173,7 @@ def make_gradient_div(i: int, initial_gradient: torch.Tensor) -> html.Div:
     return div
 
 
-def open_browser():
+def open_browser() -> None:
     if not os.environ.get("WERKZEUG_RUN_MAIN"):
         webbrowser.open_new("http://127.0.0.1:1222/")
 

--- a/tests/unit/_utils.py
+++ b/tests/unit/_utils.py
@@ -1,0 +1,3 @@
+from typing import ContextManager, TypeAlias
+
+ExceptionContext: TypeAlias = ContextManager[Exception | None]

--- a/tests/unit/aggregation/test_base.py
+++ b/tests/unit/aggregation/test_base.py
@@ -1,8 +1,9 @@
 from contextlib import nullcontext as does_not_raise
-from typing import ContextManager, Sequence
+from typing import Sequence
 
 import pytest
 import torch
+from unit._utils import ExceptionContext
 from unit.conftest import DEVICE
 
 from torchjd.aggregation import Aggregator
@@ -18,6 +19,6 @@ from torchjd.aggregation import Aggregator
         ([1, 2, 3, 4], pytest.raises(ValueError)),
     ],
 )
-def test_check_is_matrix(shape: Sequence[int], expectation: ContextManager):
+def test_check_is_matrix(shape: Sequence[int], expectation: ExceptionContext):
     with expectation:
         Aggregator._check_is_matrix(torch.randn(shape, device=DEVICE))

--- a/tests/unit/autojac/_transform/_dict_assertions.py
+++ b/tests/unit/autojac/_transform/_dict_assertions.py
@@ -2,7 +2,7 @@ from torch import Tensor
 from torch.testing import assert_close
 
 
-def assert_tensor_dicts_are_close(d1: dict[Tensor, Tensor], d2: dict[Tensor, Tensor]):
+def assert_tensor_dicts_are_close(d1: dict[Tensor, Tensor], d2: dict[Tensor, Tensor]) -> None:
     """
     Check that two dictionaries of tensors are close enough. Note that this does not require the
     keys to have the same ordering.

--- a/tests/unit/autojac/_transform/test_aggregate.py
+++ b/tests/unit/autojac/_transform/test_aggregate.py
@@ -8,7 +8,7 @@ from unit.conftest import DEVICE
 
 from torchjd.aggregation import Random
 from torchjd.autojac._transform import GradientVectors, JacobianMatrices, Jacobians
-from torchjd.autojac._transform.aggregate import _AggregateMatrices, _KeyType, _Matrixify, _Reshape
+from torchjd.autojac._transform.aggregate import _AggregateMatrices, _Matrixify, _Reshape
 
 from ._dict_assertions import assert_tensor_dicts_are_close
 
@@ -89,7 +89,7 @@ def test_aggregate_matrices_empty_dict():
     ],
 )
 def test_disunite_wrong_vector_length(
-    united_gradient_vector: Tensor, jacobian_matrices: dict[_KeyType, Tensor]
+    united_gradient_vector: Tensor, jacobian_matrices: dict[Tensor, Tensor]
 ):
     """
     Tests that the _disunite method raises a ValueError when used on vectors of the wrong length.

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -223,7 +223,7 @@ def test_equivalence_jac_grad():
     grads_1 = _grad(
         [outputs[0]],
         inputs,
-        grad_outputs[0],
+        [grad_outputs[0]],
         retain_graph=True,
         create_graph=False,
         allow_unused=True,
@@ -232,7 +232,7 @@ def test_equivalence_jac_grad():
     grads_2 = _grad(
         [outputs[1]],
         inputs,
-        grad_outputs[1],
+        [grad_outputs[1]],
         retain_graph=True,
         create_graph=False,
         allow_unused=True,

--- a/tests/unit/autojac/_transform/test_tensor_dict.py
+++ b/tests/unit/autojac/_transform/test_tensor_dict.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from pytest import raises
 from torch import Tensor
+from unit._utils import ExceptionContext
 from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import (
@@ -28,7 +29,7 @@ _key_shapes = [[], [1], [2, 3]]
         ([[], [1], [2, 4]], raises(ValueError)),  # Wrong number of elements
     ],
 )
-def test_gradients(value_shapes: list[list[int]], expectation):
+def test_gradients(value_shapes: list[list[int]], expectation: ExceptionContext):
     """Tests that the Gradients class checks properly its inputs."""
 
     _assert_class_checks_properly(Gradients, value_shapes, expectation)
@@ -44,7 +45,7 @@ def test_gradients(value_shapes: list[list[int]], expectation):
         ([[5], [5, 1], [5, 2, 4]], raises(ValueError)),  # Wrong number of elements
     ],
 )
-def test_jacobians(value_shapes: list[list[int]], expectation):
+def test_jacobians(value_shapes: list[list[int]], expectation: ExceptionContext):
     """Tests that the Jacobians class checks properly its inputs."""
 
     _assert_class_checks_properly(Jacobians, value_shapes, expectation)
@@ -59,7 +60,7 @@ def test_jacobians(value_shapes: list[list[int]], expectation):
         ([[2], [1], [6]], raises(ValueError)),  # Wrong number of elements
     ],
 )
-def test_gradient_vectors(value_shapes: list[list[int]], expectation):
+def test_gradient_vectors(value_shapes: list[list[int]], expectation: ExceptionContext):
     """Tests that the GradientVectors class checks properly its inputs."""
 
     _assert_class_checks_properly(GradientVectors, value_shapes, expectation)
@@ -75,7 +76,7 @@ def test_gradient_vectors(value_shapes: list[list[int]], expectation):
         ([[5, 2], [5, 1], [5, 6]], raises(ValueError)),  # Wrong number of elements
     ],
 )
-def test_jacobian_matrices(value_shapes: list[list[int]], expectation):
+def test_jacobian_matrices(value_shapes: list[list[int]], expectation: ExceptionContext):
     """Tests that the JacobianMatrices class checks properly its inputs."""
 
     _assert_class_checks_properly(JacobianMatrices, value_shapes, expectation)
@@ -101,7 +102,7 @@ def test_least_common_ancestor(
 
 
 def _assert_class_checks_properly(
-    class_: type[TensorDict], value_shapes: list[list[int]], expectation
+    class_: type[TensorDict], value_shapes: list[list[int]], expectation: ExceptionContext
 ):
     tensor_mapping = _make_tensor_dict(value_shapes)
 

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -29,7 +29,7 @@ def test_backward_various_aggregators(A: Aggregator):
 
 @pytest.mark.parametrize("A", [Mean(), UPGrad(), MGDA()])
 @pytest.mark.parametrize("shape", [(2, 3), (2, 6), (5, 8), (60, 55), (120, 143)])
-def test_backward_value_is_correct(A: Aggregator, shape: tuple[int]):
+def test_backward_value_is_correct(A: Aggregator, shape: tuple[int, int]):
     """
     Tests that the .grad value filled by backward is correct in a simple example of matrix-vector
     product.

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from pytest import raises
 from torch.testing import assert_close
+from unit._utils import ExceptionContext
 from unit.conftest import DEVICE
 
 from torchjd import backward
@@ -161,7 +162,7 @@ def test_backward_non_positive_chunk_size(chunk_size: int):
     ["chunk_size", "expectation"],
     [(1, raises(ValueError)), (2, does_not_raise()), (None, does_not_raise())],
 )
-def test_backward_no_retain_graph_small_chunk_size(chunk_size: int, expectation):
+def test_backward_no_retain_graph_small_chunk_size(chunk_size: int, expectation: ExceptionContext):
     """
     Tests that backward raises an error when using retain_graph=False and a chunk size that is not
     large enough to allow differentiation of all tensors are once.

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from pytest import raises
 from torch.testing import assert_close
+from unit._utils import ExceptionContext
 from unit.conftest import DEVICE
 
 from torchjd import mtl_backward
@@ -432,7 +433,9 @@ def test_mtl_backward_non_positive_chunk_size(chunk_size: int):
     ["chunk_size", "expectation"],
     [(1, raises(ValueError)), (2, does_not_raise()), (None, does_not_raise())],
 )
-def test_mtl_backward_no_retain_graph_small_chunk_size(chunk_size: int, expectation):
+def test_mtl_backward_no_retain_graph_small_chunk_size(
+    chunk_size: int, expectation: ExceptionContext
+):
     """
     Tests that mtl_backward raises an error when using retain_graph=False and a chunk size that is
     not large enough to allow differentiation of all tensors are once.

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -37,7 +37,7 @@ def test_mtl_backward_various_aggregators(A: Aggregator):
 
 @pytest.mark.parametrize("A", [Mean(), UPGrad(), MGDA()])
 @pytest.mark.parametrize("shape", [(2, 3), (2, 6), (5, 8), (60, 55), (120, 143)])
-def test_mtl_backward_value_is_correct(A: Aggregator, shape: tuple[int]):
+def test_mtl_backward_value_is_correct(A: Aggregator, shape: tuple[int, int]):
     """
     Tests that the .grad value filled by mtl_backward is correct in a simple example of
     matrix-vector product for shared representation and three tasks whose loss are given by a simple
@@ -294,7 +294,7 @@ def test_mtl_backward_empty_features():
         (5, 4, 3, 2),
     ],
 )
-def test_mtl_backward_various_single_features(shape: tuple[int]):
+def test_mtl_backward_various_single_features(shape: tuple[int, ...]):
     """Tests that mtl_backward works correctly with various kinds of feature tensors."""
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -17,7 +17,7 @@ if DEVICE == "cuda" and not torch.cuda.is_available():
 
 
 @pytest.fixture(autouse=True)
-def fix_randomness():
+def fix_randomness() -> None:
     rand.seed(0)
     torch.manual_seed(0)
     torch.use_deterministic_algorithms(True)


### PR DESCRIPTION
- Fix erroneous type hints
- Add missing type hints
- Add `ExceptionContext` type hint for expectations
- Override `__call__` in `_Weighting` and `Aggregator` to specify type hints
- Force `_as_tensor_list` to cast tensors into a list of tensors
- Fix wrong type provided to `_grad` and `_jac`
- Rename `v` to `grad_outputs` in `get_vjp`

I think one of the best changes is `get_vjp`. It was not clear at all what `v` was supposed to be.
In fact, `jac_outputs` is a `Sequence[Tensor]` and `v` is also a `Sequence[Tensor]`, but of each tensor has 1 less dimension. So `v` is what we refer to as `grad_outputs`. I thus renamed `v` to `grad_outputs`.