### PR TITLE
Fix device type in `conftest.py`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ with maintainers before implementing major changes.
 
    - If you have access to a cuda-enabled GPU, you should also check that the unit tests pass on it:
      ```bash
-     CUBLAS_WORKSPACE_CONFIG=:4096:8 PYTEST_TORCH_DEVICE=cuda pdm run pytest tests/unit
+     CUBLAS_WORKSPACE_CONFIG=:4096:8 PYTEST_TORCH_DEVICE=cuda:0 pdm run pytest tests/unit
      ```
 
    - To check that the usage examples from docstrings and `.rst` files are correct, we test their

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,15 +5,17 @@ import torch
 from pytest import fixture
 
 try:
-    DEVICE = os.environ["PYTEST_TORCH_DEVICE"]
+    _device_str = os.environ["PYTEST_TORCH_DEVICE"]
 except KeyError:
-    DEVICE = "cpu"  # Default to cpu if environment variable not set
+    _device_str = "cpu"  # Default to cpu if environment variable not set
 
-if DEVICE != "cuda" and DEVICE != "cpu":
-    raise ValueError(f"Invalid value of environment variable PYTEST_TORCH_DEVICE: {DEVICE}")
+if _device_str != "cuda" and _device_str != "cpu":
+    raise ValueError(f"Invalid value of environment variable PYTEST_TORCH_DEVICE: {_device_str}")
 
-if DEVICE == "cuda" and not torch.cuda.is_available():
+if _device_str == "cuda" and not torch.cuda.is_available():
     raise ValueError('Requested device "cuda" but cuda is not available.')
+
+DEVICE = torch.device(_device_str)
 
 
 @fixture(autouse=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,11 +9,11 @@ try:
 except KeyError:
     _device_str = "cpu"  # Default to cpu if environment variable not set
 
-if _device_str != "cuda" and _device_str != "cpu":
+if _device_str != "cuda:0" and _device_str != "cpu":
     raise ValueError(f"Invalid value of environment variable PYTEST_TORCH_DEVICE: {_device_str}")
 
-if _device_str == "cuda" and not torch.cuda.is_available():
-    raise ValueError('Requested device "cuda" but cuda is not available.')
+if _device_str == "cuda:0" and not torch.cuda.is_available():
+    raise ValueError('Requested device "cuda:0" but cuda is not available.')
 
 DEVICE = torch.device(_device_str)
 


### PR DESCRIPTION
- **Change DEVICE to be a torch.device instead of a string** => I think it's slightly cleaner
- **Change cuda to cuda:0** => When a tensor is given device "cuda", its device field will actually be "cuda:0", so using "cuda:0" directly makes things less tedious when testing representations.

