### PR TITLE
Turn `Store` into `Accumulate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ changes that do not affect the user.
 - **BREAKING**: Removed the possibility of populating the `.grad` field of a tensor that does not
   expect it when calling `backward`. If an input `t` provided to backward does not satisfy
   `t.requires_grad and (t.is_leaf or t.retains_grad)`, an error is now raised.
-
+- **BREAKING**: When using `backward`, aggregations are now accumulated into the `.grad` fields
+  of the inputs rather than replacing those fields if they already existed. This is in line with the
+  behavior of `torch.autograd.backward`.
 
 ## [0.1.0] - 2024-06-22
 

--- a/src/torchjd/autojac/_transform/__init__.py
+++ b/src/torchjd/autojac/_transform/__init__.py
@@ -1,3 +1,4 @@
+from .accumulate import Accumulate
 from .aggregate import Aggregate
 from .base import Composition, Conjunction, Transform
 from .diagonalize import Diagonalize
@@ -6,7 +7,6 @@ from .init import Init
 from .jac import Jac
 from .select import Select
 from .stack import Stack
-from .store import Store
 from .tensor_dict import (
     EmptyTensorDict,
     Gradients,

--- a/src/torchjd/autojac/_transform/accumulate.py
+++ b/src/torchjd/autojac/_transform/accumulate.py
@@ -6,13 +6,13 @@ from .base import Transform
 from .tensor_dict import EmptyTensorDict, Gradients
 
 
-class Store(Transform[Gradients, EmptyTensorDict]):
+class Accumulate(Transform[Gradients, EmptyTensorDict]):
     def __init__(self, required_keys: Iterable[Tensor]):
         self._required_keys = set(required_keys)
 
     def _compute(self, gradients: Gradients) -> EmptyTensorDict:
         """
-        Stores gradients with respect to keys in their ``.grad`` field.
+        Accumulates gradients with respect to keys in their ``.grad`` field.
         """
 
         for key in gradients.keys():

--- a/src/torchjd/autojac/backward.py
+++ b/src/torchjd/autojac/backward.py
@@ -4,7 +4,7 @@ from torch import Tensor
 
 from torchjd.aggregation import Aggregator
 
-from ._transform import Aggregate, Diagonalize, EmptyTensorDict, Init, Jac, Store
+from ._transform import Accumulate, Aggregate, Diagonalize, EmptyTensorDict, Init, Jac
 from ._utils import (
     _as_tensor_list,
     _check_optional_positive_chunk_size,
@@ -21,7 +21,7 @@ def backward(
 ) -> None:
     r"""
     Computes the Jacobian of all values in ``tensors`` with respect to all ``inputs``. Computes its
-    aggregation by ``A`` and stores it in the ``.grad`` fields of the ``inputs``.
+    aggregation by ``A`` and accumulates it in the ``.grad`` fields of the ``inputs``.
 
     :param tensors: The tensor or tensors to differentiate. Should be non-empty. The Jacobian
         matrices will have one row for each value of each of these tensors.
@@ -83,9 +83,9 @@ def backward(
     # Transform that aggregates the Jacobians.
     aggregate = Aggregate(A, inputs)
 
-    # Transform that stores the result in the .grad field of the inputs.
-    store = Store(inputs)
+    # Transform that accumulates the result in the .grad field of the inputs.
+    accumulate = Accumulate(inputs)
 
-    backward_transform = store << aggregate << jac << diag << init
+    backward_transform = accumulate << aggregate << jac << diag << init
 
     backward_transform(EmptyTensorDict())

--- a/src/torchjd/autojac/mtl_backward.py
+++ b/src/torchjd/autojac/mtl_backward.py
@@ -5,6 +5,7 @@ from torch import Tensor
 from torchjd.aggregation import Aggregator
 
 from ._transform import (
+    Accumulate,
     Aggregate,
     EmptyTensorDict,
     Grad,
@@ -13,7 +14,6 @@ from ._transform import (
     Jac,
     Select,
     Stack,
-    Store,
     Transform,
 )
 from ._utils import (
@@ -37,9 +37,9 @@ def mtl_backward(
     by several task-specific heads. A loss can then be computed for each task.
 
     This function computes the gradient of each task-specific loss with respect to its task-specific
-    parameters and stores it in their ``.grad`` fields. Then, it computes the Jacobian of all losses
-    with respect to the shared parameters, aggregates it and stores the result in their ``.grad``
-    fields.
+    parameters and accumulates it in their ``.grad`` fields. Then, it computes the Jacobian of all
+    losses with respect to the shared parameters, aggregates it and accumulates the result in their
+    ``.grad`` fields.
 
     :param losses: The task losses. The Jacobian matrix will have one row per loss.
     :param features: The last shared representation used for all tasks, as given by the feature
@@ -85,9 +85,9 @@ def mtl_backward(
     shared_params = list(shared_params)
     tasks_params = [list(task_params) for task_params in tasks_params]
 
-    # Task-specific transforms. Each of them computes and stores the gradient of the task's loss
-    # w.r.t. the task's specific parameters, and computes and backpropagates the gradient of the
-    # losses w.r.t. the shared representations.
+    # Task-specific transforms. Each of them computes and accumulates the gradient of the task's
+    # loss w.r.t. the task's specific parameters, and computes and backpropagates the gradient of
+    # the losses w.r.t. the shared representations.
     task_transforms = [
         _make_task_transform(
             features,
@@ -108,10 +108,10 @@ def mtl_backward(
     # Transform that aggregates the Jacobians.
     aggregate = Aggregate(A, shared_params)
 
-    # Transform that stores the result in the .grad field of the shared parameters.
-    store = Store(shared_params)
+    # Transform that accumulates the result in the .grad field of the shared parameters.
+    accumulate = Accumulate(shared_params)
 
-    backward_transform = store << aggregate << jac << stack
+    backward_transform = accumulate << aggregate << jac << stack
 
     backward_transform(EmptyTensorDict())
 
@@ -132,16 +132,16 @@ def _make_task_transform(
     # the features.
     grad = Grad([loss], to_differentiate, retain_graph)
 
-    # Transform that stores the gradients w.r.t. the task-specific parameters into their
+    # Transform that accumulates the gradients w.r.t. the task-specific parameters into their
     # .grad fields.
-    store = Store(tasks_params) << Select(tasks_params, to_differentiate)
+    accumulate = Accumulate(tasks_params) << Select(tasks_params, to_differentiate)
 
     # Transform that backpropagates the gradients of the losses w.r.t. the features.
     backpropagate = Select(features, to_differentiate)
 
-    # Transform that stores the gradient of the losses w.r.t. the task-specific parameters into
+    # Transform that accumulates the gradient of the losses w.r.t. the task-specific parameters into
     # their .grad fields and backpropagates the gradient of the losses w.r.t. to the features.
-    backward_task = (backpropagate | store) << grad << init
+    backward_task = (backpropagate | accumulate) << grad << init
     return backward_task
 
 

--- a/tests/unit/autojac/_transform/test_accumulate.py
+++ b/tests/unit/autojac/_transform/test_accumulate.py
@@ -7,8 +7,11 @@ from torchjd.autojac._transform import Accumulate, Gradients
 from ._dict_assertions import assert_tensor_dicts_are_close
 
 
-def test_accumulate():
-    """Tests that the Accumulate transform correctly accumulates gradients in .grad fields."""
+def test_single_accumulation():
+    """
+    Tests that the Accumulate transform correctly accumulates gradients in .grad fields when run
+    once.
+    """
 
     key1 = torch.zeros([], requires_grad=True, device=DEVICE)
     key2 = torch.zeros([1], requires_grad=True, device=DEVICE)
@@ -27,6 +30,36 @@ def test_accumulate():
 
     grads = {key1: key1.grad, key2: key2.grad, key3: key3.grad}
     expected_grads = {key1: value1, key2: value2, key3: value3}
+
+    assert_tensor_dicts_are_close(grads, expected_grads)
+
+
+@pytest.mark.parametrize("iterations", [1, 2, 4, 10, 13])
+def test_multiple_accumulation(iterations: int):
+    """
+    Tests that the Accumulate transform correctly accumulates gradients in .grad fields when run
+    `iterations` times.
+    """
+
+    key1 = torch.zeros([], requires_grad=True, device=DEVICE)
+    key2 = torch.zeros([1], requires_grad=True, device=DEVICE)
+    key3 = torch.zeros([2, 3], requires_grad=True, device=DEVICE)
+    value1 = torch.ones([], device=DEVICE)
+    value2 = torch.ones([1], device=DEVICE)
+    value3 = torch.ones([2, 3], device=DEVICE)
+    input = Gradients({key1: value1, key2: value2, key3: value3})
+
+    accumulate = Accumulate([key1, key2, key3])
+
+    for i in range(iterations):
+        accumulate(input)
+
+    grads = {key1: key1.grad, key2: key2.grad, key3: key3.grad}
+    expected_grads = {
+        key1: iterations * value1,
+        key2: iterations * value2,
+        key3: iterations * value3,
+    }
 
     assert_tensor_dicts_are_close(grads, expected_grads)
 

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -3,6 +3,7 @@ from torch.testing import assert_close
 from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import (
+    Accumulate,
     Conjunction,
     Diagonalize,
     EmptyTensorDict,
@@ -12,7 +13,6 @@ from torchjd.autojac._transform import (
     Jac,
     Select,
     Stack,
-    Store,
     TensorDict,
 )
 from torchjd.autojac._transform.grad import _grad
@@ -179,11 +179,11 @@ def test_conjunction_is_associative():
     assert_tensor_dicts_are_close(output, expected_output)
 
 
-def test_conjunction_store_select():
+def test_conjunction_accumulate_select():
     """
-    Tests that it is possible to conjunct a Store and a Select in this order.
-    It is not trivial since the type of the TensorDict returned by the first transform (Store) is
-    EmptyDict, which is not the type that the conjunction should return (Gradients).
+    Tests that it is possible to conjunct an Accumulate and a Select in this order.
+    It is not trivial since the type of the TensorDict returned by the first transform (Accumulate)
+    is EmptyDict, which is not the type that the conjunction should return (Gradients).
     """
 
     key = torch.tensor([1.0, 2.0, 3.0], requires_grad=True, device=DEVICE)
@@ -191,8 +191,8 @@ def test_conjunction_store_select():
     input = Gradients({key: value})
 
     select = Select([], [key])
-    store = Store([key])
-    conjunction = store | select
+    accumulate = Accumulate([key])
+    conjunction = accumulate | select
 
     output = conjunction(input)
     expected_output = {}


### PR DESCRIPTION
- Fixes #116 

might be relevant:
https://stackoverflow.com/questions/55266154/pytorch-preferred-way-to-copy-a-tensor

TL;DR: We might have to use `t.detach().clone()` instead of `t.clone()` to remove the computation graph dependence between the new grad and the previous, we might also want to detach the tensor we sum. This makes the accumulation non-differentiable.

I think we are suppose to detach, in torch, the way to be able to differentiate a differentiation seems to be by using `torch.autograd.grad` with `create_graph` set to `True`. The function `autograd.backward` or `tensor.backward` will set `.grad` fields that do not `require_grad`, they are therefore not in any graph.