### PR TITLE
Add python 3.13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false  # Ensure matrix jobs keep running even if one fails
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -5,4 +5,4 @@
 :end-before: <!-- end installation -->
 ```
 
-Note that `torchjd` requires python 3.10, 3.11 or 3.12 and `torch>=2.0`.
+Note that `torchjd` requires python 3.10, 3.11, 3.12 or 3.13 and `torch>=2.0`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]


### PR DESCRIPTION
This PR is just a draft to see if torchjd already works with python 3.13, and with which OS.
Requirement:
- [x] https://github.com/pytorch/pytorch/issues/130249


