### PR TITLE
Add release.yml action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+# Adapted from https://pdm-project.org/latest/usage/publish/
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi-publish:
+    name: Publish to PyPI
+    environment: release
+    runs-on: ubuntu-latest
+    permissions:
+      # This permission is needed for private repositories.
+      contents: read
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pdm-project/setup-pdm@v4
+      - name: Publish package distributions to PyPI
+        run: pdm publish


### PR DESCRIPTION
With this + adding a trusted publisher on PyPI + adding the `release` environment, we should have torchjd automatically published on PyPI whenever we make a github release (after approval of the publishing job by 1+ reviewer, and a waiting time of 5 minutes).

The `release` environment should ensure that the job is triggered from the `main` branch or from a tag of the form `v*.*.*`. I'm not sure when we release on github and create tag at the same time (it's an option of the release), if it's considered as coming from main, from the newly created tag, or from both (since both have the same commit hash). This should work in any case.

Additionally, when we make the github release, the job should only be created with the "waiting" status. It will need at least the approval of one reviewer + 5 minutes of waiting before being able to start. I think this 5 minutes rule will allow us to double check everything without being too tedious. See 
[this](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/reviewing-deployments#bypassing-environment-protection-rules) for more information about job reviewing.

I think the only (easy) way to really test this is to merge this PR and try to publish v0.2.1 by making the github release for it. If it doesn't work, we can quickly publish v0.2.1 manually.