### PR TITLE
Improve introduction to TorchJD in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 [![Tests](https://github.com/TorchJD/torchjd/actions/workflows/tests.yml/badge.svg)](https://github.com/TorchJD/torchjd/actions/workflows/tests.yml)
 
-TorchJD is a library enabling [Jacobian descent](https://arxiv.org/pdf/2406.16232) with PyTorch, to
-train neural networks with multiple objectives. In particular, it can be used for multi-task
-learning, with a wide variety of algorithms from the literature. It also enables the instance-wise
-risk minimization paradigm, as proposed in
-[Jacobian Descent For Multi-Objective Optimization](https://arxiv.org/pdf/2406.16232). The full
-documentation is available at [torchjd.org](https://torchjd.org), with several usage examples.
+TorchJD is a library extending autograd to enable
+[Jacobian descent](https://arxiv.org/pdf/2406.16232) with PyTorch. In can be used to train neural
+networks with multiple objectives. In particular, it supports multi-task learning, with a wide
+variety of aggregators from the literature. It also enables the instance-wise risk minimization
+paradigm. The full documentation is available at [torchjd.org](https://torchjd.org), with several usage examples.
 
 ## Installation
 <!-- start installation -->


### PR DESCRIPTION
- I think having a link to the paper when talking about IWRM was a bit too much. If people want to know what IWRM is, they can google it. It they don't, we don't want them to lose focus on this.
- I think it's important to say that TorchJD extends autograd. This way, people will instantly understand what it's all about.