### PR TITLE
Maintain autojac unit tests

### DIFF
--- a/tests/unit/autojac/_transform/test_accumulate.py
+++ b/tests/unit/autojac/_transform/test_accumulate.py
@@ -64,7 +64,7 @@ def test_multiple_accumulation(iterations: int):
     assert_tensor_dicts_are_close(grads, expected_grads)
 
 
-def test_accumulate_fails_on_no_requires_grad():
+def test_no_requires_grad_fails():
     """
     Tests that the Accumulate transform raises an error when it tries to populate a .grad of a
     tensor that does not require grad.
@@ -80,7 +80,7 @@ def test_accumulate_fails_on_no_requires_grad():
         accumulate(input)
 
 
-def test_accumulate_fails_on_no_leaf_and_no_retains_grad():
+def test_no_leaf_and_no_retains_grad_fails():
     """
     Tests that the Accumulate transform raises an error when it tries to populate a .grad of a
     tensor that is not a leaf and that does not retain grad.

--- a/tests/unit/autojac/_transform/test_accumulate.py
+++ b/tests/unit/autojac/_transform/test_accumulate.py
@@ -86,8 +86,7 @@ def test_no_leaf_and_no_retains_grad_fails():
     tensor that is not a leaf and that does not retain grad.
     """
 
-    a = torch.tensor([1.0], requires_grad=True, device=DEVICE)
-    key1 = 2 * a  # requires_grad=True, but is_leaf=False and retains_grad=False
+    key1 = torch.tensor([1.0], requires_grad=True, device=DEVICE) * 2
     value1 = torch.ones([1], device=DEVICE)
     input = Gradients({key1: value1})
 

--- a/tests/unit/autojac/_transform/test_accumulate.py
+++ b/tests/unit/autojac/_transform/test_accumulate.py
@@ -70,11 +70,11 @@ def test_no_requires_grad_fails():
     tensor that does not require grad.
     """
 
-    key1 = torch.zeros([1], requires_grad=False, device=DEVICE)
-    value1 = torch.ones([1], device=DEVICE)
-    input = Gradients({key1: value1})
+    key = torch.zeros([1], requires_grad=False, device=DEVICE)
+    value = torch.ones([1], device=DEVICE)
+    input = Gradients({key: value})
 
-    accumulate = Accumulate([key1])
+    accumulate = Accumulate([key])
 
     with raises(ValueError):
         accumulate(input)
@@ -86,11 +86,11 @@ def test_no_leaf_and_no_retains_grad_fails():
     tensor that is not a leaf and that does not retain grad.
     """
 
-    key1 = torch.tensor([1.0], requires_grad=True, device=DEVICE) * 2
-    value1 = torch.ones([1], device=DEVICE)
-    input = Gradients({key1: value1})
+    key = torch.tensor([1.0], requires_grad=True, device=DEVICE) * 2
+    value = torch.ones([1], device=DEVICE)
+    input = Gradients({key: value})
 
-    accumulate = Accumulate([key1])
+    accumulate = Accumulate([key])
 
     with raises(ValueError):
         accumulate(input)

--- a/tests/unit/autojac/_transform/test_aggregate.py
+++ b/tests/unit/autojac/_transform/test_aggregate.py
@@ -55,9 +55,7 @@ def test_aggregate_matrices_output_structure(jacobian_matrices: JacobianMatrices
     assert set(jacobian_matrices.keys()) == set(gradient_vectors.keys())
 
     for key in jacobian_matrices.keys():
-        jacobian_matrix = jacobian_matrices[key]
-        gradient_vector = gradient_vectors[key]
-        assert gradient_vector.numel() == jacobian_matrix[0].numel()
+        assert gradient_vectors[key].numel() == jacobian_matrices[key][0].numel()
 
 
 def test_aggregate_matrices_empty_dict():

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -45,7 +45,7 @@ def test_call_checks_keys():
 
     t1 = torch.randn([2], device=DEVICE)
     t2 = torch.randn([3], device=DEVICE)
-    transform = FakeTransform({t1}, {t1, t2})
+    transform = FakeTransform(required_keys={t1}, output_keys={t1, t2})
 
     transform(TensorDict({t1: t2}))
 
@@ -67,8 +67,8 @@ def test_compose_checks_keys():
 
     t1 = torch.randn([2], device=DEVICE)
     t2 = torch.randn([3], device=DEVICE)
-    transform1 = FakeTransform({t1}, {t1, t2})
-    transform2 = FakeTransform({t2}, {t1})
+    transform1 = FakeTransform(required_keys={t1}, output_keys={t1, t2})
+    transform2 = FakeTransform(required_keys={t2}, output_keys={t1})
 
     transform1 << transform2
 
@@ -85,9 +85,9 @@ def test_conjunct_checks_required_keys():
     t1 = torch.randn([2], device=DEVICE)
     t2 = torch.randn([3], device=DEVICE)
 
-    transform1 = FakeTransform({t1}, set())
-    transform2 = FakeTransform({t1}, set())
-    transform3 = FakeTransform({t2}, set())
+    transform1 = FakeTransform(required_keys={t1}, output_keys=set())
+    transform2 = FakeTransform(required_keys={t1}, output_keys=set())
+    transform3 = FakeTransform(required_keys={t2}, output_keys=set())
 
     transform1 | transform2
 
@@ -107,9 +107,9 @@ def test_conjunct_checks_output_keys():
     t1 = torch.randn([2], device=DEVICE)
     t2 = torch.randn([3], device=DEVICE)
 
-    transform1 = FakeTransform(set(), {t1, t2})
-    transform2 = FakeTransform(set(), {t1})
-    transform3 = FakeTransform(set(), {t2})
+    transform1 = FakeTransform(required_keys=set(), output_keys={t1, t2})
+    transform2 = FakeTransform(required_keys=set(), output_keys={t1})
+    transform3 = FakeTransform(required_keys=set(), output_keys={t2})
 
     transform2 | transform3
 
@@ -137,7 +137,7 @@ def test_str():
     conjunctions.
     """
 
-    t = FakeTransform(set(), set())
+    t = FakeTransform(required_keys=set(), output_keys=set())
     transform = (t | t << t << t | t) << t << (t | t)
 
     assert str(transform) == "(T | T ∘ T ∘ T | T) ∘ T ∘ (T | T)"

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -37,7 +37,7 @@ class FakeTransform(Transform[_B, _C]):
         return self._output_keys
 
 
-def test_apply_keys():
+def test_call_checks_keys():
     """
     Tests that a ``Transform`` checks that the provided dictionary to the `__call__` function
     contains keys that correspond exactly to `required_keys`.
@@ -59,7 +59,7 @@ def test_apply_keys():
         transform(TensorDict({t1: t2, t2: t1}))
 
 
-def test_compose_keys_match():
+def test_compose_checks_keys():
     """
     Tests that the composition of ``Transform``s checks that the inner transform's `output_keys`
     match with the outer transform's `required_keys`.
@@ -76,7 +76,7 @@ def test_compose_keys_match():
         transform2 << transform1
 
 
-def test_conjunct_required_keys():
+def test_conjunct_checks_required_keys():
     """
     Tests that the conjunction of ``Transform``s checks that the provided transforms all have the
     same `required_keys`.
@@ -98,7 +98,7 @@ def test_conjunct_required_keys():
         transform1 | transform2 | transform3
 
 
-def test_conjunct_wrong_output_keys():
+def test_conjunct_checks_output_keys():
     """
     Tests that the conjunction of ``Transform``s checks that the transforms `output_keys` are
     disjoint.
@@ -120,7 +120,7 @@ def test_conjunct_wrong_output_keys():
         transform1 | transform2 | transform3
 
 
-def test_conjunction_empty_transforms():
+def test_empty_conjunction():
     """
     Tests that it is possible to take the conjunction of no transform. This should return an empty
     dictionary.

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -43,20 +43,20 @@ def test_call_checks_keys():
     contains keys that correspond exactly to `required_keys`.
     """
 
-    t1 = torch.randn([2], device=DEVICE)
-    t2 = torch.randn([3], device=DEVICE)
-    transform = FakeTransform(required_keys={t1}, output_keys={t1, t2})
+    a1 = torch.randn([2], device=DEVICE)
+    a2 = torch.randn([3], device=DEVICE)
+    t = FakeTransform(required_keys={a1}, output_keys={a1, a2})
 
-    transform(TensorDict({t1: t2}))
-
-    with raises(ValueError):
-        transform(TensorDict({t2: t1}))
+    t(TensorDict({a1: a2}))
 
     with raises(ValueError):
-        transform(TensorDict({}))
+        t(TensorDict({a2: a1}))
 
     with raises(ValueError):
-        transform(TensorDict({t1: t2, t2: t1}))
+        t(TensorDict({}))
+
+    with raises(ValueError):
+        t(TensorDict({a1: a2, a2: a1}))
 
 
 def test_compose_checks_keys():
@@ -65,15 +65,15 @@ def test_compose_checks_keys():
     match with the outer transform's `required_keys`.
     """
 
-    t1 = torch.randn([2], device=DEVICE)
-    t2 = torch.randn([3], device=DEVICE)
-    transform1 = FakeTransform(required_keys={t1}, output_keys={t1, t2})
-    transform2 = FakeTransform(required_keys={t2}, output_keys={t1})
+    a1 = torch.randn([2], device=DEVICE)
+    a2 = torch.randn([3], device=DEVICE)
+    t1 = FakeTransform(required_keys={a1}, output_keys={a1, a2})
+    t2 = FakeTransform(required_keys={a2}, output_keys={a1})
 
-    transform1 << transform2
+    t1 << t2
 
     with raises(ValueError):
-        transform2 << transform1
+        t2 << t1
 
 
 def test_conjunct_checks_required_keys():
@@ -82,20 +82,20 @@ def test_conjunct_checks_required_keys():
     same `required_keys`.
     """
 
-    t1 = torch.randn([2], device=DEVICE)
-    t2 = torch.randn([3], device=DEVICE)
+    a1 = torch.randn([2], device=DEVICE)
+    a2 = torch.randn([3], device=DEVICE)
 
-    transform1 = FakeTransform(required_keys={t1}, output_keys=set())
-    transform2 = FakeTransform(required_keys={t1}, output_keys=set())
-    transform3 = FakeTransform(required_keys={t2}, output_keys=set())
+    t1 = FakeTransform(required_keys={a1}, output_keys=set())
+    t2 = FakeTransform(required_keys={a1}, output_keys=set())
+    t3 = FakeTransform(required_keys={a2}, output_keys=set())
 
-    transform1 | transform2
-
-    with raises(ValueError):
-        transform2 | transform3
+    t1 | t2
 
     with raises(ValueError):
-        transform1 | transform2 | transform3
+        t2 | t3
+
+    with raises(ValueError):
+        t1 | t2 | t3
 
 
 def test_conjunct_checks_output_keys():
@@ -104,20 +104,20 @@ def test_conjunct_checks_output_keys():
     disjoint.
     """
 
-    t1 = torch.randn([2], device=DEVICE)
-    t2 = torch.randn([3], device=DEVICE)
+    a1 = torch.randn([2], device=DEVICE)
+    a2 = torch.randn([3], device=DEVICE)
 
-    transform1 = FakeTransform(required_keys=set(), output_keys={t1, t2})
-    transform2 = FakeTransform(required_keys=set(), output_keys={t1})
-    transform3 = FakeTransform(required_keys=set(), output_keys={t2})
+    t1 = FakeTransform(required_keys=set(), output_keys={a1, a2})
+    t2 = FakeTransform(required_keys=set(), output_keys={a1})
+    t3 = FakeTransform(required_keys=set(), output_keys={a2})
 
-    transform2 | transform3
-
-    with raises(ValueError):
-        transform1 | transform3
+    t2 | t3
 
     with raises(ValueError):
-        transform1 | transform2 | transform3
+        t1 | t3
+
+    with raises(ValueError):
+        t1 | t2 | t3
 
 
 def test_empty_conjunction():

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -23,8 +23,8 @@ class FakeTransform(Transform[_B, _C]):
         return "T"
 
     def _compute(self, input: _B) -> _C:
-        # ignore the input, create a dictionary with the right keys as an output.
-        # cast the type for the purpose of type-checking.
+        # Ignore the input, create a dictionary with the right keys as an output.
+        # Cast the type for the purpose of type-checking.
         output_dict = {key: torch.empty(0, device=DEVICE) for key in self._output_keys}
         return typing.cast(_C, output_dict)
 
@@ -39,7 +39,7 @@ class FakeTransform(Transform[_B, _C]):
 
 def test_apply_keys():
     """
-    Tests that a ``Transform`` checks that the provided dictionary to the `__apply__` function
+    Tests that a ``Transform`` checks that the provided dictionary to the `__call__` function
     contains keys that correspond exactly to `required_keys`.
     """
 

--- a/tests/unit/autojac/_transform/test_diagonalize.py
+++ b/tests/unit/autojac/_transform/test_diagonalize.py
@@ -6,7 +6,7 @@ from torchjd.autojac._transform import Diagonalize, Gradients
 from ._dict_assertions import assert_tensor_dicts_are_close
 
 
-def test_diagonalize_single_input():
+def test_single_input():
     """Tests that the Diagonalize transform works when given a single input."""
 
     key = torch.tensor([1.0, 2.0, 3.0], device=DEVICE)
@@ -23,7 +23,7 @@ def test_diagonalize_single_input():
     assert_tensor_dicts_are_close(output, expected_output)
 
 
-def test_diagonalize_multiple_inputs():
+def test_multiple_inputs():
     """Tests that the Diagonalize transform works when given multiple inputs."""
 
     key1 = torch.tensor([[1.0, 2.0], [4.0, 5.0]], device=DEVICE)
@@ -82,7 +82,7 @@ def test_diagonalize_multiple_inputs():
     assert_tensor_dicts_are_close(output, expected_output)
 
 
-def test_diagonalize_permute_order():
+def test_permute_order():
     """
     Tests that the Diagonalize transform outputs a permuted mapping when its keys are permuted.
     """

--- a/tests/unit/autojac/_transform/test_grad.py
+++ b/tests/unit/autojac/_transform/test_grad.py
@@ -238,9 +238,7 @@ def test_conjunction_of_grads_is_grad():
     x2 = torch.tensor(6.0, device=DEVICE)
     a1 = torch.tensor(2.0, requires_grad=True, device=DEVICE)
     a2 = torch.tensor(3.0, requires_grad=True, device=DEVICE)
-    y1 = a1 * x1
-    y2 = a2 * x2
-    y = torch.stack([y1, y2])
+    y = torch.stack([a1 * x1, a2 * x2])
     input = Gradients({y: torch.ones_like(y)})
 
     grad1 = Grad(outputs=[y], inputs=[a1], retain_graph=True)

--- a/tests/unit/autojac/_transform/test_grad.py
+++ b/tests/unit/autojac/_transform/test_grad.py
@@ -85,7 +85,7 @@ def test_retain_graph():
 
 def test_single_input_two_levels():
     """
-    Tests that the Grad transform works correctly for a very simple example of differentiation.
+    Tests that the Grad transform works correctly when composed with another Grad transform.
     Here, the function considered is: `z = a * x1 * x2`, which is computed in 2 parts: `y = a * x1`
     and `z = y * x2`. We want to compute the derivative of `z` with respect to the parameter `a`, by
     using chain rule. This derivative should be equal to `x1 * x2`.

--- a/tests/unit/autojac/_transform/test_grad.py
+++ b/tests/unit/autojac/_transform/test_grad.py
@@ -256,10 +256,10 @@ def test_create_graph():
     """Tests that the Grad transform behaves correctly when `create_graph` is set to `True`."""
 
     a = torch.tensor(2.0, requires_grad=True, device=DEVICE)
-    b = a * a
-    input = Gradients({b: torch.ones_like(b)})
+    y = a * a
+    input = Gradients({y: torch.ones_like(y)})
 
-    grad = Grad(outputs=[b], inputs=[a], create_graph=True)
+    grad = Grad(outputs=[y], inputs=[a], create_graph=True)
 
     gradients = grad(input)
 

--- a/tests/unit/autojac/_transform/test_init.py
+++ b/tests/unit/autojac/_transform/test_init.py
@@ -6,7 +6,7 @@ from torchjd.autojac._transform import EmptyTensorDict, Init
 from ._dict_assertions import assert_tensor_dicts_are_close
 
 
-def test_init_single_input():
+def test_single_input():
     """
     Tests that when there is a single key to initialize, the Init transform creates a TensorDict
     whose value is a tensor full of ones, of the same shape as its key.
@@ -23,7 +23,7 @@ def test_init_single_input():
     assert_tensor_dicts_are_close(output, expected_output)
 
 
-def test_init_multiple_input():
+def test_multiple_inputs():
     """
     Tests that when there are several keys to initialize, the Init transform creates a TensorDict
     whose values are tensors full of ones, of the same shape as their corresponding keys.

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -66,7 +66,7 @@ def test_single_differentiation():
     assert_tensor_dicts_are_close(output, expected_output)
 
 
-def test_multiple_differentiation_with_grad():
+def test_multiple_differentiations():
     """
     Tests that we can perform multiple scalar differentiations with the conjunction of multiple Grad
     transforms, composed with an Init transform.
@@ -200,7 +200,7 @@ def test_conjunction_accumulate_select():
     assert_tensor_dicts_are_close(output, expected_output)
 
 
-def test_equivalence_jac_grad():
+def test_equivalence_jac_grads():
     """
     Tests that differentiation in parallel using `_jac` is equivalent to sequential differentiation
     using several calls to `_grad` and stacking the resulting gradients.

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -182,7 +182,8 @@ def test_conjunction_accumulate_select():
     """
     Tests that it is possible to conjunct an Accumulate and a Select in this order.
     It is not trivial since the type of the TensorDict returned by the first transform (Accumulate)
-    is EmptyDict, which is not the type that the conjunction should return (Gradients).
+    is EmptyDict, which is not the type that the conjunction should return (Gradients), but a
+    subclass of it.
     """
 
     key = torch.tensor([1.0, 2.0, 3.0], requires_grad=True, device=DEVICE)

--- a/tests/unit/autojac/_transform/test_jac.py
+++ b/tests/unit/autojac/_transform/test_jac.py
@@ -195,7 +195,6 @@ def test_composition_of_jacs_is_jac():
     x1 = torch.tensor(5.0, device=DEVICE)
     x2 = torch.tensor(6.0, device=DEVICE)
     a = torch.tensor(2.0, requires_grad=True, device=DEVICE)
-    b = torch.tensor(1.0, requires_grad=True, device=DEVICE)
     y1 = a * x1
     y2 = a * x2
     z1 = y1 + x2
@@ -204,10 +203,10 @@ def test_composition_of_jacs_is_jac():
         {z1: torch.tensor([1.0, 0.0], device=DEVICE), z2: torch.tensor([0.0, 1.0], device=DEVICE)}
     )
 
-    outer_jac = Jac(outputs=[y1, y2], inputs=[a, b], chunk_size=None, retain_graph=True)
+    outer_jac = Jac(outputs=[y1, y2], inputs=[a], chunk_size=None, retain_graph=True)
     inner_jac = Jac(outputs=[z1, z2], inputs=[y1, y2], chunk_size=None, retain_graph=True)
     composed_jac = outer_jac << inner_jac
-    jac = Jac(outputs=[z1, z2], inputs=[a, b], chunk_size=None)
+    jac = Jac(outputs=[z1, z2], inputs=[a], chunk_size=None)
 
     jacobians = composed_jac(input)
     expected_jacobians = jac(input)

--- a/tests/unit/autojac/_transform/test_jac.py
+++ b/tests/unit/autojac/_transform/test_jac.py
@@ -55,10 +55,10 @@ def test_empty_inputs_2():
     """
 
     x = torch.tensor(5.0, device=DEVICE)
-    a = torch.tensor(1.0, requires_grad=True, device=DEVICE)
-    b = torch.tensor(1.0, requires_grad=True, device=DEVICE)
-    y1 = a * x
-    y2 = b * x
+    a1 = torch.tensor(1.0, requires_grad=True, device=DEVICE)
+    a2 = torch.tensor(1.0, requires_grad=True, device=DEVICE)
+    y1 = a1 * x
+    y2 = a2 * x
     y = torch.stack([y1, y2])
     input = Jacobians({y: torch.eye(2, device=DEVICE)})
 
@@ -103,18 +103,18 @@ def test_two_levels():
 
     x1 = torch.tensor(5.0, device=DEVICE)
     x2 = torch.tensor(6.0, device=DEVICE)
-    a = torch.tensor(2.0, requires_grad=True, device=DEVICE)
-    b = torch.tensor(3.0, requires_grad=True, device=DEVICE)
-    y1 = a * x1
-    y2 = b * x1
+    a1 = torch.tensor(2.0, requires_grad=True, device=DEVICE)
+    a2 = torch.tensor(3.0, requires_grad=True, device=DEVICE)
+    y1 = a1 * x1
+    y2 = a2 * x1
     y = torch.stack([y1, y2])
     z = y * x2
     input = Jacobians({z: torch.eye(2, device=DEVICE)})
 
-    outer_jac = Jac(outputs=[y], inputs=[a, b], chunk_size=None, retain_graph=True)
+    outer_jac = Jac(outputs=[y], inputs=[a1, a2], chunk_size=None, retain_graph=True)
     inner_jac = Jac(outputs=[z], inputs=[y], chunk_size=None, retain_graph=True)
     composed_jac = outer_jac << inner_jac
-    jac = Jac(outputs=[z], inputs=[a, b], chunk_size=None)
+    jac = Jac(outputs=[z], inputs=[a1, a2], chunk_size=None)
 
     jacobians = composed_jac(input)
     expected_jacobians = jac(input)

--- a/tests/unit/autojac/_transform/test_jac.py
+++ b/tests/unit/autojac/_transform/test_jac.py
@@ -17,9 +17,7 @@ def test_single_input():
     x = torch.tensor(5.0, device=DEVICE)
     a1 = torch.tensor(2.0, requires_grad=True, device=DEVICE)
     a2 = torch.tensor(3.0, requires_grad=True, device=DEVICE)
-    y1 = a1 * x
-    y2 = a2 * x
-    y = torch.stack([y1, y2])
+    y = torch.stack([a1 * x, a2 * x])
     input = Jacobians({y: torch.eye(2, device=DEVICE)})
 
     jac = Jac(outputs=[y], inputs=[a1, a2], chunk_size=None)

--- a/tests/unit/autojac/_transform/test_jac.py
+++ b/tests/unit/autojac/_transform/test_jac.py
@@ -10,9 +10,8 @@ from ._dict_assertions import assert_tensor_dicts_are_close
 def test_single_input():
     """
     Tests that the Jac transform works correctly for an example of multiple differentiation. Here,
-    the functions considered are: `y1 = a1 * x` and `y2 = a2 * x`. We want to compute the jacobians
-    of `[y1, y2]` with respect to the parameters `a1` and `a2`. These jacobians should be equal to
-    [x, 0] and [0, x], respectively.
+    the function considered is: `y = [a1 * x, a2 * x]`. We want to compute the jacobians of `y` with
+    respect to `a1` and `a2`.
     """
 
     x = torch.tensor(5.0, device=DEVICE)

--- a/tests/unit/autojac/_transform/test_select.py
+++ b/tests/unit/autojac/_transform/test_select.py
@@ -8,8 +8,8 @@ from ._dict_assertions import assert_tensor_dicts_are_close
 
 def test_select_partition():
     """
-    Tests that the Select transform works correctly by applying 2 different Selects to a
-    TensorDict, whose keys form a partition of the keys of the TensorDict.
+    Tests that the Select transform works correctly by applying 2 different Selects to a TensorDict,
+    whose keys form a partition of the keys of the TensorDict.
     """
 
     key1 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device=DEVICE)

--- a/tests/unit/autojac/_transform/test_select.py
+++ b/tests/unit/autojac/_transform/test_select.py
@@ -6,7 +6,7 @@ from torchjd.autojac._transform import Select, TensorDict
 from ._dict_assertions import assert_tensor_dicts_are_close
 
 
-def test_select_partition():
+def test_partition():
     """
     Tests that the Select transform works correctly by applying 2 different Selects to a TensorDict,
     whose keys form a partition of the keys of the TensorDict.

--- a/tests/unit/autojac/_transform/test_stack.py
+++ b/tests/unit/autojac/_transform/test_stack.py
@@ -30,7 +30,7 @@ class FakeGradientsTransform(Transform[EmptyTensorDict, Gradients]):
         return self.keys
 
 
-def test_stack_single_key():
+def test_single_key():
     """
     Tests that the Stack transform correctly stacks gradients into a jacobian, in a very simple
     example with 2 transforms sharing the same key.
@@ -48,7 +48,7 @@ def test_stack_single_key():
     assert_tensor_dicts_are_close(output, expected_output)
 
 
-def test_stack_disjoint_key_sets():
+def test_disjoint_key_sets():
     """
     Tests that the Stack transform correctly stacks gradients into a jacobian, in an example where
     the output key sets of all of its transforms are disjoint. The missing values should be replaced
@@ -72,7 +72,7 @@ def test_stack_disjoint_key_sets():
     assert_tensor_dicts_are_close(output, expected_output)
 
 
-def test_stack_overlapping_key_sets():
+def test_overlapping_key_sets():
     """
     Tests that the Stack transform correctly stacks gradients into a jacobian, in an example where
     the output key sets all of its transforms are overlapping (non-empty intersection, but not
@@ -98,7 +98,7 @@ def test_stack_overlapping_key_sets():
     assert_tensor_dicts_are_close(output, expected_output)
 
 
-def test_stack_no_transform():
+def test_empty():
     """Tests that the Stack transform correctly handles an empty list of transforms."""
 
     stack = Stack([])

--- a/tests/unit/autojac/_transform/test_stack.py
+++ b/tests/unit/autojac/_transform/test_stack.py
@@ -11,8 +11,8 @@ from ._dict_assertions import assert_tensor_dicts_are_close
 
 class FakeGradientsTransform(Transform[EmptyTensorDict, Gradients]):
     """
-    Transform that produces gradients filled with ones, for testing purposes.
-    Note that it does the same thing as Init, but it does not depend on Init.
+    Transform that produces gradients filled with ones, for testing purposes. Note that it does the
+    same thing as Init, but it does not depend on Init.
     """
 
     def __init__(self, keys: Iterable[Tensor]):

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -170,8 +170,8 @@ def test_backward_non_positive_chunk_size(chunk_size: int):
 )
 def test_backward_no_retain_graph_small_chunk_size(chunk_size: int, expectation: ExceptionContext):
     """
-    Tests that backward raises an error when using retain_graph=False and a chunk size that is not
-    large enough to allow differentiation of all tensors at once.
+    Tests that when using retain_graph=False, backward only works if the chunk size is large enough
+    to allow differentiation of all tensors at once.
     """
 
     aggregator = UPGrad()

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -177,13 +177,13 @@ def test_input_retaining_grad_fails():
     parameter retains grad.
     """
 
-    a1 = torch.tensor(1.0, requires_grad=True, device=DEVICE)
-    a2 = 2 * a1
-    a2.retain_grad()
-    y = 3 * a2
+    a = torch.tensor(1.0, requires_grad=True, device=DEVICE)
+    b = 2 * a
+    b.retain_grad()
+    y = 3 * b
 
     with raises(RuntimeError):
-        backward(tensors=y, aggregator=UPGrad(), inputs=[a2])
+        backward(tensors=y, aggregator=UPGrad(), inputs=[b])
 
 
 def test_non_input_retaining_grad_fails():
@@ -192,14 +192,14 @@ def test_non_input_retaining_grad_fails():
     the ``tensors`` parameter retains grad.
     """
 
-    a1 = torch.tensor(1.0, requires_grad=True, device=DEVICE)
-    a2 = 2 * a1
-    a2.retain_grad()
-    y = 3 * a2
+    a = torch.tensor(1.0, requires_grad=True, device=DEVICE)
+    b = 2 * a
+    b.retain_grad()
+    y = 3 * b
 
     # backward itself doesn't raise the error, but it fills b.grad with a BatchedTensor
-    backward(tensors=y, aggregator=UPGrad(), inputs=[a1])
+    backward(tensors=y, aggregator=UPGrad(), inputs=[a])
 
     with raises(RuntimeError):
         # Using such a BatchedTensor should result in an error
-        _ = -a2.grad
+        _ = -b.grad

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -11,7 +11,7 @@ from torchjd.aggregation import MGDA, Aggregator, Mean, Random, UPGrad
 
 
 @mark.parametrize("aggregator", [Mean(), UPGrad(), MGDA(), Random()])
-def test_backward_various_aggregators(aggregator: Aggregator):
+def test_various_aggregators(aggregator: Aggregator):
     """Tests that backward works for various aggregators."""
 
     p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
@@ -30,7 +30,7 @@ def test_backward_various_aggregators(aggregator: Aggregator):
 @mark.parametrize("aggregator", [Mean(), UPGrad(), MGDA()])
 @mark.parametrize("shape", [(2, 3), (2, 6), (5, 8), (60, 55), (120, 143)])
 @mark.parametrize("manually_specify_inputs", [True, False])
-def test_backward_value_is_correct(
+def test_value_is_correct(
     aggregator: Aggregator, shape: tuple[int, int], manually_specify_inputs: bool
 ):
     """
@@ -52,7 +52,7 @@ def test_backward_value_is_correct(
     assert_close(input.grad, aggregator(J))
 
 
-def test_backward_empty_inputs():
+def test_empty_inputs():
     """Tests that backward does not fill the .grad values if no input is specified."""
 
     aggregator = Mean()
@@ -70,7 +70,7 @@ def test_backward_empty_inputs():
         assert p.grad is None
 
 
-def test_backward_partial_inputs():
+def test_partial_inputs():
     """
     Tests that backward fills the right .grad values when only a subset of the parameters are
     specified as inputs.
@@ -90,7 +90,7 @@ def test_backward_partial_inputs():
     assert p2.grad is None
 
 
-def test_backward_empty_tensors():
+def test_empty_tensors_fails():
     """Tests that backward raises an error when called with an empty list of tensors."""
 
     aggregator = UPGrad()
@@ -102,7 +102,7 @@ def test_backward_empty_tensors():
         backward([], aggregator, inputs=[p1, p2])
 
 
-def test_backward_multiple_tensors():
+def test_multiple_tensors():
     """
     Tests that giving multiple tensors to backward is equivalent to giving a single tensor
     containing the all the values of the original tensors.
@@ -130,7 +130,7 @@ def test_backward_multiple_tensors():
 
 
 @mark.parametrize("chunk_size", [None, 1, 2, 4])
-def test_backward_valid_chunk_size(chunk_size):
+def test_various_valid_chunk_sizes(chunk_size):
     """Tests that backward works for various valid values of parallel_chunk_size."""
 
     aggregator = UPGrad()
@@ -149,7 +149,7 @@ def test_backward_valid_chunk_size(chunk_size):
 
 
 @mark.parametrize("chunk_size", [0, -1])
-def test_backward_non_positive_chunk_size(chunk_size: int):
+def test_non_positive_chunk_size_fails(chunk_size: int):
     """Tests that backward raises an error when using invalid chunk sizes."""
 
     aggregator = UPGrad()
@@ -168,7 +168,7 @@ def test_backward_non_positive_chunk_size(chunk_size: int):
     ["chunk_size", "expectation"],
     [(1, raises(ValueError)), (2, does_not_raise()), (None, does_not_raise())],
 )
-def test_backward_no_retain_graph_small_chunk_size(chunk_size: int, expectation: ExceptionContext):
+def test_no_retain_graph_various_chunk_sizes(chunk_size: int, expectation: ExceptionContext):
     """
     Tests that when using retain_graph=False, backward only works if the chunk size is large enough
     to allow differentiation of all tensors at once.
@@ -186,7 +186,7 @@ def test_backward_no_retain_graph_small_chunk_size(chunk_size: int, expectation:
         backward([y1, y2], aggregator, retain_graph=False, parallel_chunk_size=chunk_size)
 
 
-def test_backward_fails_with_input_retaining_grad():
+def test_input_retaining_grad_fails():
     """
     Tests that backward raises an error when some input in the computation graph of the ``tensors``
     parameter retains grad.
@@ -201,7 +201,7 @@ def test_backward_fails_with_input_retaining_grad():
         backward(tensors=c, aggregator=UPGrad(), inputs=[b])
 
 
-def test_backward_fails_with_non_input_retaining_grad():
+def test_non_input_retaining_grad_fails():
     """
     Tests that backward fails to fill a valid `.grad` when some tensor in the computation graph of
     the ``tensors`` parameter retains grad.

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -18,12 +18,12 @@ def test_various_aggregators(aggregator: Aggregator):
     p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
     p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    r1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
-    r2 = (p0**2).sum() + p0.norm()
-    y1 = r1 * p1[0] + r2 * p1[1]
-    y2 = r1 * p2[0] + r2 * p2[1]
+    f1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f2 = (p0**2).sum() + p0.norm()
+    y1 = f1 * p1[0] + f2 * p1[1]
+    y2 = f1 * p2[0] + f2 * p2[1]
 
-    mtl_backward(losses=[y1, y2], features=[r1, r2], aggregator=aggregator)
+    mtl_backward(losses=[y1, y2], features=[f1, f2], aggregator=aggregator)
 
     for p in [p0, p1, p2]:
         assert (p.grad is not None) and (p.shape == p.grad.shape)
@@ -41,8 +41,8 @@ def test_value_is_correct(
 ):
     """
     Tests that the .grad value filled by mtl_backward is correct in a simple example of
-    matrix-vector product for shared representation and three tasks whose loss are given by a simple
-    inner product of the shared representation with the task parameter.
+    matrix-vector product for three tasks whose loss are given by a simple inner product of the
+    shared representation with the task parameter.
 
     This test should work with or without manually specifying the parameters.
     """

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -403,8 +403,8 @@ def test_mtl_backward_no_retain_graph_small_chunk_size(
     chunk_size: int, expectation: ExceptionContext
 ):
     """
-    Tests that mtl_backward raises an error when using retain_graph=False and a chunk size that is
-    not large enough to allow differentiation of all tensors at once.
+    Tests that when using retain_graph=False, mtl_backward only works if the chunk size is large
+    enough to allow differentiation of all tensors at once.
     """
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
@@ -526,7 +526,7 @@ def test_mtl_backward_task_params_are_the_same():
 
 def test_mtl_backward_task_params_are_subset_of_other_task_params():
     """
-    Tests that mtl_backward works correctly when one task's params are a subset of another task's
+    Tests that mtl_backward works correctly when one task's params is a subset of another task's
     params.
     """
 

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -11,7 +11,7 @@ from torchjd.aggregation import MGDA, Aggregator, Mean, Random, UPGrad
 
 
 @mark.parametrize("aggregator", [Mean(), UPGrad(), MGDA(), Random()])
-def test_mtl_backward_various_aggregators(aggregator: Aggregator):
+def test_various_aggregators(aggregator: Aggregator):
     """Tests that mtl_backward works for various aggregators."""
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
@@ -33,7 +33,7 @@ def test_mtl_backward_various_aggregators(aggregator: Aggregator):
 @mark.parametrize("shape", [(2, 3), (2, 6), (5, 8), (60, 55), (120, 143)])
 @mark.parametrize("manually_specify_shared_params", [True, False])
 @mark.parametrize("manually_specify_tasks_params", [True, False])
-def test_mtl_backward_value_is_correct(
+def test_value_is_correct(
     aggregator: Aggregator,
     shape: tuple[int, int],
     manually_specify_shared_params: bool,
@@ -86,7 +86,7 @@ def test_mtl_backward_value_is_correct(
     assert_close(p0.grad, expected_aggregation)
 
 
-def test_mtl_backward_empty_tasks():
+def test_empty_tasks_fails():
     """Tests that mtl_backward raises an error when called with an empty list of tasks."""
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
@@ -98,7 +98,7 @@ def test_mtl_backward_empty_tasks():
         mtl_backward(losses=[], features=[r1, r2], aggregator=UPGrad())
 
 
-def test_mtl_backward_single_task():
+def test_single_task():
     """Tests that mtl_backward works correctly with a single task."""
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
@@ -114,7 +114,7 @@ def test_mtl_backward_single_task():
         assert (p.grad is not None) and (p.shape == p.grad.shape)
 
 
-def test_mtl_backward_incoherent_task_number():
+def test_incoherent_task_number_fails():
     """
     Tests that mtl_backward raises an error when called with the number of tasks losses different
     from the number of tasks parameters.
@@ -147,7 +147,7 @@ def test_mtl_backward_incoherent_task_number():
         )
 
 
-def test_mtl_backward_empty_params():
+def test_empty_params():
     """Tests that mtl_backward does not fill the .grad values if no parameter is specified."""
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
@@ -171,7 +171,7 @@ def test_mtl_backward_empty_params():
         assert p.grad is None
 
 
-def test_mtl_backward_multiple_params_per_task():
+def test_multiple_params_per_task():
     """Tests that mtl_backward works correctly when the tasks each have several parameters."""
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
@@ -205,7 +205,7 @@ def test_mtl_backward_multiple_params_per_task():
         [(5, 4, 3, 2), (5, 4, 3, 2)],
     ],
 )
-def test_mtl_backward_various_shared_params(shared_params_shapes: list[tuple[int]]):
+def test_various_shared_params(shared_params_shapes: list[tuple[int]]):
     """Tests that mtl_backward works correctly with various kinds of shared_params."""
 
     shared_params = [
@@ -230,7 +230,7 @@ def test_mtl_backward_various_shared_params(shared_params_shapes: list[tuple[int
         assert (p.grad is not None) and (p.shape == p.grad.shape)
 
 
-def test_mtl_backward_partial_params():
+def test_partial_params():
     """
     Tests that mtl_backward fills the right .grad values when only a subset of the parameters are
     specified as inputs.
@@ -258,7 +258,7 @@ def test_mtl_backward_partial_params():
     assert p2.grad is None
 
 
-def test_mtl_backward_empty_features():
+def test_empty_features_fails():
     """Tests that mtl_backward expectedly raises an error when no there is no feature."""
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
@@ -283,7 +283,7 @@ def test_mtl_backward_empty_features():
         (5, 4, 3, 2),
     ],
 )
-def test_mtl_backward_various_single_features(shape: tuple[int, ...]):
+def test_various_single_features(shape: tuple[int, ...]):
     """Tests that mtl_backward works correctly with various kinds of feature tensors."""
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
@@ -314,7 +314,7 @@ def test_mtl_backward_various_single_features(shape: tuple[int, ...]):
         [(5, 4, 3, 2), (5, 4, 3, 2)],
     ],
 )
-def test_mtl_backward_various_feature_lists(shapes: list[tuple[int]]):
+def test_various_feature_lists(shapes: list[tuple[int]]):
     """Tests that mtl_backward works correctly with various kinds of feature lists."""
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
@@ -332,7 +332,7 @@ def test_mtl_backward_various_feature_lists(shapes: list[tuple[int]]):
         assert (p.grad is not None) and (p.shape == p.grad.shape)
 
 
-def test_mtl_backward_non_scalar_loss():
+def test_non_scalar_loss_fails():
     """Tests that mtl_backward raises an error when used with a non-scalar loss."""
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
@@ -349,7 +349,7 @@ def test_mtl_backward_non_scalar_loss():
 
 
 @mark.parametrize("chunk_size", [None, 1, 2, 4])
-def test_mtl_backward_valid_chunk_size(chunk_size):
+def test_various_valid_chunk_sizes(chunk_size):
     """Tests that mtl_backward works for various valid values of parallel_chunk_size."""
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
@@ -374,7 +374,7 @@ def test_mtl_backward_valid_chunk_size(chunk_size):
 
 
 @mark.parametrize("chunk_size", [0, -1])
-def test_mtl_backward_non_positive_chunk_size(chunk_size: int):
+def test_non_positive_chunk_size_fails(chunk_size: int):
     """Tests that mtl_backward raises an error when using invalid chunk sizes."""
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
@@ -399,9 +399,7 @@ def test_mtl_backward_non_positive_chunk_size(chunk_size: int):
     ["chunk_size", "expectation"],
     [(1, raises(ValueError)), (2, does_not_raise()), (None, does_not_raise())],
 )
-def test_mtl_backward_no_retain_graph_small_chunk_size(
-    chunk_size: int, expectation: ExceptionContext
-):
+def test_no_retain_graph_various_chunk_sizes(chunk_size: int, expectation: ExceptionContext):
     """
     Tests that when using retain_graph=False, mtl_backward only works if the chunk size is large
     enough to allow differentiation of all tensors at once.
@@ -426,7 +424,7 @@ def test_mtl_backward_no_retain_graph_small_chunk_size(
         )
 
 
-def test_mtl_backward_fails_with_shared_param_retaining_grad():
+def test_shared_param_retaining_grad_fails():
     """
     Tests that mtl_backward raises an error when some shared param in the computation graph of the
     ``features`` parameter retains grad.
@@ -452,7 +450,7 @@ def test_mtl_backward_fails_with_shared_param_retaining_grad():
         )
 
 
-def test_mtl_backward_fails_with_shared_activation_retaining_grad():
+def test_shared_activation_retaining_grad_fails():
     """
     Tests that mtl_backward fails to fill a valid `.grad` when some tensor in the computation graph
     of the ``features`` parameter retains grad.
@@ -482,7 +480,7 @@ def test_mtl_backward_fails_with_shared_activation_retaining_grad():
         _ = -a.grad
 
 
-def test_mtl_backward_task_params_have_some_overlap():
+def test_tasks_params_overlap():
     """Tests that mtl_backward works correctly when the tasks' parameters have some overlap."""
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
@@ -505,7 +503,7 @@ def test_mtl_backward_task_params_have_some_overlap():
     assert_close(p0.grad, aggregator(J))
 
 
-def test_mtl_backward_task_params_are_the_same():
+def test_tasks_params_are_the_same():
     """Tests that mtl_backward works correctly when the tasks have the same params."""
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
@@ -524,7 +522,7 @@ def test_mtl_backward_task_params_are_the_same():
     assert_close(p0.grad, aggregator(J))
 
 
-def test_mtl_backward_task_params_are_subset_of_other_task_params():
+def test_task_params_is_subset_of_other_task_params():
     """
     Tests that mtl_backward works correctly when one task's params is a subset of another task's
     params.
@@ -548,7 +546,7 @@ def test_mtl_backward_task_params_are_subset_of_other_task_params():
     assert_close(p0.grad, aggregator(J))
 
 
-def test_mtl_backward_shared_params_overlap_with_tasks_params():
+def test_shared_params_overlapping_with_tasks_params_fails():
     """
     Tests that mtl_backward raises an error when the set of shared params overlaps with the set of
     task-specific params.
@@ -573,7 +571,7 @@ def test_mtl_backward_shared_params_overlap_with_tasks_params():
         )
 
 
-def test_mtl_backward_default_shared_params_overlap_with_default_tasks_params():
+def test_default_shared_params_overlapping_with_default_tasks_params_fails():
     """
     Tests that mtl_backward raises an error when the set of shared params obtained by default
     overlaps with the set of task-specific params obtained by default.

--- a/tests/unit/autojac/test_utils.py
+++ b/tests/unit/autojac/test_utils.py
@@ -9,56 +9,56 @@ from torchjd.autojac._utils import _get_leaf_tensors
 def test_simple_get_leaf_tensors():
     """Tests that _get_leaf_tensors works correctly in a very simple setting."""
 
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p1 + p2.sum()
-    y2 = (p1**2).sum() + p2.norm()
+    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ a1 + a2.sum()
+    y2 = (a1**2).sum() + a2.norm()
 
     leaves = _get_leaf_tensors(tensors=[y1, y2], excluded=set())
-    assert leaves == {p1, p2}
+    assert leaves == {a1, a2}
 
 
 def test_get_leaf_tensors_excluded_1():
     """
     Tests that _get_leaf_tensors works correctly when some tensors are excluded from the search.
 
-    Note that `p2` itself is not in `excluded`, but it is not accessible from `y1` or `y2` when `x2`
+    Note that `a2` itself is not in `excluded`, but it is not accessible from `y1` or `y2` when `b2`
     is excluded from the graph traversal.
     """
 
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    x1 = (p1**2).sum()
-    x2 = (p2**2).sum()
+    b1 = (a1**2).sum()
+    b2 = (a2**2).sum()
 
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p1 + x2
-    y2 = x1
+    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ a1 + b2
+    y2 = b1
 
-    leaves = _get_leaf_tensors(tensors=[y1, y2], excluded={x1, x2})
-    assert leaves == {p1}
+    leaves = _get_leaf_tensors(tensors=[y1, y2], excluded={b1, b2})
+    assert leaves == {a1}
 
 
 def test_get_leaf_tensors_excluded_2():
     """
     Tests that _get_leaf_tensors works correctly when some tensors are excluded from the search.
 
-    Even though `x1` and `x2`, that have `p1` and `p2` as descendants, are excluded, `y1` depends on
-    `p1` and `p2` from another path, so these two tensors should be in the result.
+    Even though `b1` and `b2`, that have `a1` and `a2` as descendants, are excluded, `y1` depends on
+    `a1` and `a2` from another path, so these two tensors should be in the result.
     """
 
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    x1 = (p1**2).sum()
-    x2 = (p2**2).sum()
+    b1 = (a1**2).sum()
+    b2 = (a2**2).sum()
 
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p1 + p2.sum()
-    y2 = x1
+    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ a1 + a2.sum()
+    y2 = b1
 
-    leaves = _get_leaf_tensors(tensors=[y1, y2], excluded={x1, x2})
-    assert leaves == {p1, p2}
+    leaves = _get_leaf_tensors(tensors=[y1, y2], excluded={b1, b2})
+    assert leaves == {a1, a2}
 
 
 def test_get_leaf_tensors_leaf_not_requiring_grad():
@@ -66,14 +66,14 @@ def test_get_leaf_tensors_leaf_not_requiring_grad():
     Tests that _get_leaf_tensors does not include tensors that do not require grad in its results.
     """
 
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=False, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=False, device=DEVICE)
 
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p1 + p2.sum()
-    y2 = (p1**2).sum() + p2.norm()
+    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ a1 + a2.sum()
+    y2 = (a1**2).sum() + a2.norm()
 
     leaves = _get_leaf_tensors(tensors=[y1, y2], excluded=set())
-    assert leaves == {p1}
+    assert leaves == {a1}
 
 
 def test_get_leaf_tensors_model():
@@ -136,14 +136,14 @@ def test_get_leaf_tensors_empty_roots():
 def test_get_leaf_tensors_excluded_root():
     """Tests that _get_leaf_tensors correctly excludes the root."""
 
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
 
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p1 + p2.sum()
-    y2 = (p1**2).sum()
+    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ a1 + a2.sum()
+    y2 = (a1**2).sum()
 
     leaves = _get_leaf_tensors(tensors=[y1, y2], excluded={y1})
-    assert leaves == {p1}
+    assert leaves == {a1}
 
 
 @mark.parametrize("depth", [100, 1000, 10000])


### PR DESCRIPTION
- **Shorten test_aggregate_matrices_empty_dict**
- **Improve comments and docstrings**
- **Uniformize and improve test names**
- **Shorten test_no_leaf_and_no_retains_grad_fails**
- **Pass parameters by name to FakeTransform**
- **Rename tensors to a and transforms to t in test_base.py**
- **Shorten test_conjunction_of_grads_is_grad**
- **Improve clarity of transform construction in test_interactions.py**
- **Simplify docstring of test_single_input**
- **Shorten test_single_input**
- **Remove unused variable b in test_composition_of_jacs_is_jac**
- **Fix docstring of test_value_is_correct**
- **Uniformize variable names in autojac unit tests**
- **Remove assignment to a variable of one-use inputs or aggregator**
