### PR TITLE
Move `__str__` to `Aggregator`

### DIFF
--- a/src/torchjd/aggregation/bases.py
+++ b/src/torchjd/aggregation/bases.py
@@ -38,6 +38,9 @@ class Aggregator(nn.Module, ABC):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}()"
 
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}"
+
 
 class _Weighting(nn.Module, ABC):
     r"""

--- a/src/torchjd/aggregation/bases.py
+++ b/src/torchjd/aggregation/bases.py
@@ -97,9 +97,3 @@ class _WeightedAggregator(Aggregator):
         weights = self.weighting(matrix)
         vector = self.combine(matrix, weights)
         return vector
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}()"
-
-    def __str__(self) -> str:
-        return f"{self.__class__.__name__}"


### PR DESCRIPTION
I think it's a good thing to have a default implementation of `__str__` and `__repr__` for Aggregators. They even sometimes rely on it, by not overridding those methods themselves (see `Mean` for instance).
The default implementation of `nn.Module` (that `Aggregator` extends) is not necessarily enough because it might change in the future, which would break our tests.

However, currently, `Aggregator.__str__` is not defined, and `_WeightedAggregator` redundantly defines `__str__` and `__repr__`.

This PR fixes this:
- **Add default implementation of `__str__` in `Aggregator`**
- **Remove `__repr__` and `__str__` in `_WeightedAggregator`**
