### PR TITLE
Remove lightning logs

### DIFF
--- a/docs/source/examples/lightning_integration.rst
+++ b/docs/source/examples/lightning_integration.rst
@@ -59,7 +59,13 @@ The following code example demonstrates a basic multi-task learning setup using 
 
     dataset = TensorDataset(inputs, task1_targets, task2_targets)
     train_loader = DataLoader(dataset)
-    trainer = Trainer(accelerator="cpu", max_epochs=1, enable_checkpointing=False, logger=False)
+    trainer = Trainer(
+        accelerator="cpu",
+        max_epochs=1,
+        enable_checkpointing=False,
+        logger=False,
+        enable_progress_bar=False,
+    )
 
     trainer.fit(model=model, train_dataloaders=train_loader)
 

--- a/tests/doc/test_rst.py
+++ b/tests/doc/test_rst.py
@@ -163,6 +163,12 @@ def test_lightning_integration():
 
     dataset = TensorDataset(inputs, task1_targets, task2_targets)
     train_loader = DataLoader(dataset)
-    trainer = Trainer(accelerator="cpu", max_epochs=1, enable_checkpointing=False, logger=False)
+    trainer = Trainer(
+        accelerator="cpu",
+        max_epochs=1,
+        enable_checkpointing=False,
+        logger=False,
+        enable_progress_bar=False,
+    )
 
     trainer.fit(model=model, train_dataloaders=train_loader)

--- a/tests/doc/test_rst.py
+++ b/tests/doc/test_rst.py
@@ -113,9 +113,11 @@ def test_mtl():
 
 
 def test_lightning_integration():
+    import logging
     import warnings
 
     warnings.filterwarnings("ignore")
+    logging.disable(logging.INFO)
 
     import torch
     from lightning import LightningModule, Trainer


### PR DESCRIPTION
When running the tests, `test_lightning_integration` produces some logs in the terminal. This PR disables them to keep test outputs clean.
- Disable progress bar in lightning example
- Disable INFO logs in test_lightning_integration