### PR TITLE
Make _pref_vector_to_weighting take a default weighting as param

### DIFF
--- a/src/torchjd/aggregation/_pref_vector_utils.py
+++ b/src/torchjd/aggregation/_pref_vector_utils.py
@@ -1,7 +1,7 @@
 from torch import Tensor
 
+from .bases import _Weighting
 from .constant import _ConstantWeighting
-from .mean import _MeanWeighting
 
 
 def _check_pref_vector(pref_vector: Tensor | None) -> None:
@@ -15,12 +15,13 @@ def _check_pref_vector(pref_vector: Tensor | None) -> None:
             )
 
 
-def _pref_vector_to_weighting(pref_vector: Tensor | None) -> _ConstantWeighting | _MeanWeighting:
-    """Returns the weighting associated to a given preference vector."""
+def _pref_vector_to_weighting(pref_vector: Tensor | None, default: _Weighting) -> _Weighting:
+    """
+    Returns the weighting associated to a given preference vector, with a fallback to a default
+    weighting if the preference vector is None.
+    """
 
     if pref_vector is None:
-        weighting = _MeanWeighting()
+        return default
     else:
-        weighting = _ConstantWeighting(pref_vector)
-
-    return weighting
+        return _ConstantWeighting(pref_vector)

--- a/src/torchjd/aggregation/aligned_mtl.py
+++ b/src/torchjd/aggregation/aligned_mtl.py
@@ -32,6 +32,7 @@ from torch.linalg import LinAlgError
 from ._pref_vector_utils import _check_pref_vector, _pref_vector_to_weighting
 from ._str_utils import _vector_to_str
 from .bases import _WeightedAggregator, _Weighting
+from .mean import _MeanWeighting
 
 
 class AlignedMTL(_WeightedAggregator):
@@ -63,7 +64,7 @@ class AlignedMTL(_WeightedAggregator):
 
     def __init__(self, pref_vector: Tensor | None = None):
         _check_pref_vector(pref_vector)
-        weighting = _pref_vector_to_weighting(pref_vector)
+        weighting = _pref_vector_to_weighting(pref_vector, default=_MeanWeighting())
         self._pref_vector = pref_vector
 
         super().__init__(weighting=_AlignedMTLWrapper(weighting))

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -9,6 +9,7 @@ from ._gramian_utils import _compute_normalized_gramian
 from ._pref_vector_utils import _check_pref_vector, _pref_vector_to_weighting
 from ._str_utils import _vector_to_str
 from .bases import _WeightedAggregator, _Weighting
+from .mean import _MeanWeighting
 
 
 class DualProj(_WeightedAggregator):
@@ -50,7 +51,7 @@ class DualProj(_WeightedAggregator):
         solver: Literal["quadprog"] = "quadprog",
     ):
         _check_pref_vector(pref_vector)
-        weighting = _pref_vector_to_weighting(pref_vector)
+        weighting = _pref_vector_to_weighting(pref_vector, default=_MeanWeighting())
         self._pref_vector = pref_vector
 
         super().__init__(

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -9,6 +9,7 @@ from ._gramian_utils import _compute_normalized_gramian
 from ._pref_vector_utils import _check_pref_vector, _pref_vector_to_weighting
 from ._str_utils import _vector_to_str
 from .bases import _WeightedAggregator, _Weighting
+from .mean import _MeanWeighting
 
 
 class UPGrad(_WeightedAggregator):
@@ -49,7 +50,7 @@ class UPGrad(_WeightedAggregator):
         solver: Literal["quadprog"] = "quadprog",
     ):
         _check_pref_vector(pref_vector)
-        weighting = _pref_vector_to_weighting(pref_vector)
+        weighting = _pref_vector_to_weighting(pref_vector, default=_MeanWeighting())
         self._pref_vector = pref_vector
 
         super().__init__(


### PR DESCRIPTION
I think this is much cleaner for the case where we would want the default weighting to be something else than the `_MeanWeighting`. For instance, for `ConFIG`, if we add a `pref_vector` parameter, we would want the weighting to default to `_SumWeighting`. In opposition, the previous version assumed that the default weighting always had to be `_MeanWeighting`, which I think is wrong.
