### PR TITLE
Remove raise in abstract methods

### DIFF
--- a/src/torchjd/aggregation/bases.py
+++ b/src/torchjd/aggregation/bases.py
@@ -29,8 +29,6 @@ class Aggregator(nn.Module, ABC):
     def forward(self, matrix: Tensor) -> Tensor:
         """Computes the aggregation from the input matrix."""
 
-        raise NotImplementedError
-
     # Override to make type hints and documentation more specific
     def __call__(self, matrix: Tensor) -> Tensor:
         """Computes the aggregation from the input matrix and applies all registered hooks."""
@@ -53,8 +51,6 @@ class _Weighting(nn.Module, ABC):
     @abstractmethod
     def forward(self, matrix: Tensor) -> Tensor:
         """Computes the vector of weights from the input matrix."""
-
-        raise NotImplementedError
 
     # Override to make type hints and documentation more specific
     def __call__(self, matrix: Tensor) -> Tensor:

--- a/src/torchjd/autojac/_transform/_differentiate.py
+++ b/src/torchjd/autojac/_transform/_differentiate.py
@@ -38,8 +38,6 @@ class _Differentiate(Transform[_A, _A], ABC):
         tensor_outputs should be.
         """
 
-        raise NotImplementedError
-
     @property
     def required_keys(self) -> set[Tensor]:
         # outputs in the forward direction become inputs in the backward direction, and vice-versa

--- a/src/torchjd/autojac/_transform/base.py
+++ b/src/torchjd/autojac/_transform/base.py
@@ -43,8 +43,6 @@ class Transform(Generic[_B, _C], ABC):
     def _compute(self, input: _B) -> _C:
         """Applies the transform to the input."""
 
-        raise NotImplementedError
-
     def __call__(self, input: _B) -> _C:
         input.check_keys_are(self.required_keys)
         return self._compute(input)
@@ -56,14 +54,10 @@ class Transform(Generic[_B, _C], ABC):
         Returns the set of keys that the transform requires to be present in its input TensorDicts.
         """
 
-        raise NotImplementedError
-
     @property
     @abstractmethod
     def output_keys(self) -> set[Tensor]:
         """Returns the set of keys that will be present in the output of the transform."""
-
-        raise NotImplementedError
 
     __lshift__ = compose
     __or__ = conjunct


### PR DESCRIPTION
- **Remove raise NotImplementedError in abstract methods**

Should be merged after #178 

The goal of this pull request is to remove the `raise NotImplementedError` from methods decorated as `@abstractmethod`, because this is non-standard and redundant, and it artificially reduces our code coverage.

Since method bodies can't be empty (need at least `...`, `pass`, `raise NotImplementedError` or a docstring), this is the perfect occasion to also provide documentation to those methods.

It's written [here](https://stackoverflow.com/a/44316506) that you're supposed to have either `@abstractmethod` or `raise NotImplementedError`. [Here](https://stackoverflow.com/a/61800126), they suggest that it's possible to combine both (so what we're currently doing is fine, but it's non-standard).

Removing the `raise` and adding a docstring is precisely what is suggested [here](https://github.com/pytest-dev/pytest-cov/issues/428#issuecomment-898590712) and [there](https://stackoverflow.com/questions/9202723/excluding-abstractproperties-from-coverage-reports#comment22011257_9212387).