### PR TITLE
Remove __str__ and __repr__ from _Weighting

### DIFF
--- a/src/torchjd/aggregation/bases.py
+++ b/src/torchjd/aggregation/bases.py
@@ -58,12 +58,6 @@ class _Weighting(nn.Module, ABC):
 
         return super().__call__(matrix)
 
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}()"
-
-    def __str__(self) -> str:
-        return f"{self.__class__.__name__}"
-
 
 class _WeightedAggregator(Aggregator):
     """


### PR DESCRIPTION
`_Weighting` is protected, so users shouldn't really call anything on it, including `__repr__` and `__str__`. Besides, `__repr__` is actually already defined in `nn.Module` that `_Weighting` extends. Since by default, `__str__` returns what `__repr__` returns, this also gives a default implementation to `__str__`.

So basically, these two functions are more or less useless and they would exist anyway without defining them in `_Weighting`.
