### PR TITLE
Add dashes next to TJD-specific lines in usage example of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@ The main way to use TorchJD is to replace the usual call to `loss.backward()` by
 `torchjd.backward` or `torchjd.mtl_backward`, depending on the use-case.
 
 The following example shows how to use TorchJD to train a multi-task model with Jacobian descent,
-using [UPGrad](https://torchjd.org/docs/aggregation/upgrad/).
+using [UPGrad](https://torchjd.org/docs/aggregation/upgrad/). The TorchJD-specific lines have been
+marked with dashes.
 
 ```python
 import torch
 from torch.nn import Linear, MSELoss, ReLU, Sequential
 from torch.optim import SGD
 
-from torchjd import mtl_backward
-from torchjd.aggregation import UPGrad
+from torchjd import mtl_backward  # ------------------------------------------------
+from torchjd.aggregation import UPGrad  # ------------------------------------------
 
 shared_module = Sequential(Linear(10, 5), ReLU(), Linear(5, 3), ReLU())
 task1_module = Linear(3, 1)
@@ -46,7 +47,7 @@ params = [
 
 loss_fn = MSELoss()
 optimizer = SGD(params, lr=0.1)
-A = UPGrad()
+A = UPGrad()  # --------------------------------------------------------------------
 
 inputs = torch.randn(8, 16, 10)  # 8 batches of 16 random input vectors of length 10
 task1_targets = torch.randn(8, 16, 1)  # 8 batches of 16 targets for the first task
@@ -60,13 +61,13 @@ for input, target1, target2 in zip(inputs, task1_targets, task2_targets):
     loss2 = loss_fn(output2, target2)
 
     optimizer.zero_grad()
-    mtl_backward(
-        losses=[loss1, loss2],
-        features=features,
-        tasks_params=[task1_module.parameters(), task2_module.parameters()],
-        shared_params=shared_module.parameters(),
-        A=A,
-    )
+    mtl_backward(  # ---------------------------------------------------------------
+        losses=[loss1, loss2],  # --------------------------------------------------
+        features=features,  # ------------------------------------------------------
+        tasks_params=[task1_module.parameters(), task2_module.parameters()],  # ----
+        shared_params=shared_module.parameters(),  # -------------------------------
+        A=A,  # --------------------------------------------------------------------
+    )  # ---------------------------------------------------------------------------
     optimizer.step()
 ```
 


### PR DESCRIPTION
This corresponds to the line highlights of https://torchjd.org/examples/mtl/

In markdown, we can't highlight lines of code instead it uses comments with dashes. I think it doesn't look so bad and it improves readability / makes torchjd less scary because we see that there are only a few extra lines of code.