### PR TITLE
Add ecos>=2.0.14 to the core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "numpy>=1.21.0",  # Does not work before 1.21
     "qpsolvers>=1.0.1",  # Does not work before 1.0.1
     "cvxpy>=1.3.0",  # No Clarabel solver before 1.3.0
+    "ecos>=2.0.14",  # Does not work before 2.0.14
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Very recently, cvxpy released v1.16.0 which removed ecos from its dependencies. Since we use ecos in NashMTL, we thus have to explicitly depend on ecos ourselves.

This should fix the failing tests.