### PR TITLE
Rename dev dependency section to dependency-groups in pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). This changelog does not include internal
 changes that do not affect the user.
 
+## [Unreleased]
+
+### Changed
+
+- Switched to the [PEP 735](https://peps.python.org/pep-0735/) dependency groups format in
+  `pyproject.toml` (from a `[tool.pdm.dev-dependencies]` to a `[dependency-groups]` section). This
+  should only affect development dependencies.
+
 ## [0.2.2] - 2024-11-11
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ Documentation = "https://torchjd.org/"
 Source = "https://github.com/TorchJD/torchjd"
 Changelog = "https://github.com/TorchJD/torchjd/blob/main/CHANGELOG.md"
 
-[tool.pdm.dev-dependencies]
+[dependency-groups]
 check = [
     "pre-commit>=2.9.2"  # isort doesn't work before 2.9.2
 ]


### PR DESCRIPTION
[A new PEP](https://peps.python.org/pep-0735/) was recently (2024-10-10) accepted with the goal of standardizing dependency groups.

Soon after this, PDM has published [a release](https://github.com/pdm-project/pdm/releases/tag/2.20.0) that supports the new format proposed in the PEP.

Basically, instead of having a PDM-specific section `[tool.pdm.dev-dependencies]` in the `pyproject.toml`, we can now have a standardized `[dependency-groups]` section. It serves the same purpose and for our case the transition is trivial because we do not use any advanced PDM-specific feature of the `[tool.pdm.dev-dependencies]` section. We literally just have to rename the section header.

So this is very cool in my opinion.

Lastly, with this release, PDM has somehow changed its default behavior to not install the dependency groups of `[tool.pdm.dev-dependencies]` by default when running `pdm install` (before this, it would install everything). This change does not break our CI or our users, but it breaks the proposed installation steps provided in `CONTRIBUTING.md`: `pdm install --frozen-lockfile` is now not enough to have every dependency group installed.
With the new header name (`[dependency-groups]`), `pdm install` will install everything (unless asked otherwise), so this PR also fixes this issue.

An alternative would be to change `pdm install --frozen-lockfile` to `pdm install --frozen-lockfile --dev` in `CONTRIBUTING.md`.

I think the changes of PDM make sense and are improvements (not bugs), so I think it's good to follow the flow (and merge this PR).

