### PR TITLE
Add `fail-fast: false` in `tests.yml`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ jobs:
   Testing:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false  # Ensure matrix jobs keep running even if one fails
       matrix:
         python-version: ['3.10', '3.11', '3.12']
         os: [ubuntu-latest, macOS-latest, windows-latest]


### PR DESCRIPTION
This ensures that when one of the jobs in the matrix fails, others will keep running. For instance, if the windows tests fail, we want to keep running the mac and linux tests.

See [this](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) for the documentation about `fail-fast`.

I'm not really sure how to test this, but it seems very standard. We should probably merge and one day when the infrastructure for one of the OS fails, we will be able to see if this worked correctly.
