### PR TITLE
Add warning about backward and mtl_backward being incompatible with compiled functions.

### DIFF
--- a/src/torchjd/autojac/backward.py
+++ b/src/torchjd/autojac/backward.py
@@ -59,6 +59,11 @@ def backward(
 
         The ``.grad`` field of ``param`` now contains the aggregation of the Jacobian of
         :math:`\begin{bmatrix}y_1 \\ y_2\end{bmatrix}` with respect to ``param``.
+
+    .. warning::
+        ``backward`` relies on a usage of ``torch.vmap`` that is not compatible with compiled
+        functions. The arguments of ``backward`` should thus not come from a compiled model. Check
+        https://github.com/pytorch/pytorch/issues/138422 for the status of this issue.
     """
     _check_optional_positive_chunk_size(parallel_chunk_size)
 

--- a/src/torchjd/autojac/mtl_backward.py
+++ b/src/torchjd/autojac/mtl_backward.py
@@ -64,6 +64,11 @@ def mtl_backward(
 
         A usage example of ``mtl_backward`` is provided in
         :doc:`Multi-Task Learning (MTL) <../../examples/mtl>`.
+
+    .. warning::
+        ``mtl_backward`` relies on a usage of ``torch.vmap`` that is not compatible with compiled
+        functions. The arguments of ``mtl_backward`` should thus not come from a compiled model.
+        Check https://github.com/pytorch/pytorch/issues/138422 for the status of this issue.
     """
 
     _check_optional_positive_chunk_size(parallel_chunk_size)


### PR DESCRIPTION
This PR adds a warning about the usage of compiled models in `backward` and `mtl_backward`. Since the problem is now out of our control, I think it should close #154.

- Closes #154 
