### PR TITLE
Avoid using `vmap` when `parallel_chunk_size=1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ changes that do not affect the user.
 
 ## [Unreleased]
 
+### Changed
+
+- Changed how the Jacobians are computed when calling `backward` or `mtl_backward` with
+  `parallel_chunk_size=1` to not rely on `torch.autograd.vmap` in this case. Whenever `vmap` does
+  not support something (compiled functions, RNN on cuda, etc.), users should now be able to avoid
+  using `vmap` by calling `backward` or `mtl_backward` with `parallel_chunk_size=1` and
+  `retain_graph=True`.
+
 ## [0.3.1] - 2024-12-21
 
 ### Changed

--- a/tests/unit/autojac/_transform/test_jac.py
+++ b/tests/unit/autojac/_transform/test_jac.py
@@ -1,5 +1,5 @@
 import torch
-from pytest import raises
+from pytest import mark, raises
 from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import Jac, Jacobians
@@ -7,7 +7,8 @@ from torchjd.autojac._transform import Jac, Jacobians
 from ._dict_assertions import assert_tensor_dicts_are_close
 
 
-def test_single_input():
+@mark.parametrize(["chunk_size", "retain_graph"], [(1, True), (3, True), (None, False)])
+def test_single_input(chunk_size: int | None, retain_graph: bool):
     """
     Tests that the Jac transform works correctly for an example of multiple differentiation. Here,
     the function considered is: `y = [a1 * x, a2 * x]`. We want to compute the jacobians of `y` with
@@ -20,7 +21,7 @@ def test_single_input():
     y = torch.stack([a1 * x, a2 * x])
     input = Jacobians({y: torch.eye(2, device=DEVICE)})
 
-    jac = Jac(outputs=[y], inputs=[a1, a2], chunk_size=None)
+    jac = Jac(outputs=[y], inputs=[a1, a2], chunk_size=chunk_size, retain_graph=True)
 
     jacobians = jac(input)
     expected_jacobians = {
@@ -31,7 +32,8 @@ def test_single_input():
     assert_tensor_dicts_are_close(jacobians, expected_jacobians)
 
 
-def test_empty_inputs_1():
+@mark.parametrize(["chunk_size", "retain_graph"], [(1, True), (3, True), (None, False)])
+def test_empty_inputs_1(chunk_size: int | None, retain_graph: bool):
     """
     Tests that the Jac transform works correctly when the `inputs` parameter is an empty `Iterable`.
     """
@@ -41,7 +43,7 @@ def test_empty_inputs_1():
     y = torch.stack([y1, y2])
     input = Jacobians({y: torch.eye(2, device=DEVICE)})
 
-    jac = Jac(outputs=[y], inputs=[], chunk_size=None)
+    jac = Jac(outputs=[y], inputs=[], chunk_size=chunk_size, retain_graph=True)
 
     jacobians = jac(input)
     expected_jacobians = {}
@@ -49,7 +51,8 @@ def test_empty_inputs_1():
     assert_tensor_dicts_are_close(jacobians, expected_jacobians)
 
 
-def test_empty_inputs_2():
+@mark.parametrize(["chunk_size", "retain_graph"], [(1, True), (3, True), (None, False)])
+def test_empty_inputs_2(chunk_size: int | None, retain_graph: bool):
     """
     Tests that the Jac transform works correctly when the `inputs` parameter is an empty `Iterable`.
     """
@@ -62,7 +65,7 @@ def test_empty_inputs_2():
     y = torch.stack([y1, y2])
     input = Jacobians({y: torch.eye(2, device=DEVICE)})
 
-    jac = Jac(outputs=[y], inputs=[], chunk_size=None)
+    jac = Jac(outputs=[y], inputs=[], chunk_size=chunk_size, retain_graph=True)
 
     jacobians = jac(input)
     expected_jacobians = {}
@@ -122,7 +125,8 @@ def test_two_levels():
     assert_tensor_dicts_are_close(jacobians, expected_jacobians)
 
 
-def test_multiple_outputs_1():
+@mark.parametrize(["chunk_size", "retain_graph"], [(1, True), (3, True), (None, False)])
+def test_multiple_outputs_1(chunk_size: int | None, retain_graph: bool):
     """
     Tests that the Jac transform works correctly when the `outputs` contains 3 vectors.
     The input (jac_outputs) is not the same for all outputs, so that this test also checks that the
@@ -143,7 +147,7 @@ def test_multiple_outputs_1():
     jac_output3 = torch.cat([zeros_2x2, zeros_2x2, identity_2x2])
     input = Jacobians({y1: jac_output1, y2: jac_output2, y3: jac_output3})
 
-    jac = Jac(outputs=[y1, y2, y3], inputs=[a1, a2], chunk_size=None)
+    jac = Jac(outputs=[y1, y2, y3], inputs=[a1, a2], chunk_size=chunk_size, retain_graph=True)
 
     jacobians = jac(input)
     zero_scalar = torch.tensor(0.0, device=DEVICE)
@@ -155,7 +159,8 @@ def test_multiple_outputs_1():
     assert_tensor_dicts_are_close(jacobians, expected_jacobians)
 
 
-def test_multiple_outputs_2():
+@mark.parametrize(["chunk_size", "retain_graph"], [(1, True), (3, True), (None, False)])
+def test_multiple_outputs_2(chunk_size: int | None, retain_graph: bool):
     """
     Same as test_multiple_outputs_1 but with different jac_outputs, so the returned jacobians are of
     different shapes.
@@ -175,7 +180,7 @@ def test_multiple_outputs_2():
     jac_output3 = torch.stack([zeros_2, zeros_2, ones_2])
     input = Jacobians({y1: jac_output1, y2: jac_output2, y3: jac_output3})
 
-    jac = Jac(outputs=[y1, y2, y3], inputs=[a1, a2], chunk_size=None)
+    jac = Jac(outputs=[y1, y2, y3], inputs=[a1, a2], chunk_size=chunk_size, retain_graph=True)
 
     jacobians = jac(input)
     expected_jacobians = {

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -29,8 +29,12 @@ def test_various_aggregators(aggregator: Aggregator):
 @mark.parametrize("aggregator", [Mean(), UPGrad()])
 @mark.parametrize("shape", [(2, 3), (2, 6), (5, 8), (20, 55)])
 @mark.parametrize("manually_specify_inputs", [True, False])
+@mark.parametrize("chunk_size", [1, 3, None])
 def test_value_is_correct(
-    aggregator: Aggregator, shape: tuple[int, int], manually_specify_inputs: bool
+    aggregator: Aggregator,
+    shape: tuple[int, int],
+    manually_specify_inputs: bool,
+    chunk_size: int | None,
 ):
     """
     Tests that the .grad value filled by backward is correct in a simple example of matrix-vector
@@ -46,7 +50,13 @@ def test_value_is_correct(
     else:
         inputs = None
 
-    backward([output], aggregator, inputs=inputs)
+    backward(
+        [output],
+        aggregator,
+        inputs=inputs,
+        retain_graph=True,
+        parallel_chunk_size=chunk_size,
+    )
 
     assert_close(input.grad, aggregator(J))
 

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -26,8 +26,8 @@ def test_various_aggregators(aggregator: Aggregator):
         assert (a.grad is not None) and (a.shape == a.grad.shape)
 
 
-@mark.parametrize("aggregator", [Mean(), UPGrad(), MGDA()])
-@mark.parametrize("shape", [(2, 3), (2, 6), (5, 8), (60, 55), (120, 143)])
+@mark.parametrize("aggregator", [Mean(), UPGrad()])
+@mark.parametrize("shape", [(2, 3), (2, 6), (5, 8), (20, 55)])
 @mark.parametrize("manually_specify_inputs", [True, False])
 def test_value_is_correct(
     aggregator: Aggregator, shape: tuple[int, int], manually_specify_inputs: bool

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -33,11 +33,13 @@ def test_various_aggregators(aggregator: Aggregator):
 @mark.parametrize("shape", [(2, 3), (2, 6), (5, 8), (20, 55)])
 @mark.parametrize("manually_specify_shared_params", [True, False])
 @mark.parametrize("manually_specify_tasks_params", [True, False])
+@mark.parametrize("chunk_size", [1, 3, None])
 def test_value_is_correct(
     aggregator: Aggregator,
     shape: tuple[int, int],
     manually_specify_shared_params: bool,
     manually_specify_tasks_params: bool,
+    chunk_size: int | None,
 ):
     """
     Tests that the .grad value filled by mtl_backward is correct in a simple example of
@@ -74,6 +76,8 @@ def test_value_is_correct(
         aggregator=aggregator,
         tasks_params=tasks_params,
         shared_params=shared_params,
+        retain_graph=True,
+        parallel_chunk_size=chunk_size,
     )
 
     assert_close(p1.grad, f)

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -29,8 +29,8 @@ def test_various_aggregators(aggregator: Aggregator):
         assert (p.grad is not None) and (p.shape == p.grad.shape)
 
 
-@mark.parametrize("aggregator", [Mean(), UPGrad(), MGDA()])
-@mark.parametrize("shape", [(2, 3), (2, 6), (5, 8), (60, 55), (120, 143)])
+@mark.parametrize("aggregator", [Mean(), UPGrad()])
+@mark.parametrize("shape", [(2, 3), (2, 6), (5, 8), (20, 55)])
 @mark.parametrize("manually_specify_shared_params", [True, False])
 @mark.parametrize("manually_specify_tasks_params", [True, False])
 def test_value_is_correct(


### PR DESCRIPTION
- [x] Add a special case to Jac when `parallel_chunk_size=1` + comment to explain that this is a fix to vmap
- [x] Add tests of `Jac` with `chunk_size=1`.
- [x] Add tests of `backward` and `mtl_backward` with `parallel_chunk_size=1`.
- [x] Add test with cyclic tensor graph
- [x] Add changelog entry

Note that even without the change to `Jac`, and even with CUDA, `test_tensor_used_multiple_times` succeeds, so the issue is really with CUDA + RNN rather than with CUDA + the graph of tensors being cyclical. Still, I think this test is interesting so I kept it.