### PR TITLE
Improve IMTLG clarity

### DIFF
--- a/src/torchjd/aggregation/imtl_g.py
+++ b/src/torchjd/aggregation/imtl_g.py
@@ -41,11 +41,11 @@ class _IMTLGWeighting(_Weighting):
         d = torch.linalg.norm(matrix, dim=1)
 
         try:
-            # Equivalent to `raw_weights = torch.linalg.pinv(matrix @ matrix.T) @ d`, but safer
+            # Equivalent to `alpha_star = torch.linalg.pinv(matrix @ matrix.T) @ d`, but safer
             # according to https://pytorch.org/docs/stable/generated/torch.linalg.pinv.html
-            raw_weights = torch.linalg.lstsq(matrix @ matrix.T, d).solution
+            alpha_star = torch.linalg.lstsq(matrix @ matrix.T, d).solution
         except RuntimeError:  # This can happen when the matrix has extremely large values
-            raw_weights = torch.ones(matrix.shape[0], device=matrix.device, dtype=matrix.dtype)
+            alpha_star = torch.ones(matrix.shape[0], device=matrix.device, dtype=matrix.dtype)
 
-        weights = raw_weights / raw_weights.sum()
+        weights = alpha_star / alpha_star.sum()
         return weights

--- a/src/torchjd/aggregation/imtl_g.py
+++ b/src/torchjd/aggregation/imtl_g.py
@@ -8,7 +8,8 @@ class IMTLG(_WeightedAggregator):
     """
     :class:`~torchjd.aggregation.bases.Aggregator` generalizing the method described in
     `Towards Impartial Multi-task Learning <https://discovery.ucl.ac.uk/id/eprint/10120667/>`_.
-    This generalization supports matrices with some linearly dependant rows.
+    This generalization, defined formally in `Jacobian Descent For Multi-Objective Optimization
+    <https://arxiv.org/pdf/2406.16232>`_, supports matrices with some linearly dependant rows.
 
     .. admonition::
         Example
@@ -31,10 +32,9 @@ class IMTLG(_WeightedAggregator):
 
 class _IMTLGWeighting(_Weighting):
     """
-    :class:`~torchjd.aggregation.bases._Weighting` that extracts weights using a method which is
-    a generalization of the method described in `Towards Impartial Multi-task Learning
-    <https://discovery.ucl.ac.uk/id/eprint/10120667/>`_, supporting non-linearly independent rows
-    of the matrix.
+    :class:`~torchjd.aggregation.bases._Weighting` that extracts weights as described in the
+    definition of A_IMTLG of `Jacobian Descent For Multi-Objective Optimization
+    <https://arxiv.org/pdf/2406.16232>`_.
     """
 
     def forward(self, matrix: Tensor) -> Tensor:

--- a/src/torchjd/aggregation/imtl_g.py
+++ b/src/torchjd/aggregation/imtl_g.py
@@ -41,6 +41,8 @@ class _IMTLGWeighting(_Weighting):
         d = torch.linalg.norm(matrix, dim=1)
 
         try:
+            # Equivalent to `raw_weights = torch.linalg.pinv(matrix @ matrix.T) @ d`, but safer
+            # according to https://pytorch.org/docs/stable/generated/torch.linalg.pinv.html
             raw_weights = torch.linalg.lstsq(matrix @ matrix.T, d).solution
         except RuntimeError:  # This can happen when the matrix has extremely large values
             raw_weights = torch.ones(matrix.shape[0], device=matrix.device, dtype=matrix.dtype)


### PR DESCRIPTION
This PR intends to make the link between our math definition of `A_IMTLG` (in the unreleased version of the paper) and the code of IMTLG clearer.

- **Add comment about usage of lstsq**
- **Rename `raw_weights` to `alpha_star`**
- **Link our paper in IMTLG docstrings**

@PierreQuinton FYI