### PR TITLE
Remove numpy uppercap in pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ changes that do not affect the user.
 
 ## [Unreleased]
 
+### Changed
+
+- Removed upper cap on numpy version in the dependencies. This makes `torchjd` compatible with
+  the most recent numpy versions too.
+
 ### Fixed
 
 - **BREAKING** Prevented IMTLG from dividing by zero during its weight rescaling step. If the input

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "torch>=2.0.0",
     "quadprog>=0.1.9, != 0.1.10",  # Doesn't work before 0.1.9, 0.1.10 is yanked
-    "numpy>=1.21.0, <2.0.0",  # Does not work before 1.21. On Windows, torch does not seem to be compatible with numpy>=2.0.0 yet. The upper cap should be removed when this becomes the case. See https://github.com/pytorch/pytorch/issues/128860.
+    "numpy>=1.21.0",  # Does not work before 1.21
     "qpsolvers>=1.0.1",  # Does not work before 1.0.1
     "cvxpy>=1.3.0",  # No Clarabel solver before 1.3.0
 ]


### PR DESCRIPTION
This is an updated version of https://github.com/TorchJD/torchjd/pull/68

It now works, but I don't know why. It could come from a change in numpy (in 2.1.1) or from a change in torch (in 2.4.1).

I don't think it could come from numpy 2.1.0 because the CI already failed on august 28 with numpy 2.1.0 on windows.
But after reading the changelogs of numpy 2.1.1 and torch 2.4.1 I don't understand what could have fixed the problem.

Perhaps this:
![IMG_20240916_193841](https://github.com/user-attachments/assets/1c36e331-6587-43c8-811d-5a0a339303c5)

Yeah, somehow the wheel for numpy 2.1.0 was only released in 2.1.1 apparently.