### PR TITLE
Remove pytest prefix by changing how it is imported

### DIFF
--- a/tests/unit/aggregation/_property_testers.py
+++ b/tests/unit/aggregation/_property_testers.py
@@ -1,5 +1,5 @@
-import pytest
 import torch
+from pytest import mark
 from torch import Tensor
 from torch.testing import assert_close
 
@@ -17,7 +17,7 @@ class ExpectedStructureProperty:
     """
 
     @classmethod
-    @pytest.mark.parametrize("matrix", scaled_matrices + zero_rank_matrices)
+    @mark.parametrize("matrix", scaled_matrices + zero_rank_matrices)
     def test_expected_structure_property(cls, aggregator: Aggregator, matrix: Tensor):
         cls._assert_expected_structure_property(aggregator, matrix)
 
@@ -34,7 +34,7 @@ class NonConflictingProperty:
     """
 
     @classmethod
-    @pytest.mark.parametrize("matrix", stationary_matrices + matrices)
+    @mark.parametrize("matrix", stationary_matrices + matrices)
     def test_non_conflicting_property(
         cls,
         aggregator: Aggregator,
@@ -62,7 +62,7 @@ class PermutationInvarianceProperty:
     N_PERMUTATIONS = 5
 
     @classmethod
-    @pytest.mark.parametrize("matrix", matrices)
+    @mark.parametrize("matrix", matrices)
     def test_permutation_invariance_property(cls, aggregator: Aggregator, matrix: Tensor):
         cls._assert_permutation_invariance_property(aggregator, matrix)
 

--- a/tests/unit/aggregation/test_aligned_mtl.py
+++ b/tests/unit/aggregation/test_aligned_mtl.py
@@ -1,11 +1,11 @@
-import pytest
+from pytest import mark
 
 from torchjd.aggregation import AlignedMTL
 
 from ._property_testers import ExpectedStructureProperty, PermutationInvarianceProperty
 
 
-@pytest.mark.parametrize("aggregator", [AlignedMTL()])
+@mark.parametrize("aggregator", [AlignedMTL()])
 class TestAlignedMTL(ExpectedStructureProperty, PermutationInvarianceProperty):
     pass
 

--- a/tests/unit/aggregation/test_base.py
+++ b/tests/unit/aggregation/test_base.py
@@ -1,22 +1,22 @@
 from contextlib import nullcontext as does_not_raise
 from typing import Sequence
 
-import pytest
 import torch
+from pytest import mark, raises
 from unit._utils import ExceptionContext
 from unit.conftest import DEVICE
 
 from torchjd.aggregation import Aggregator
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     ["shape", "expectation"],
     [
-        ([], pytest.raises(ValueError)),
-        ([1], pytest.raises(ValueError)),
+        ([], raises(ValueError)),
+        ([1], raises(ValueError)),
         ([1, 2], does_not_raise()),
-        ([1, 2, 3], pytest.raises(ValueError)),
-        ([1, 2, 3, 4], pytest.raises(ValueError)),
+        ([1, 2, 3], raises(ValueError)),
+        ([1, 2, 3, 4], raises(ValueError)),
     ],
 )
 def test_check_is_matrix(shape: Sequence[int], expectation: ExceptionContext):

--- a/tests/unit/aggregation/test_cagrad.py
+++ b/tests/unit/aggregation/test_cagrad.py
@@ -1,4 +1,4 @@
-import pytest
+from pytest import mark
 from torch import Tensor
 from torch.testing import assert_close
 
@@ -8,22 +8,22 @@ from ._inputs import matrices, stationary_matrices
 from ._property_testers import ExpectedStructureProperty, NonConflictingProperty
 
 
-@pytest.mark.filterwarnings("ignore:np.find_common_type is deprecated:")
-@pytest.mark.parametrize("aggregator", [CAGrad(c=0.5)])
+@mark.filterwarnings("ignore:np.find_common_type is deprecated:")
+@mark.parametrize("aggregator", [CAGrad(c=0.5)])
 class TestCAGrad(ExpectedStructureProperty):
     pass
 
 
-@pytest.mark.filterwarnings("ignore:np.find_common_type is deprecated:")
-@pytest.mark.parametrize("aggregator", [CAGrad(c=1.0), CAGrad(c=2.0)])
+@mark.filterwarnings("ignore:np.find_common_type is deprecated:")
+@mark.parametrize("aggregator", [CAGrad(c=1.0), CAGrad(c=2.0)])
 class TestCAGradNonConflicting(NonConflictingProperty):
     """Tests that CAGrad is non-conflicting when c >= 1 (it should not hold when c < 1)"""
 
     pass
 
 
-@pytest.mark.filterwarnings("ignore:np.find_common_type is deprecated:")
-@pytest.mark.parametrize("matrix", stationary_matrices + matrices)
+@mark.filterwarnings("ignore:np.find_common_type is deprecated:")
+@mark.parametrize("matrix", stationary_matrices + matrices)
 def test_equivalence_mean(matrix: Tensor):
     """Tests that CAGrad is equivalent to Mean when c=0."""
 

--- a/tests/unit/aggregation/test_constant.py
+++ b/tests/unit/aggregation/test_constant.py
@@ -1,5 +1,5 @@
-import pytest
 import torch
+from pytest import mark
 from torch import Tensor
 from unit.conftest import DEVICE
 
@@ -32,7 +32,7 @@ class TestConstant(ExpectedStructureProperty):
     # right aggregator with each matrix.
 
     @classmethod
-    @pytest.mark.parametrize(["aggregator", "matrix"], zip(_aggregators_1, _matrices_1))
+    @mark.parametrize(["aggregator", "matrix"], zip(_aggregators_1, _matrices_1))
     def test_expected_structure_property(cls, aggregator: Constant, matrix: Tensor):
         cls._assert_expected_structure_property(aggregator, matrix)
 

--- a/tests/unit/aggregation/test_dualproj.py
+++ b/tests/unit/aggregation/test_dualproj.py
@@ -1,4 +1,4 @@
-import pytest
+from pytest import mark
 
 from torchjd.aggregation import DualProj
 
@@ -9,7 +9,7 @@ from ._property_testers import (
 )
 
 
-@pytest.mark.parametrize("aggregator", [DualProj()])
+@mark.parametrize("aggregator", [DualProj()])
 class TestDualProj(
     ExpectedStructureProperty, NonConflictingProperty, PermutationInvarianceProperty
 ):

--- a/tests/unit/aggregation/test_graddrop.py
+++ b/tests/unit/aggregation/test_graddrop.py
@@ -1,12 +1,12 @@
-import pytest
 import torch
+from pytest import mark
 
 from torchjd.aggregation import GradDrop
 
 from ._property_testers import ExpectedStructureProperty
 
 
-@pytest.mark.parametrize("aggregator", [GradDrop()])
+@mark.parametrize("aggregator", [GradDrop()])
 class TestGradDrop(ExpectedStructureProperty):
     pass
 

--- a/tests/unit/aggregation/test_imtl_g.py
+++ b/tests/unit/aggregation/test_imtl_g.py
@@ -1,5 +1,5 @@
-import pytest
 import torch
+from pytest import mark
 from torch.testing import assert_close
 from unit.conftest import DEVICE
 
@@ -8,7 +8,7 @@ from torchjd.aggregation import IMTLG
 from ._property_testers import ExpectedStructureProperty, PermutationInvarianceProperty
 
 
-@pytest.mark.parametrize("aggregator", [IMTLG()])
+@mark.parametrize("aggregator", [IMTLG()])
 class TestIMTLG(ExpectedStructureProperty, PermutationInvarianceProperty):
     pass
 

--- a/tests/unit/aggregation/test_krum.py
+++ b/tests/unit/aggregation/test_krum.py
@@ -1,4 +1,4 @@
-import pytest
+from pytest import mark
 from torch import Tensor
 
 from torchjd.aggregation import Krum
@@ -7,12 +7,12 @@ from ._inputs import scaled_matrices_2_plus_rows
 from ._property_testers import ExpectedStructureProperty
 
 
-@pytest.mark.parametrize("aggregator", [Krum(n_byzantine=1)])
+@mark.parametrize("aggregator", [Krum(n_byzantine=1)])
 class TestKrum(ExpectedStructureProperty):
     # Override the parametrization of some property-testing methods because Krum only works on
     # matrices with >= 2 rows.
     @classmethod
-    @pytest.mark.parametrize("matrix", scaled_matrices_2_plus_rows)
+    @mark.parametrize("matrix", scaled_matrices_2_plus_rows)
     def test_expected_structure_property(cls, aggregator: Krum, matrix: Tensor):
         cls._assert_expected_structure_property(aggregator, matrix)
 

--- a/tests/unit/aggregation/test_mean.py
+++ b/tests/unit/aggregation/test_mean.py
@@ -1,11 +1,11 @@
-import pytest
+from pytest import mark
 
 from torchjd.aggregation import Mean
 
 from ._property_testers import ExpectedStructureProperty, PermutationInvarianceProperty
 
 
-@pytest.mark.parametrize("aggregator", [Mean()])
+@mark.parametrize("aggregator", [Mean()])
 class TestMean(ExpectedStructureProperty, PermutationInvarianceProperty):
     pass
 

--- a/tests/unit/aggregation/test_mgda.py
+++ b/tests/unit/aggregation/test_mgda.py
@@ -1,5 +1,5 @@
-import pytest
 import torch
+from pytest import mark
 from torch.testing import assert_close
 from unit.conftest import DEVICE
 
@@ -13,12 +13,12 @@ from ._property_testers import (
 )
 
 
-@pytest.mark.parametrize("aggregator", [MGDA()])
+@mark.parametrize("aggregator", [MGDA()])
 class TestMGDA(ExpectedStructureProperty, NonConflictingProperty, PermutationInvarianceProperty):
     pass
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "shape",
     [
         (5, 7),

--- a/tests/unit/aggregation/test_pcgrad.py
+++ b/tests/unit/aggregation/test_pcgrad.py
@@ -1,5 +1,5 @@
-import pytest
 import torch
+from pytest import mark
 from torch.testing import assert_close
 from unit.conftest import DEVICE
 
@@ -11,12 +11,12 @@ from torchjd.aggregation.upgrad import _UPGradWrapper
 from ._property_testers import ExpectedStructureProperty
 
 
-@pytest.mark.parametrize("aggregator", [PCGrad()])
+@mark.parametrize("aggregator", [PCGrad()])
 class TestPCGrad(ExpectedStructureProperty):
     pass
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "shape",
     [
         (2, 5),

--- a/tests/unit/aggregation/test_random.py
+++ b/tests/unit/aggregation/test_random.py
@@ -1,11 +1,11 @@
-import pytest
+from pytest import mark
 
 from torchjd.aggregation import Random
 
 from ._property_testers import ExpectedStructureProperty
 
 
-@pytest.mark.parametrize("aggregator", [Random()])
+@mark.parametrize("aggregator", [Random()])
 class TestRGW(ExpectedStructureProperty):
     pass
 

--- a/tests/unit/aggregation/test_sum.py
+++ b/tests/unit/aggregation/test_sum.py
@@ -1,11 +1,11 @@
-import pytest
+from pytest import mark
 
 from torchjd.aggregation import Sum
 
 from ._property_testers import ExpectedStructureProperty, PermutationInvarianceProperty
 
 
-@pytest.mark.parametrize("aggregator", [Sum()])
+@mark.parametrize("aggregator", [Sum()])
 class TestSum(ExpectedStructureProperty, PermutationInvarianceProperty):
     pass
 

--- a/tests/unit/aggregation/test_trimmed_mean.py
+++ b/tests/unit/aggregation/test_trimmed_mean.py
@@ -1,4 +1,4 @@
-import pytest
+from pytest import mark
 from torch import Tensor
 
 from torchjd.aggregation import Aggregator, TrimmedMean
@@ -7,17 +7,17 @@ from ._inputs import matrices_2_plus_rows, scaled_matrices_2_plus_rows
 from ._property_testers import ExpectedStructureProperty, PermutationInvarianceProperty
 
 
-@pytest.mark.parametrize("aggregator", [TrimmedMean(trim_number=1)])
+@mark.parametrize("aggregator", [TrimmedMean(trim_number=1)])
 class TestTrimmedMean(ExpectedStructureProperty, PermutationInvarianceProperty):
     # Override the parametrization of some property-testing methods because `TrimmedMean` with
     # `trim_number=1` only works on matrices with >= 2 rows.
     @classmethod
-    @pytest.mark.parametrize("matrix", scaled_matrices_2_plus_rows)
+    @mark.parametrize("matrix", scaled_matrices_2_plus_rows)
     def test_expected_structure_property(cls, aggregator: TrimmedMean, matrix: Tensor):
         cls._assert_expected_structure_property(aggregator, matrix)
 
     @classmethod
-    @pytest.mark.parametrize("matrix", matrices_2_plus_rows)
+    @mark.parametrize("matrix", matrices_2_plus_rows)
     def test_permutation_invariance_property(cls, aggregator: Aggregator, matrix: Tensor):
         cls._assert_permutation_invariance_property(aggregator, matrix)
 

--- a/tests/unit/aggregation/test_upgrad.py
+++ b/tests/unit/aggregation/test_upgrad.py
@@ -1,5 +1,5 @@
-import pytest
 import torch
+from pytest import mark
 from torch.testing import assert_close
 from unit.conftest import DEVICE
 
@@ -14,12 +14,12 @@ from ._property_testers import (
 )
 
 
-@pytest.mark.parametrize("aggregator", [UPGrad()])
+@mark.parametrize("aggregator", [UPGrad()])
 class TestUPGrad(ExpectedStructureProperty, NonConflictingProperty, PermutationInvarianceProperty):
     pass
 
 
-@pytest.mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100)])
+@mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100)])
 def test_upgrad_lagrangian_satisfies_kkt_conditions(shape: tuple[int, int]):
     matrix = torch.randn(shape, device=DEVICE)
     weights = torch.rand(shape[0], device=DEVICE)

--- a/tests/unit/autojac/_transform/test_accumulate.py
+++ b/tests/unit/autojac/_transform/test_accumulate.py
@@ -1,5 +1,5 @@
-import pytest
 import torch
+from pytest import mark, raises
 from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import Accumulate, Gradients
@@ -34,7 +34,7 @@ def test_single_accumulation():
     assert_tensor_dicts_are_close(grads, expected_grads)
 
 
-@pytest.mark.parametrize("iterations", [1, 2, 4, 10, 13])
+@mark.parametrize("iterations", [1, 2, 4, 10, 13])
 def test_multiple_accumulation(iterations: int):
     """
     Tests that the Accumulate transform correctly accumulates gradients in .grad fields when run
@@ -76,7 +76,7 @@ def test_accumulate_fails_on_no_requires_grad():
 
     accumulate = Accumulate([key1])
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         accumulate(input)
 
 
@@ -93,5 +93,5 @@ def test_accumulate_fails_on_no_leaf_and_no_retains_grad():
 
     accumulate = Accumulate([key1])
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         accumulate(input)

--- a/tests/unit/autojac/_transform/test_aggregate.py
+++ b/tests/unit/autojac/_transform/test_aggregate.py
@@ -1,8 +1,8 @@
 import math
 from collections import OrderedDict
 
-import pytest
 import torch
+from pytest import mark, raises
 from torch import Tensor
 from unit.conftest import DEVICE
 
@@ -42,7 +42,7 @@ _rng.manual_seed(0)
 _jacobian_matrix_dicts = [_make_jacobian_matrices(n_outputs, _rng) for n_outputs in [1, 2, 5]]
 
 
-@pytest.mark.parametrize("jacobian_matrices", _jacobian_matrix_dicts)
+@mark.parametrize("jacobian_matrices", _jacobian_matrix_dicts)
 def test_aggregate_matrices_output_structure(jacobian_matrices: JacobianMatrices):
     """
     Tests that applying _AggregateMatrices to various dictionaries of jacobian matrices gives an
@@ -68,7 +68,7 @@ def test_aggregate_matrices_empty_dict():
     assert len(gradient_vectors) == 0
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     ["united_gradient_vector", "jacobian_matrices"],
     [
         (
@@ -95,7 +95,7 @@ def test_disunite_wrong_vector_length(
     Tests that the _disunite method raises a ValueError when used on vectors of the wrong length.
     """
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         _AggregateMatrices._disunite(united_gradient_vector, OrderedDict(jacobian_matrices))
 
 

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -1,7 +1,7 @@
 import typing
 
-import pytest
 import torch
+from pytest import raises
 from torch import Tensor
 from unit.conftest import DEVICE
 
@@ -49,13 +49,13 @@ def test_apply_keys():
 
     transform(TensorDict({t1: t2}))
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         transform(TensorDict({t2: t1}))
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         transform(TensorDict({}))
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         transform(TensorDict({t1: t2, t2: t1}))
 
 
@@ -72,7 +72,7 @@ def test_compose_keys_match():
 
     transform1 << transform2
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         transform2 << transform1
 
 
@@ -91,10 +91,10 @@ def test_conjunct_required_keys():
 
     transform1 | transform2
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         transform2 | transform3
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         transform1 | transform2 | transform3
 
 
@@ -113,10 +113,10 @@ def test_conjunct_wrong_output_keys():
 
     transform2 | transform3
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         transform1 | transform3
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         transform1 | transform2 | transform3
 
 

--- a/tests/unit/autojac/_transform/test_tensor_dict.py
+++ b/tests/unit/autojac/_transform/test_tensor_dict.py
@@ -1,8 +1,7 @@
 from contextlib import nullcontext as does_not_raise
 
-import pytest
 import torch
-from pytest import raises
+from pytest import mark, raises
 from torch import Tensor
 from unit._utils import ExceptionContext
 from unit.conftest import DEVICE
@@ -20,7 +19,7 @@ from torchjd.autojac._transform.tensor_dict import _least_common_ancestor
 _key_shapes = [[], [1], [2, 3]]
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     ["value_shapes", "expectation"],
     [
         ([[], [1], [2, 3]], does_not_raise()),
@@ -35,7 +34,7 @@ def test_gradients(value_shapes: list[list[int]], expectation: ExceptionContext)
     _assert_class_checks_properly(Gradients, value_shapes, expectation)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     ["value_shapes", "expectation"],
     [
         ([[5], [5, 1], [5, 2, 3]], does_not_raise()),
@@ -51,7 +50,7 @@ def test_jacobians(value_shapes: list[list[int]], expectation: ExceptionContext)
     _assert_class_checks_properly(Jacobians, value_shapes, expectation)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     ["value_shapes", "expectation"],
     [
         ([[1], [1], [6]], does_not_raise()),
@@ -66,7 +65,7 @@ def test_gradient_vectors(value_shapes: list[list[int]], expectation: ExceptionC
     _assert_class_checks_properly(GradientVectors, value_shapes, expectation)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     ["value_shapes", "expectation"],
     [
         ([[5, 1], [5, 1], [5, 6]], does_not_raise()),
@@ -82,7 +81,7 @@ def test_jacobian_matrices(value_shapes: list[list[int]], expectation: Exception
     _assert_class_checks_properly(JacobianMatrices, value_shapes, expectation)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     ["first", "second", "result"],
     [
         (EmptyTensorDict, EmptyTensorDict, EmptyTensorDict),

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -1,8 +1,7 @@
 from contextlib import nullcontext as does_not_raise
 
-import pytest
 import torch
-from pytest import raises
+from pytest import mark, raises
 from torch.testing import assert_close
 from unit._utils import ExceptionContext
 from unit.conftest import DEVICE
@@ -11,7 +10,7 @@ from torchjd import backward
 from torchjd.aggregation import MGDA, Aggregator, Mean, Random, UPGrad
 
 
-@pytest.mark.parametrize("A", [Mean(), UPGrad(), MGDA(), Random()])
+@mark.parametrize("A", [Mean(), UPGrad(), MGDA(), Random()])
 def test_backward_various_aggregators(A: Aggregator):
     """Tests that backward works for various aggregators."""
 
@@ -28,9 +27,9 @@ def test_backward_various_aggregators(A: Aggregator):
         assert (p.grad is not None) and (p.shape == p.grad.shape)
 
 
-@pytest.mark.parametrize("A", [Mean(), UPGrad(), MGDA()])
-@pytest.mark.parametrize("shape", [(2, 3), (2, 6), (5, 8), (60, 55), (120, 143)])
-@pytest.mark.parametrize("manually_specify_inputs", [True, False])
+@mark.parametrize("A", [Mean(), UPGrad(), MGDA()])
+@mark.parametrize("shape", [(2, 3), (2, 6), (5, 8), (60, 55), (120, 143)])
+@mark.parametrize("manually_specify_inputs", [True, False])
 def test_backward_value_is_correct(
     A: Aggregator, shape: tuple[int, int], manually_specify_inputs: bool
 ):
@@ -99,7 +98,7 @@ def test_backward_empty_tensors():
     p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
     p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         backward([], A, inputs=[p1, p2])
 
 
@@ -130,7 +129,7 @@ def test_backward_multiple_tensors():
         assert (p.grad == param_to_grad[p]).all()
 
 
-@pytest.mark.parametrize("chunk_size", [None, 1, 2, 4])
+@mark.parametrize("chunk_size", [None, 1, 2, 4])
 def test_backward_valid_chunk_size(chunk_size):
     """Tests that backward works for various valid values of parallel_chunk_size."""
 
@@ -149,7 +148,7 @@ def test_backward_valid_chunk_size(chunk_size):
         assert (p.grad is not None) and (p.shape == p.grad.shape)
 
 
-@pytest.mark.parametrize("chunk_size", [0, -1])
+@mark.parametrize("chunk_size", [0, -1])
 def test_backward_non_positive_chunk_size(chunk_size: int):
     """Tests that backward raises an error when using invalid chunk sizes."""
 
@@ -161,11 +160,11 @@ def test_backward_non_positive_chunk_size(chunk_size: int):
     y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p1 + p2.sum()
     y2 = (p1**2).sum() + p2.norm()
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         backward([y1, y2], A, parallel_chunk_size=chunk_size)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     ["chunk_size", "expectation"],
     [(1, raises(ValueError)), (2, does_not_raise()), (None, does_not_raise())],
 )

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -1,8 +1,7 @@
 from contextlib import nullcontext as does_not_raise
 
-import pytest
 import torch
-from pytest import raises
+from pytest import mark, raises
 from torch.testing import assert_close
 from unit._utils import ExceptionContext
 from unit.conftest import DEVICE
@@ -11,7 +10,7 @@ from torchjd import mtl_backward
 from torchjd.aggregation import MGDA, Aggregator, Mean, Random, UPGrad
 
 
-@pytest.mark.parametrize("A", [Mean(), UPGrad(), MGDA(), Random()])
+@mark.parametrize("A", [Mean(), UPGrad(), MGDA(), Random()])
 def test_mtl_backward_various_aggregators(A: Aggregator):
     """Tests that mtl_backward works for various aggregators."""
 
@@ -30,10 +29,10 @@ def test_mtl_backward_various_aggregators(A: Aggregator):
         assert (p.grad is not None) and (p.shape == p.grad.shape)
 
 
-@pytest.mark.parametrize("A", [Mean(), UPGrad(), MGDA()])
-@pytest.mark.parametrize("shape", [(2, 3), (2, 6), (5, 8), (60, 55), (120, 143)])
-@pytest.mark.parametrize("manually_specify_shared_params", [True, False])
-@pytest.mark.parametrize("manually_specify_tasks_params", [True, False])
+@mark.parametrize("A", [Mean(), UPGrad(), MGDA()])
+@mark.parametrize("shape", [(2, 3), (2, 6), (5, 8), (60, 55), (120, 143)])
+@mark.parametrize("manually_specify_shared_params", [True, False])
+@mark.parametrize("manually_specify_tasks_params", [True, False])
 def test_mtl_backward_value_is_correct(
     A: Aggregator,
     shape: tuple[int, int],
@@ -95,7 +94,7 @@ def test_mtl_backward_empty_tasks():
     r1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
     r2 = (p0**2).sum() + p0.norm()
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         mtl_backward(losses=[], features=[r1, r2], A=UPGrad())
 
 
@@ -130,7 +129,7 @@ def test_mtl_backward_incoherent_task_number():
     y1 = r1 * p1[0] + r2 * p1[1]
     y2 = r1 * p2[0] + r2 * p2[1]
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         mtl_backward(
             losses=[y1, y2],
             features=[r1, r2],
@@ -138,7 +137,7 @@ def test_mtl_backward_incoherent_task_number():
             tasks_params=[[p1]],  # Wrong
             shared_params=[p0],
         )
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         mtl_backward(
             losses=[y1],  # Wrong
             features=[r1, r2],
@@ -193,7 +192,7 @@ def test_mtl_backward_multiple_params_per_task():
         assert (p.grad is not None) and (p.shape == p.grad.shape)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "shared_params_shapes",
     [
         [tuple()],
@@ -271,11 +270,11 @@ def test_mtl_backward_empty_features():
     y1 = r1 * p1[0] + r2 * p1[1]
     y2 = r1 * p2[0] + r2 * p2[1]
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         mtl_backward(losses=[y1, y2], features=[], A=UPGrad())
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "shape",
     [
         (2,),
@@ -302,7 +301,7 @@ def test_mtl_backward_various_single_features(shape: tuple[int, ...]):
         assert (p.grad is not None) and (p.shape == p.grad.shape)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "shapes",
     [
         [(2,)],
@@ -345,11 +344,11 @@ def test_mtl_backward_non_scalar_loss():
     y1 = torch.stack([r1 * p1[0], r2 * p1[1]])  # Non-scalar
     y2 = r1 * p2[0] + r2 * p2[1]
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         mtl_backward(losses=[y1, y2], features=[r1, r2], A=UPGrad())
 
 
-@pytest.mark.parametrize("chunk_size", [None, 1, 2, 4])
+@mark.parametrize("chunk_size", [None, 1, 2, 4])
 def test_mtl_backward_valid_chunk_size(chunk_size):
     """Tests that mtl_backward works for various valid values of parallel_chunk_size."""
 
@@ -374,7 +373,7 @@ def test_mtl_backward_valid_chunk_size(chunk_size):
         assert (p.grad is not None) and (p.shape == p.grad.shape)
 
 
-@pytest.mark.parametrize("chunk_size", [0, -1])
+@mark.parametrize("chunk_size", [0, -1])
 def test_mtl_backward_non_positive_chunk_size(chunk_size: int):
     """Tests that mtl_backward raises an error when using invalid chunk sizes."""
 
@@ -387,11 +386,11 @@ def test_mtl_backward_non_positive_chunk_size(chunk_size: int):
     y1 = r1 * p1[0] + r2 * p1[1]
     y2 = r1 * p2[0] + r2 * p2[1]
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         mtl_backward(losses=[y1, y2], features=[r1, r2], A=UPGrad(), parallel_chunk_size=chunk_size)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     ["chunk_size", "expectation"],
     [(1, raises(ValueError)), (2, does_not_raise()), (None, does_not_raise())],
 )

--- a/tests/unit/autojac/test_utils.py
+++ b/tests/unit/autojac/test_utils.py
@@ -1,5 +1,5 @@
-import pytest
 import torch
+from pytest import mark
 from torch.nn import Linear, MSELoss, ReLU, Sequential
 from unit.conftest import DEVICE
 
@@ -183,7 +183,7 @@ def test_get_leaf_tensors_excluded_root():
     assert leaves == {p1}
 
 
-@pytest.mark.parametrize("depth", [100, 1000, 10000])
+@mark.parametrize("depth", [100, 1000, 10000])
 def test_get_leaf_tensors_deep(depth: int):
     """Tests that _get_leaf_tensors works when the graph is very deep."""
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,8 +1,8 @@
 import os
 import random as rand
 
-import pytest
 import torch
+from pytest import fixture
 
 try:
     DEVICE = os.environ["PYTEST_TORCH_DEVICE"]
@@ -16,7 +16,7 @@ if DEVICE == "cuda" and not torch.cuda.is_available():
     raise ValueError('Requested device "cuda" but cuda is not available.')
 
 
-@pytest.fixture(autouse=True)
+@fixture(autouse=True)
 def fix_randomness() -> None:
     rand.seed(0)
     torch.manual_seed(0)


### PR DESCRIPTION
- `@pytest.mark.parametrize` => `@mark.parametrize`
- `@pytest.mark.filterwarnings` => `@mark.filterwarnings`
- `@pytest.fixture` => `@fixture`
- `pytest.raises` => `raises`
- imports adjusted accordingly

Note that it's not possible to just have `@parametrize` (we can't import `mark.parametrize` directly, I think that parametrize is a field of `mark`).
