### PR TITLE
Remove errors in abstract methods

### DIFF
--- a/src/torchjd/aggregation/bases.py
+++ b/src/torchjd/aggregation/bases.py
@@ -27,13 +27,11 @@ class Aggregator(nn.Module, ABC):
 
     @abstractmethod
     def forward(self, matrix: Tensor) -> Tensor:
-        """Computes and returns the aggregation from the input matrix."""
+        """Computes the aggregation from the input matrix."""
 
     # Override to make type hints and documentation more specific
     def __call__(self, matrix: Tensor) -> Tensor:
-        """
-        Applies all registered hooks and computes and returns the aggregation from the input matrix.
-        """
+        """Computes the aggregation from the input matrix and applies all registered hooks."""
 
         return super().__call__(matrix)
 
@@ -52,14 +50,11 @@ class _Weighting(nn.Module, ABC):
 
     @abstractmethod
     def forward(self, matrix: Tensor) -> Tensor:
-        """Computes and returns the vector of weights from the input matrix."""
+        """Computes the vector of weights from the input matrix."""
 
     # Override to make type hints and documentation more specific
     def __call__(self, matrix: Tensor) -> Tensor:
-        """
-        Applies all registered hooks and computes and returns the vector of weights from the input
-        matrix.
-        """
+        """Computes the vector of weights from the input matrix and applies all registered hooks."""
 
         return super().__call__(matrix)
 

--- a/src/torchjd/aggregation/bases.py
+++ b/src/torchjd/aggregation/bases.py
@@ -50,8 +50,13 @@ class _Weighting(nn.Module, ABC):
     def forward(self, matrix: Tensor) -> Tensor:
         raise NotImplementedError
 
-    # Override to make type hints more specific
+    # Override to make type hints and documentation more specific
     def __call__(self, matrix: Tensor) -> Tensor:
+        """
+        Applies all registered hooks and computes and returns the vector of weights from the input
+        matrix.
+        """
+
         return super().__call__(matrix)
 
     def __repr__(self) -> str:

--- a/src/torchjd/aggregation/bases.py
+++ b/src/torchjd/aggregation/bases.py
@@ -29,8 +29,6 @@ class Aggregator(nn.Module, ABC):
     def forward(self, matrix: Tensor) -> Tensor:
         """Computes and returns the aggregation from the input matrix."""
 
-        raise NotImplementedError
-
     # Override to make type hints and documentation more specific
     def __call__(self, matrix: Tensor) -> Tensor:
         """
@@ -55,8 +53,6 @@ class _Weighting(nn.Module, ABC):
     @abstractmethod
     def forward(self, matrix: Tensor) -> Tensor:
         """Computes and returns the vector of weights from the input matrix."""
-
-        raise NotImplementedError
 
     # Override to make type hints and documentation more specific
     def __call__(self, matrix: Tensor) -> Tensor:

--- a/src/torchjd/aggregation/bases.py
+++ b/src/torchjd/aggregation/bases.py
@@ -52,6 +52,8 @@ class _Weighting(nn.Module, ABC):
 
     @abstractmethod
     def forward(self, matrix: Tensor) -> Tensor:
+        """Computes and returns the vector of weights from the input matrix."""
+
         raise NotImplementedError
 
     # Override to make type hints and documentation more specific

--- a/src/torchjd/aggregation/bases.py
+++ b/src/torchjd/aggregation/bases.py
@@ -27,6 +27,8 @@ class Aggregator(nn.Module, ABC):
 
     @abstractmethod
     def forward(self, matrix: Tensor) -> Tensor:
+        """Computes and returns the aggregation from the input matrix."""
+
         raise NotImplementedError
 
     # Override to make type hints and documentation more specific

--- a/src/torchjd/aggregation/bases.py
+++ b/src/torchjd/aggregation/bases.py
@@ -29,8 +29,12 @@ class Aggregator(nn.Module, ABC):
     def forward(self, matrix: Tensor) -> Tensor:
         raise NotImplementedError
 
-    # Override to make type hints more specific
+    # Override to make type hints and documentation more specific
     def __call__(self, matrix: Tensor) -> Tensor:
+        """
+        Applies all registered hooks and computes and returns the aggregation from the input matrix.
+        """
+
         return super().__call__(matrix)
 
     def __repr__(self) -> str:

--- a/src/torchjd/autojac/_transform/_differentiate.py
+++ b/src/torchjd/autojac/_transform/_differentiate.py
@@ -29,6 +29,14 @@ class _Differentiate(Transform[_A, _A], ABC):
 
     @abstractmethod
     def _differentiate(self, tensor_outputs: Sequence[Tensor]) -> tuple[Tensor, ...]:
+        """
+        Abstract method for differentiating the outputs with respect to the inputs, and
+        right-multiplying them with the provided tensor_outputs.
+
+        The implementation of this method should define what kind of differentiation is performed
+        (whether gradients, Jacobians, etc. are computed).
+        """
+
         raise NotImplementedError
 
     @property

--- a/src/torchjd/autojac/_transform/_differentiate.py
+++ b/src/torchjd/autojac/_transform/_differentiate.py
@@ -37,8 +37,6 @@ class _Differentiate(Transform[_A, _A], ABC):
         (whether gradients, Jacobians, etc. are computed).
         """
 
-        raise NotImplementedError
-
     @property
     def required_keys(self) -> set[Tensor]:
         # outputs in the forward direction become inputs in the backward direction, and vice-versa

--- a/src/torchjd/autojac/_transform/base.py
+++ b/src/torchjd/autojac/_transform/base.py
@@ -61,6 +61,10 @@ class Transform(Generic[_B, _C], ABC):
     @property
     @abstractmethod
     def output_keys(self) -> set[Tensor]:
+        """
+        Returns the set of keys that will be present in the TensorDicts returned by the transform.
+        """
+
         raise NotImplementedError
 
     __lshift__ = compose

--- a/src/torchjd/autojac/_transform/base.py
+++ b/src/torchjd/autojac/_transform/base.py
@@ -41,6 +41,8 @@ class Transform(Generic[_B, _C], ABC):
 
     @abstractmethod
     def _compute(self, input: _B) -> _C:
+        """Applies the transform to the input and returns its result."""
+
         raise NotImplementedError
 
     def __call__(self, input: _B) -> _C:

--- a/src/torchjd/autojac/_transform/base.py
+++ b/src/torchjd/autojac/_transform/base.py
@@ -41,7 +41,7 @@ class Transform(Generic[_B, _C], ABC):
 
     @abstractmethod
     def _compute(self, input: _B) -> _C:
-        """Applies the transform to the input and returns its result."""
+        """Applies the transform to the input."""
 
     def __call__(self, input: _B) -> _C:
         input.check_keys_are(self.required_keys)
@@ -51,15 +51,13 @@ class Transform(Generic[_B, _C], ABC):
     @abstractmethod
     def required_keys(self) -> set[Tensor]:
         """
-        Returns the set of keys that the transform expects to be present in its input TensorDicts.
+        Returns the set of keys that the transform requires to be present in its input TensorDicts.
         """
 
     @property
     @abstractmethod
     def output_keys(self) -> set[Tensor]:
-        """
-        Returns the set of keys that will be present in the TensorDicts returned by the transform.
-        """
+        """Returns the set of keys that will be present in the output of the transform."""
 
     __lshift__ = compose
     __or__ = conjunct

--- a/src/torchjd/autojac/_transform/base.py
+++ b/src/torchjd/autojac/_transform/base.py
@@ -52,6 +52,10 @@ class Transform(Generic[_B, _C], ABC):
     @property
     @abstractmethod
     def required_keys(self) -> set[Tensor]:
+        """
+        Returns the set of keys that the transform expects to be present in its input TensorDicts.
+        """
+
         raise NotImplementedError
 
     @property

--- a/src/torchjd/autojac/_transform/base.py
+++ b/src/torchjd/autojac/_transform/base.py
@@ -43,8 +43,6 @@ class Transform(Generic[_B, _C], ABC):
     def _compute(self, input: _B) -> _C:
         """Applies the transform to the input and returns its result."""
 
-        raise NotImplementedError
-
     def __call__(self, input: _B) -> _C:
         input.check_keys_are(self.required_keys)
         return self._compute(input)
@@ -56,16 +54,12 @@ class Transform(Generic[_B, _C], ABC):
         Returns the set of keys that the transform expects to be present in its input TensorDicts.
         """
 
-        raise NotImplementedError
-
     @property
     @abstractmethod
     def output_keys(self) -> set[Tensor]:
         """
         Returns the set of keys that will be present in the TensorDicts returned by the transform.
         """
-
-        raise NotImplementedError
 
     __lshift__ = compose
     __or__ = conjunct

--- a/src/torchjd/autojac/_transform/grad.py
+++ b/src/torchjd/autojac/_transform/grad.py
@@ -19,6 +19,11 @@ class Grad(_Differentiate[Gradients]):
         super().__init__(outputs, inputs, retain_graph, create_graph)
 
     def _differentiate(self, grad_outputs: Sequence[Tensor]) -> tuple[Tensor, ...]:
+        """
+        Differentiates the outputs with respect to the inputs, and right-multiplies them with the
+        provided grad_outputs. Returns the obtained tuple of gradients.
+        """
+
         return _grad(
             outputs=list(self.outputs),
             inputs=list(self.inputs),

--- a/src/torchjd/autojac/_transform/jac.py
+++ b/src/torchjd/autojac/_transform/jac.py
@@ -22,6 +22,11 @@ class Jac(_Differentiate[Jacobians]):
         self.chunk_size = chunk_size
 
     def _differentiate(self, jac_outputs: Sequence[Tensor]) -> tuple[Tensor, ...]:
+        """
+        Differentiates the outputs with respect to the inputs, and right-multiplies them with the
+        provided jac_outputs. Returns the obtained tuple of Jacobians.
+        """
+
         return _jac(
             outputs=list(self.outputs),
             inputs=list(self.inputs),


### PR DESCRIPTION
The goal of this pull request is to remove the `raise NotImplementedError` from methods decorated as `@abstractmethod`, because this is non-standard and redundant, and it artificially reduces our code coverage.

Since method bodies can't be empty (need at least `...`, `pass`, `raise NotImplementedError` or a docstring), this is the perfect occasion to also provide documentation to those methods.

It's written [here](https://stackoverflow.com/a/44316506) that you're supposed to have either `@abstractmethod` or `raise NotImplementedError`. [Here](https://stackoverflow.com/a/61800126), they suggest that it's possible to combine both (so what we're currently doing is fine, but it's non-standard).

Removing the `raise` and adding a docstring is precisely what is suggested [here](https://github.com/pytest-dev/pytest-cov/issues/428#issuecomment-898590712) and [there](https://stackoverflow.com/questions/9202723/excluding-abstractproperties-from-coverage-reports#comment22011257_9212387).