### PR TITLE
Update `pre_commit.yml` to use `cache@v4`

### DIFF
--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install check dependencies
         run: pdm install --no-default --group check --frozen-lockfile
       - name: Cache pre-commit hooks
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}


### PR DESCRIPTION
![Screenshot from 2024-12-01 18-09-21](https://github.com/user-attachments/assets/2b553e33-8313-4289-8d6e-692788f80f5d)
This should fix this warning and maybe improve performance.