### PR TITLE
Add -i in pdm use command in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ before implementing major changes to torchjd.
 2) Create a virtual environment and install the project in it. From the root of torchjd, run:
    ```bash
    pdm venv create 3.12.3  # Requires python 3.12.3 to be installed
-   pdm use .venv/bin/python
+   pdm use -i .venv/bin/python
    pdm install --frozen-lockfile
    pdm run pre-commit install
    ```


### PR DESCRIPTION
The `pdm use .venv/bin/python` command somehow doesn't force pdm to use this environment. By default, it will still use the "remembered" version. The -i option forces it to ignore the remembered version and to use the specified venv.


Documentation of pdm use:
```
❯ pdm use --help
Usage: pdm use [-h] [-v | -q] [-g] [-p PROJECT_PATH] [-k SKIP] [-f | --auto-install-min | --auto-install-max]
 [-i] [--venv VENV]
 [python]

Use the given python version or path as base interpreter. If not found, PDM will try to install one.

Positional Arguments:
  python                Specify the Python version or path

Options:
  -h, --help            Show this help message and exit.
  -v, --verbose         Use `-v` for detailed output and `-vv` for more detailed
  -q, --quiet           Suppress output
  -g, --global          Use the global project, supply the project root with `-p` option
  -p PROJECT_PATH, --project PROJECT_PATH
                        Specify another path as the project root, which changes the base of pyproject.toml and
                        __pypackages__ [env var: PDM_PROJECT]
  -k SKIP, --skip SKIP  Skip some tasks and/or hooks by their comma-separated names. Can be supplied multiple
                        times. Use ":all" to skip all hooks. Use ":pre" and ":post" to skip all pre or post
                        hooks.
  -f, --first           Select the first matched interpreter - no auto install
  --auto-install-min    If `python` argument not given, auto install minimal best match - otherwise has no
                        effect
  --auto-install-max    If `python` argument not given, auto install maximum best match - otherwise has no
                        effect
  -i, --ignore-remembered
                        Ignore the remembered selection
  --venv VENV           Use the interpreter in the virtual environment with the given name
```