### PR TITLE
Use `torch.set_default_device` in `conftest.py`

### DIFF
--- a/tests/doc/test_backward.py
+++ b/tests/doc/test_backward.py
@@ -4,7 +4,6 @@ obtained `.grad` field.
 """
 
 from torch.testing import assert_close
-from unit.conftest import DEVICE
 
 
 def test_backward():
@@ -13,11 +12,11 @@ def test_backward():
     from torchjd import backward
     from torchjd.aggregation import UPGrad
 
-    param = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    param = torch.tensor([1.0, 2.0], requires_grad=True)
     # Compute arbitrary quantities that are function of param
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ param
+    y1 = torch.tensor([-1.0, 1.0]) @ param
     y2 = (param**2).sum()
 
     backward([y1, y2], UPGrad())
 
-    assert_close(param.grad, torch.tensor([0.5000, 2.5000], device=DEVICE), rtol=0.0, atol=1e-04)
+    assert_close(param.grad, torch.tensor([0.5000, 2.5000]), rtol=0.0, atol=1e-04)

--- a/tests/unit/aggregation/_inputs.py
+++ b/tests/unit/aggregation/_inputs.py
@@ -1,6 +1,5 @@
 import torch
 from torch import Tensor
-from unit.conftest import DEVICE
 
 
 def _check_valid_dimensions(n_rows: int, n_cols: int) -> None:
@@ -37,9 +36,9 @@ def _augment_orthogonal_matrix(orthogonal_matrix: Tensor) -> Tensor:
 
     n_rows = orthogonal_matrix.shape[0]
     projection = orthogonal_matrix @ orthogonal_matrix.T
-    zero = torch.zeros([n_rows], device=DEVICE)
+    zero = torch.zeros([n_rows])
     while True:
-        random_vector = torch.randn([n_rows], device=DEVICE)
+        random_vector = torch.randn([n_rows])
         projected_vector = random_vector - projection @ random_vector
         if not torch.allclose(projected_vector, zero):
             break
@@ -70,7 +69,7 @@ def _generate_unitary_matrix(n_rows: int, n_cols: int) -> Tensor:
     """Generates a unitary matrix of shape [n_rows, n_cols]."""
 
     _check_valid_dimensions(n_rows, n_cols)
-    partial_matrix = torch.randn([n_rows, 1], device=DEVICE)
+    partial_matrix = torch.randn([n_rows, 1])
     partial_matrix = torch.nn.functional.normalize(partial_matrix, dim=0)
 
     unitary_matrix = _complete_orthogonal_matrix(partial_matrix, n_cols)
@@ -83,7 +82,7 @@ def _generate_unitary_matrix_with_positive_column(n_rows: int, n_cols: int) -> T
     positive vector.
     """
     _check_valid_dimensions(n_rows, n_cols)
-    partial_matrix = torch.abs(torch.randn([n_rows, 1], device=DEVICE))
+    partial_matrix = torch.abs(torch.randn([n_rows, 1]))
     partial_matrix = torch.nn.functional.normalize(partial_matrix, dim=0)
 
     unitary_matrix_with_positive_column = _complete_orthogonal_matrix(partial_matrix, n_cols)
@@ -94,7 +93,7 @@ def _generate_diagonal_singular_values(rank: int) -> Tensor:
     """
     generates a diagonal matrix of positive values sorted in descending order.
     """
-    singular_values = torch.abs(torch.randn([rank], device=DEVICE))
+    singular_values = torch.abs(torch.randn([rank]))
     singular_values = torch.sort(singular_values, descending=True)[0]
     S = torch.diag(singular_values)
     return S
@@ -108,7 +107,7 @@ def generate_matrix(n_rows: int, n_cols: int, rank: int) -> Tensor:
     _check_valid_rank(n_rows, n_cols, rank)
 
     if rank == 0:
-        matrix = torch.zeros([n_rows, n_cols], device=DEVICE)
+        matrix = torch.zeros([n_rows, n_cols])
     else:
         U = _generate_unitary_matrix(n_rows, rank)
         V = _generate_unitary_matrix(n_cols, rank)
@@ -126,7 +125,7 @@ def generate_stationary_matrix(n_rows: int, n_cols: int, rank: int) -> Tensor:
 
     _check_valid_rank(n_rows, n_cols, rank)
     if rank == 0:
-        matrix = torch.zeros([n_rows, n_cols], device=DEVICE)
+        matrix = torch.zeros([n_rows, n_cols])
     else:
         U = _generate_unitary_matrix_with_positive_column(n_rows, rank)
         V = _generate_unitary_matrix(n_cols, rank)
@@ -161,9 +160,7 @@ matrices = [
     generate_matrix(n_rows, n_cols, rank) for n_rows, n_cols, rank in _matrix_dimension_triples
 ]
 scaled_matrices = [scale * matrix for scale in _scales for matrix in matrices]
-zero_rank_matrices = [
-    torch.zeros([n_rows, n_cols], device=DEVICE) for n_rows, n_cols in _zero_rank_matrix_shapes
-]
+zero_rank_matrices = [torch.zeros([n_rows, n_cols]) for n_rows, n_cols in _zero_rank_matrix_shapes]
 matrices_2_plus_rows = [matrix for matrix in matrices + zero_rank_matrices if matrix.shape[0] >= 2]
 scaled_matrices_2_plus_rows = [
     matrix for matrix in scaled_matrices + zero_rank_matrices if matrix.shape[0] >= 2

--- a/tests/unit/aggregation/test_base.py
+++ b/tests/unit/aggregation/test_base.py
@@ -4,7 +4,6 @@ from typing import Sequence
 import torch
 from pytest import mark, raises
 from unit._utils import ExceptionContext
-from unit.conftest import DEVICE
 
 from torchjd.aggregation import Aggregator
 
@@ -21,4 +20,4 @@ from torchjd.aggregation import Aggregator
 )
 def test_check_is_matrix(shape: Sequence[int], expectation: ExceptionContext):
     with expectation:
-        Aggregator._check_is_matrix(torch.randn(shape, device=DEVICE))
+        Aggregator._check_is_matrix(torch.randn(shape))

--- a/tests/unit/aggregation/test_constant.py
+++ b/tests/unit/aggregation/test_constant.py
@@ -1,7 +1,6 @@
 import torch
 from pytest import mark
 from torch import Tensor
-from unit.conftest import DEVICE
 
 from torchjd.aggregation import Constant
 
@@ -16,7 +15,7 @@ from ._property_testers import ExpectedStructureProperty
 
 def _make_aggregator(matrix: Tensor) -> Constant:
     n_rows = matrix.shape[0]
-    weights = torch.tensor([1.0 / n_rows] * n_rows, device=DEVICE)
+    weights = torch.tensor([1.0 / n_rows] * n_rows)
     return Constant(weights)
 
 

--- a/tests/unit/aggregation/test_constant.py
+++ b/tests/unit/aggregation/test_constant.py
@@ -38,6 +38,6 @@ class TestConstant(ExpectedStructureProperty):
 
 
 def test_representations():
-    A = Constant(weights=torch.tensor([1.0, 2.0]))
+    A = Constant(weights=torch.tensor([1.0, 2.0], device="cpu"))
     assert repr(A) == "Constant(weights=tensor([1., 2.]))"
     assert str(A) == "Constant([1., 2.])"

--- a/tests/unit/aggregation/test_graddrop.py
+++ b/tests/unit/aggregation/test_graddrop.py
@@ -12,7 +12,7 @@ class TestGradDrop(ExpectedStructureProperty):
 
 
 def test_representations():
-    A = GradDrop(leak=torch.tensor([0.0, 1.0]))
+    A = GradDrop(leak=torch.tensor([0.0, 1.0], device="cpu"))
     assert repr(A) == "GradDrop(leak=tensor([0., 1.]))"
     assert str(A) == "GradDrop([0., 1.])"
 

--- a/tests/unit/aggregation/test_imtl_g.py
+++ b/tests/unit/aggregation/test_imtl_g.py
@@ -1,7 +1,6 @@
 import torch
 from pytest import mark
 from torch.testing import assert_close
-from unit.conftest import DEVICE
 
 from torchjd.aggregation import IMTLG
 
@@ -20,8 +19,8 @@ def test_imtlg_zero():
     """
 
     A = IMTLG()
-    J = torch.zeros(2, 3, device=DEVICE)
-    assert_close(A(J), torch.zeros(3, device=DEVICE))
+    J = torch.zeros(2, 3)
+    assert_close(A(J), torch.zeros(3))
 
 
 def test_representations():

--- a/tests/unit/aggregation/test_mgda.py
+++ b/tests/unit/aggregation/test_mgda.py
@@ -1,7 +1,6 @@
 import torch
 from pytest import mark
 from torch.testing import assert_close
-from unit.conftest import DEVICE
 
 from torchjd.aggregation import MGDA
 from torchjd.aggregation.mgda import _MGDAWeighting
@@ -29,7 +28,7 @@ class TestMGDA(ExpectedStructureProperty, NonConflictingProperty, PermutationInv
     ],
 )
 def test_mgda_satisfies_kkt_conditions(shape: tuple[int, int]):
-    matrix = torch.randn(shape, device=DEVICE)
+    matrix = torch.randn(shape)
     weighting = _MGDAWeighting(epsilon=1e-05, max_iters=1000)
 
     gramian = matrix @ matrix.T
@@ -45,7 +44,7 @@ def test_mgda_satisfies_kkt_conditions(shape: tuple[int, int]):
     assert_close(positive_weights.norm(), weights.norm())
 
     weights_sum = weights.sum()
-    assert_close(weights_sum, torch.ones([], device=DEVICE))
+    assert_close(weights_sum, torch.ones([]))
 
     # Dual feasibility
     positive_mu = mu[mu >= 0]

--- a/tests/unit/aggregation/test_pcgrad.py
+++ b/tests/unit/aggregation/test_pcgrad.py
@@ -1,7 +1,6 @@
 import torch
 from pytest import mark
 from torch.testing import assert_close
-from unit.conftest import DEVICE
 
 from torchjd.aggregation import PCGrad
 from torchjd.aggregation.pcgrad import _PCGradWeighting
@@ -37,7 +36,7 @@ def test_equivalence_upgrad_sum_two_rows(shape: tuple[int, int]):
     rows.
     """
 
-    matrix = torch.randn(shape, device=DEVICE)
+    matrix = torch.randn(shape)
 
     pc_grad_weighting = _PCGradWeighting()
     upgrad_sum_weighting = _UPGradWrapper(

--- a/tests/unit/aggregation/test_upgrad.py
+++ b/tests/unit/aggregation/test_upgrad.py
@@ -1,7 +1,6 @@
 import torch
 from pytest import mark
 from torch.testing import assert_close
-from unit.conftest import DEVICE
 
 from torchjd.aggregation import UPGrad
 from torchjd.aggregation.mean import _MeanWeighting
@@ -21,8 +20,8 @@ class TestUPGrad(ExpectedStructureProperty, NonConflictingProperty, PermutationI
 
 @mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100)])
 def test_upgrad_lagrangian_satisfies_kkt_conditions(shape: tuple[int, int]):
-    matrix = torch.randn(shape, device=DEVICE)
-    weights = torch.rand(shape[0], device=DEVICE)
+    matrix = torch.randn(shape)
+    weights = torch.rand(shape[0])
 
     gramian = matrix @ matrix.T
 
@@ -41,7 +40,7 @@ def test_upgrad_lagrangian_satisfies_kkt_conditions(shape: tuple[int, int]):
     assert_close(positive_constraint.norm(), constraint.norm(), atol=1e-04, rtol=0)
 
     slackness = torch.trace(lagrange_multiplier @ constraint)
-    assert_close(slackness, torch.zeros_like(slackness, device=DEVICE), atol=3e-03, rtol=0)
+    assert_close(slackness, torch.zeros_like(slackness), atol=3e-03, rtol=0)
 
 
 def test_representations():

--- a/tests/unit/autojac/_transform/test_accumulate.py
+++ b/tests/unit/autojac/_transform/test_accumulate.py
@@ -1,6 +1,5 @@
 import torch
 from pytest import mark, raises
-from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import Accumulate, Gradients
 
@@ -13,12 +12,12 @@ def test_single_accumulation():
     once.
     """
 
-    key1 = torch.zeros([], requires_grad=True, device=DEVICE)
-    key2 = torch.zeros([1], requires_grad=True, device=DEVICE)
-    key3 = torch.zeros([2, 3], requires_grad=True, device=DEVICE)
-    value1 = torch.ones([], device=DEVICE)
-    value2 = torch.ones([1], device=DEVICE)
-    value3 = torch.ones([2, 3], device=DEVICE)
+    key1 = torch.zeros([], requires_grad=True)
+    key2 = torch.zeros([1], requires_grad=True)
+    key3 = torch.zeros([2, 3], requires_grad=True)
+    value1 = torch.ones([])
+    value2 = torch.ones([1])
+    value3 = torch.ones([2, 3])
     input = Gradients({key1: value1, key2: value2, key3: value3})
 
     accumulate = Accumulate([key1, key2, key3])
@@ -41,12 +40,12 @@ def test_multiple_accumulation(iterations: int):
     `iterations` times.
     """
 
-    key1 = torch.zeros([], requires_grad=True, device=DEVICE)
-    key2 = torch.zeros([1], requires_grad=True, device=DEVICE)
-    key3 = torch.zeros([2, 3], requires_grad=True, device=DEVICE)
-    value1 = torch.ones([], device=DEVICE)
-    value2 = torch.ones([1], device=DEVICE)
-    value3 = torch.ones([2, 3], device=DEVICE)
+    key1 = torch.zeros([], requires_grad=True)
+    key2 = torch.zeros([1], requires_grad=True)
+    key3 = torch.zeros([2, 3], requires_grad=True)
+    value1 = torch.ones([])
+    value2 = torch.ones([1])
+    value3 = torch.ones([2, 3])
     input = Gradients({key1: value1, key2: value2, key3: value3})
 
     accumulate = Accumulate([key1, key2, key3])
@@ -70,8 +69,8 @@ def test_no_requires_grad_fails():
     tensor that does not require grad.
     """
 
-    key = torch.zeros([1], requires_grad=False, device=DEVICE)
-    value = torch.ones([1], device=DEVICE)
+    key = torch.zeros([1], requires_grad=False)
+    value = torch.ones([1])
     input = Gradients({key: value})
 
     accumulate = Accumulate([key])
@@ -86,8 +85,8 @@ def test_no_leaf_and_no_retains_grad_fails():
     tensor that is not a leaf and that does not retain grad.
     """
 
-    key = torch.tensor([1.0], requires_grad=True, device=DEVICE) * 2
-    value = torch.ones([1], device=DEVICE)
+    key = torch.tensor([1.0], requires_grad=True) * 2
+    value = torch.ones([1])
     input = Gradients({key: value})
 
     accumulate = Accumulate([key])

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -3,7 +3,6 @@ import typing
 import torch
 from pytest import raises
 from torch import Tensor
-from unit.conftest import DEVICE
 
 from torchjd.autojac._transform._utils import _B, _C
 from torchjd.autojac._transform.base import Conjunction, Transform
@@ -25,7 +24,7 @@ class FakeTransform(Transform[_B, _C]):
     def _compute(self, input: _B) -> _C:
         # Ignore the input, create a dictionary with the right keys as an output.
         # Cast the type for the purpose of type-checking.
-        output_dict = {key: torch.empty(0, device=DEVICE) for key in self._output_keys}
+        output_dict = {key: torch.empty(0) for key in self._output_keys}
         return typing.cast(_C, output_dict)
 
     @property
@@ -43,8 +42,8 @@ def test_call_checks_keys():
     contains keys that correspond exactly to `required_keys`.
     """
 
-    a1 = torch.randn([2], device=DEVICE)
-    a2 = torch.randn([3], device=DEVICE)
+    a1 = torch.randn([2])
+    a2 = torch.randn([3])
     t = FakeTransform(required_keys={a1}, output_keys={a1, a2})
 
     t(TensorDict({a1: a2}))
@@ -65,8 +64,8 @@ def test_compose_checks_keys():
     match with the outer transform's `required_keys`.
     """
 
-    a1 = torch.randn([2], device=DEVICE)
-    a2 = torch.randn([3], device=DEVICE)
+    a1 = torch.randn([2])
+    a2 = torch.randn([3])
     t1 = FakeTransform(required_keys={a1}, output_keys={a1, a2})
     t2 = FakeTransform(required_keys={a2}, output_keys={a1})
 
@@ -82,8 +81,8 @@ def test_conjunct_checks_required_keys():
     same `required_keys`.
     """
 
-    a1 = torch.randn([2], device=DEVICE)
-    a2 = torch.randn([3], device=DEVICE)
+    a1 = torch.randn([2])
+    a2 = torch.randn([3])
 
     t1 = FakeTransform(required_keys={a1}, output_keys=set())
     t2 = FakeTransform(required_keys={a1}, output_keys=set())
@@ -104,8 +103,8 @@ def test_conjunct_checks_output_keys():
     disjoint.
     """
 
-    a1 = torch.randn([2], device=DEVICE)
-    a2 = torch.randn([3], device=DEVICE)
+    a1 = torch.randn([2])
+    a2 = torch.randn([3])
 
     t1 = FakeTransform(required_keys=set(), output_keys={a1, a2})
     t2 = FakeTransform(required_keys=set(), output_keys={a1})

--- a/tests/unit/autojac/_transform/test_diagonalize.py
+++ b/tests/unit/autojac/_transform/test_diagonalize.py
@@ -1,5 +1,4 @@
 import torch
-from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import Diagonalize, Gradients
 
@@ -9,16 +8,14 @@ from ._dict_assertions import assert_tensor_dicts_are_close
 def test_single_input():
     """Tests that the Diagonalize transform works when given a single input."""
 
-    key = torch.tensor([1.0, 2.0, 3.0], device=DEVICE)
+    key = torch.tensor([1.0, 2.0, 3.0])
     value = torch.ones_like(key)
     input = Gradients({key: value})
 
     diag = Diagonalize([key])
 
     output = diag(input)
-    expected_output = {
-        key: torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], device=DEVICE)
-    }
+    expected_output = {key: torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])}
 
     assert_tensor_dicts_are_close(output, expected_output)
 
@@ -26,9 +23,9 @@ def test_single_input():
 def test_multiple_inputs():
     """Tests that the Diagonalize transform works when given multiple inputs."""
 
-    key1 = torch.tensor([[1.0, 2.0], [4.0, 5.0]], device=DEVICE)
-    key2 = torch.tensor([1.0, 3.0, 5.0], device=DEVICE)
-    key3 = torch.tensor(1.0, device=DEVICE)
+    key1 = torch.tensor([[1.0, 2.0], [4.0, 5.0]])
+    key2 = torch.tensor([1.0, 3.0, 5.0])
+    key3 = torch.tensor(1.0)
     value1 = torch.ones_like(key1)
     value2 = torch.ones_like(key2)
     value3 = torch.ones_like(key3)
@@ -49,7 +46,6 @@ def test_multiple_inputs():
                 [[0.0, 0.0], [0.0, 0.0]],
                 [[0.0, 0.0], [0.0, 0.0]],
             ],
-            device=DEVICE,
         ),
         key2: torch.tensor(
             [
@@ -62,7 +58,6 @@ def test_multiple_inputs():
                 [0.0, 0.0, 1.0],
                 [0.0, 0.0, 0.0],
             ],
-            device=DEVICE,
         ),
         key3: torch.tensor(
             [
@@ -75,7 +70,6 @@ def test_multiple_inputs():
                 0.0,
                 1.0,
             ],
-            device=DEVICE,
         ),
     }
 
@@ -87,8 +81,8 @@ def test_permute_order():
     Tests that the Diagonalize transform outputs a permuted mapping when its keys are permuted.
     """
 
-    key1 = torch.tensor(2.0, device=DEVICE)
-    key2 = torch.tensor(1.0, device=DEVICE)
+    key1 = torch.tensor(2.0)
+    key2 = torch.tensor(1.0)
     value1 = torch.ones_like(key1)
     value2 = torch.ones_like(key2)
     input = Gradients({key1: value1, key2: value2})

--- a/tests/unit/autojac/_transform/test_grad.py
+++ b/tests/unit/autojac/_transform/test_grad.py
@@ -1,6 +1,5 @@
 import torch
 from pytest import raises
-from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import Grad, Gradients
 
@@ -14,8 +13,8 @@ def test_single_input():
     respect to the parameter `a`. This derivative should be equal to `x`.
     """
 
-    x = torch.tensor(5.0, device=DEVICE)
-    a = torch.tensor(2.0, requires_grad=True, device=DEVICE)
+    x = torch.tensor(5.0)
+    a = torch.tensor(2.0, requires_grad=True)
     y = a * x
     input = Gradients({y: torch.ones_like(y)})
 
@@ -33,7 +32,7 @@ def test_empty_inputs_1():
     `Iterable`.
     """
 
-    y = torch.tensor(1.0, requires_grad=True, device=DEVICE)
+    y = torch.tensor(1.0, requires_grad=True)
     input = Gradients({y: torch.ones_like(y)})
 
     grad = Grad(outputs=[y], inputs=[])
@@ -50,8 +49,8 @@ def test_empty_inputs_2():
     `Iterable`.
     """
 
-    x = torch.tensor(5.0, device=DEVICE)
-    a = torch.tensor(1.0, requires_grad=True, device=DEVICE)
+    x = torch.tensor(5.0)
+    a = torch.tensor(1.0, requires_grad=True)
     y = a * x
     input = Gradients({y: torch.ones_like(y)})
 
@@ -66,8 +65,8 @@ def test_empty_inputs_2():
 def test_retain_graph():
     """Tests that the `Grad` transform behaves as expected with the `retain_graph` flag."""
 
-    x = torch.tensor(5.0, device=DEVICE)
-    a = torch.tensor(2.0, requires_grad=True, device=DEVICE)
+    x = torch.tensor(5.0)
+    a = torch.tensor(2.0, requires_grad=True)
     y = a * x
     input = Gradients({y: torch.ones_like(y)})
 
@@ -91,9 +90,9 @@ def test_single_input_two_levels():
     using chain rule. This derivative should be equal to `x1 * x2`.
     """
 
-    x1 = torch.tensor(5.0, device=DEVICE)
-    x2 = torch.tensor(6.0, device=DEVICE)
-    a = torch.tensor(2.0, requires_grad=True, device=DEVICE)
+    x1 = torch.tensor(5.0)
+    x2 = torch.tensor(6.0)
+    a = torch.tensor(2.0, requires_grad=True)
     y = a * x1
     z = y * x2
     input = Gradients({z: torch.ones_like(z)})
@@ -114,9 +113,9 @@ def test_empty_inputs_two_levels():
     `Iterable`, with 2 composed Grad transforms.
     """
 
-    x1 = torch.tensor(5.0, device=DEVICE)
-    x2 = torch.tensor(6.0, device=DEVICE)
-    a = torch.tensor(2.0, requires_grad=True, device=DEVICE)
+    x1 = torch.tensor(5.0)
+    x2 = torch.tensor(6.0)
+    a = torch.tensor(2.0, requires_grad=True)
     y = a * x1
     z = y * x2
     input = Gradients({z: torch.ones_like(z)})
@@ -138,10 +137,10 @@ def test_vector_output():
     checks that the scaling is performed correctly.
     """
 
-    x = torch.tensor(5.0, device=DEVICE)
-    a = torch.tensor(2.0, requires_grad=True, device=DEVICE)
+    x = torch.tensor(5.0)
+    a = torch.tensor(2.0, requires_grad=True)
     y = torch.stack([a * x, a**2])
-    input = Gradients({y: torch.tensor([3.0, 1.0], device=DEVICE)})
+    input = Gradients({y: torch.tensor([3.0, 1.0])})
 
     grad = Grad(outputs=[y], inputs=[a])
 
@@ -158,8 +157,8 @@ def test_multiple_outputs():
     the scaling is performed correctly.
     """
 
-    x = torch.tensor(5.0, device=DEVICE)
-    a = torch.tensor(2.0, requires_grad=True, device=DEVICE)
+    x = torch.tensor(5.0)
+    a = torch.tensor(2.0, requires_grad=True)
     y1 = a * x
     y2 = a**2
     input = Gradients({y1: torch.ones_like(y1) * 3, y2: torch.ones_like(y2)})
@@ -179,16 +178,16 @@ def test_multiple_tensor_outputs():
     that this test also checks that the scaling is performed correctly.
     """
 
-    x = torch.tensor(5.0, device=DEVICE)
-    a = torch.tensor(2.0, requires_grad=True, device=DEVICE)
+    x = torch.tensor(5.0)
+    a = torch.tensor(2.0, requires_grad=True)
     y1 = a * x
     y2 = torch.stack([a**2, 2 * a**2])
     y3 = torch.stack([a**3, 2 * a**3]).unsqueeze(0)
     input = Gradients(
         {
-            y1: torch.tensor(3.0, device=DEVICE),
-            y2: torch.tensor([6.0, 7.0], device=DEVICE),
-            y3: torch.tensor([[9.0, 10.0]], device=DEVICE),
+            y1: torch.tensor(3.0),
+            y2: torch.tensor([6.0, 7.0]),
+            y3: torch.tensor([[9.0, 10.0]]),
         }
     )
 
@@ -207,10 +206,10 @@ def test_composition_of_grads_is_grad():
     a single transform.
     """
 
-    x1 = torch.tensor(5.0, device=DEVICE)
-    x2 = torch.tensor(6.0, device=DEVICE)
-    a = torch.tensor(2.0, requires_grad=True, device=DEVICE)
-    b = torch.tensor(1.0, requires_grad=True, device=DEVICE)
+    x1 = torch.tensor(5.0)
+    x2 = torch.tensor(6.0)
+    a = torch.tensor(2.0, requires_grad=True)
+    b = torch.tensor(1.0, requires_grad=True)
     y1 = a * x1
     y2 = a * x2
     z1 = y1 + x2
@@ -234,10 +233,10 @@ def test_conjunction_of_grads_is_grad():
     a single transform.
     """
 
-    x1 = torch.tensor(5.0, device=DEVICE)
-    x2 = torch.tensor(6.0, device=DEVICE)
-    a1 = torch.tensor(2.0, requires_grad=True, device=DEVICE)
-    a2 = torch.tensor(3.0, requires_grad=True, device=DEVICE)
+    x1 = torch.tensor(5.0)
+    x2 = torch.tensor(6.0)
+    a1 = torch.tensor(2.0, requires_grad=True)
+    a2 = torch.tensor(3.0, requires_grad=True)
     y = torch.stack([a1 * x1, a2 * x2])
     input = Gradients({y: torch.ones_like(y)})
 
@@ -255,7 +254,7 @@ def test_conjunction_of_grads_is_grad():
 def test_create_graph():
     """Tests that the Grad transform behaves correctly when `create_graph` is set to `True`."""
 
-    a = torch.tensor(2.0, requires_grad=True, device=DEVICE)
+    a = torch.tensor(2.0, requires_grad=True)
     y = a * a
     input = Gradients({y: torch.ones_like(y)})
 

--- a/tests/unit/autojac/_transform/test_init.py
+++ b/tests/unit/autojac/_transform/test_init.py
@@ -1,5 +1,4 @@
 import torch
-from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import EmptyTensorDict, Init
 
@@ -12,13 +11,13 @@ def test_single_input():
     whose value is a tensor full of ones, of the same shape as its key.
     """
 
-    key = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device=DEVICE)
+    key = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     input = EmptyTensorDict()
 
     init = Init([key])
 
     output = init(input)
-    expected_output = {key: torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], device=DEVICE)}
+    expected_output = {key: torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])}
 
     assert_tensor_dicts_are_close(output, expected_output)
 
@@ -29,16 +28,16 @@ def test_multiple_inputs():
     whose values are tensors full of ones, of the same shape as their corresponding keys.
     """
 
-    key1 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device=DEVICE)
-    key2 = torch.tensor([1.0, 3.0, 5.0], device=DEVICE)
+    key1 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    key2 = torch.tensor([1.0, 3.0, 5.0])
     input = EmptyTensorDict()
 
     init = Init([key1, key2])
 
     output = init(input)
     expected = {
-        key1: torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], device=DEVICE),
-        key2: torch.tensor([1.0, 1.0, 1.0], device=DEVICE),
+        key1: torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]),
+        key2: torch.tensor([1.0, 1.0, 1.0]),
     }
     assert_tensor_dicts_are_close(output, expected)
 
@@ -49,8 +48,8 @@ def test_conjunction_of_inits_is_init():
     multiple keys.
     """
 
-    x1 = torch.tensor(5.0, device=DEVICE)
-    x2 = torch.tensor(6.0, device=DEVICE)
+    x1 = torch.tensor(5.0)
+    x2 = torch.tensor(6.0)
     input = EmptyTensorDict()
 
     init1 = Init([x1])

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -1,6 +1,5 @@
 import torch
 from torch.testing import assert_close
-from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import (
     Accumulate,
@@ -26,9 +25,9 @@ def test_jac_is_stack_of_grads():
     Select transforms.
     """
 
-    x = torch.tensor(5.0, device=DEVICE)
-    a1 = torch.tensor(2.0, requires_grad=True, device=DEVICE)
-    a2 = torch.tensor(3.0, requires_grad=True, device=DEVICE)
+    x = torch.tensor(5.0)
+    a1 = torch.tensor(2.0, requires_grad=True)
+    a2 = torch.tensor(3.0, requires_grad=True)
     y1 = a1 * x
     y2 = a2 * x
     input = Gradients({y1: torch.ones_like(y1), y2: torch.ones_like(y2)})
@@ -55,7 +54,7 @@ def test_single_differentiation():
     Init transform.
     """
 
-    a = torch.tensor([1.0, 2.0, 3.0], requires_grad=True, device=DEVICE)
+    a = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
     y = a * 2.0
     input = EmptyTensorDict()
 
@@ -64,7 +63,7 @@ def test_single_differentiation():
     transform = grad << init
 
     output = transform(input)
-    expected_output = {a: torch.tensor([2.0, 2.0, 2.0], device=DEVICE)}
+    expected_output = {a: torch.tensor([2.0, 2.0, 2.0])}
 
     assert_tensor_dicts_are_close(output, expected_output)
 
@@ -75,8 +74,8 @@ def test_multiple_differentiations():
     transforms, composed with an Init transform.
     """
 
-    a1 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], requires_grad=True, device=DEVICE)
-    a2 = torch.tensor([1.0, 3.0, 5.0], requires_grad=True, device=DEVICE)
+    a1 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], requires_grad=True)
+    a2 = torch.tensor([1.0, 3.0, 5.0], requires_grad=True)
     y1 = a1 * 2.0
     y2 = a2 * 3.0
     input = EmptyTensorDict()
@@ -90,8 +89,8 @@ def test_multiple_differentiations():
 
     output = transform(input)
     expected_output = {
-        a1: torch.tensor([[2.0, 2.0, 2.0], [2.0, 2.0, 2.0]], device=DEVICE),
-        a2: torch.tensor([3.0, 3.0, 3.0], device=DEVICE),
+        a1: torch.tensor([[2.0, 2.0, 2.0], [2.0, 2.0, 2.0]]),
+        a2: torch.tensor([3.0, 3.0, 3.0]),
     }
 
     assert_tensor_dicts_are_close(output, expected_output)
@@ -114,9 +113,9 @@ def test_simple_conjunction():
     Because of this, the output is expected to be the same as the input.
     """
 
-    x1 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device=DEVICE)
-    x2 = torch.tensor([1.0, 3.0, 5.0], device=DEVICE)
-    x3 = torch.tensor(4.0, device=DEVICE)
+    x1 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    x2 = torch.tensor([1.0, 3.0, 5.0])
+    x3 = torch.tensor(4.0)
     input = TensorDict({x1: torch.ones_like(x1), x2: torch.ones_like(x2), x3: torch.ones_like(x3)})
 
     select1 = Select([x1], [x1, x2, x3])
@@ -136,8 +135,8 @@ def test_conjunction_is_commutative():
     transforms are given.
     """
 
-    x1 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device=DEVICE)
-    x2 = torch.tensor([1.0, 3.0, 5.0], device=DEVICE)
+    x1 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    x2 = torch.tensor([1.0, 3.0, 5.0])
     input = TensorDict({x1: torch.ones_like(x1), x2: torch.ones_like(x2)})
 
     a = Select([x1], [x1, x2])
@@ -156,10 +155,10 @@ def test_conjunction_is_associative():
     Tests that the Conjunction transform gives the same result no matter how it is parenthesized.
     """
 
-    x1 = torch.tensor([[3.0, 11.0], [2.0, 7.0]], device=DEVICE)
-    x2 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device=DEVICE)
-    x3 = torch.tensor([1.0, 3.0, 5.0], device=DEVICE)
-    x4 = torch.tensor(4.0, device=DEVICE)
+    x1 = torch.tensor([[3.0, 11.0], [2.0, 7.0]])
+    x2 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    x3 = torch.tensor([1.0, 3.0, 5.0])
+    x4 = torch.tensor(4.0)
     input = TensorDict(
         {
             x1: torch.ones_like(x1),
@@ -191,7 +190,7 @@ def test_conjunction_accumulate_select():
     subclass of it.
     """
 
-    key = torch.tensor([1.0, 2.0, 3.0], requires_grad=True, device=DEVICE)
+    key = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
     value = torch.ones_like(key)
     input = Gradients({key: value})
 
@@ -211,12 +210,12 @@ def test_equivalence_jac_grads():
     using several calls to `_grad` and stacking the resulting gradients.
     """
 
-    A = torch.tensor([[4.0, 5.0], [6.0, 7.0], [8.0, 9.0]], requires_grad=True, device=DEVICE)
-    b = torch.tensor([0.0, 2.0], requires_grad=True, device=DEVICE)
-    c = torch.tensor(1.0, requires_grad=True, device=DEVICE)
+    A = torch.tensor([[4.0, 5.0], [6.0, 7.0], [8.0, 9.0]], requires_grad=True)
+    b = torch.tensor([0.0, 2.0], requires_grad=True)
+    c = torch.tensor(1.0, requires_grad=True)
 
-    X1 = torch.tensor([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]], device=DEVICE)
-    x2 = torch.tensor([5.0, 4.0, 3.0], device=DEVICE)
+    X1 = torch.tensor([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]])
+    x2 = torch.tensor([5.0, 4.0, 3.0])
 
     y1 = X1 @ A @ b
     y2 = x2 @ A @ b + c
@@ -235,7 +234,7 @@ def test_equivalence_jac_grads():
 
     n_outputs = len(outputs)
     batched_grad_outputs = [
-        torch.zeros((n_outputs,) + grad_output.shape, device=DEVICE) for grad_output in grad_outputs
+        torch.zeros((n_outputs,) + grad_output.shape) for grad_output in grad_outputs
     ]
     for i, grad_output in enumerate(grad_outputs):
         batched_grad_outputs[i][i] = grad_output

--- a/tests/unit/autojac/_transform/test_select.py
+++ b/tests/unit/autojac/_transform/test_select.py
@@ -1,5 +1,4 @@
 import torch
-from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import Select, TensorDict
 
@@ -12,9 +11,9 @@ def test_partition():
     whose keys form a partition of the keys of the TensorDict.
     """
 
-    key1 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device=DEVICE)
-    key2 = torch.tensor([1.0, 3.0, 5.0], device=DEVICE)
-    key3 = torch.tensor(2.0, device=DEVICE)
+    key1 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    key2 = torch.tensor([1.0, 3.0, 5.0])
+    key3 = torch.tensor(2.0)
     value1 = torch.ones_like(key1)
     value2 = torch.ones_like(key2)
     value3 = torch.ones_like(key3)
@@ -40,9 +39,9 @@ def test_conjunction_of_selects_is_select():
     the union of the keys of the 2 Selects.
     """
 
-    x1 = torch.tensor(5.0, device=DEVICE)
-    x2 = torch.tensor(6.0, device=DEVICE)
-    x3 = torch.tensor(7.0, device=DEVICE)
+    x1 = torch.tensor(5.0)
+    x2 = torch.tensor(6.0)
+    x3 = torch.tensor(7.0)
     input = TensorDict({x1: torch.ones_like(x1), x2: torch.ones_like(x2), x3: torch.ones_like(x3)})
 
     select1 = Select([x1], [x1, x2, x3])

--- a/tests/unit/autojac/_transform/test_stack.py
+++ b/tests/unit/autojac/_transform/test_stack.py
@@ -2,7 +2,6 @@ from typing import Iterable
 
 import torch
 from torch import Tensor
-from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import EmptyTensorDict, Gradients, Stack, Transform
 
@@ -36,14 +35,14 @@ def test_single_key():
     example with 2 transforms sharing the same key.
     """
 
-    key = torch.zeros([3, 4], device=DEVICE)
+    key = torch.zeros([3, 4])
     input = EmptyTensorDict()
 
     transform = FakeGradientsTransform([key])
     stack = Stack([transform, transform])
 
     output = stack(input)
-    expected_output = {key: torch.ones([2, 3, 4], device=DEVICE)}
+    expected_output = {key: torch.ones([2, 3, 4])}
 
     assert_tensor_dicts_are_close(output, expected_output)
 
@@ -55,8 +54,8 @@ def test_disjoint_key_sets():
     by zeros.
     """
 
-    key1 = torch.zeros([1, 2], device=DEVICE)
-    key2 = torch.zeros([3], device=DEVICE)
+    key1 = torch.zeros([1, 2])
+    key2 = torch.zeros([3])
     input = EmptyTensorDict()
 
     transform1 = FakeGradientsTransform([key1])
@@ -65,8 +64,8 @@ def test_disjoint_key_sets():
 
     output = stack(input)
     expected_output = {
-        key1: torch.tensor([[[1.0, 1.0]], [[0.0, 0.0]]], device=DEVICE),
-        key2: torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]], device=DEVICE),
+        key1: torch.tensor([[[1.0, 1.0]], [[0.0, 0.0]]]),
+        key2: torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]),
     }
 
     assert_tensor_dicts_are_close(output, expected_output)
@@ -79,9 +78,9 @@ def test_overlapping_key_sets():
     equal). The missing values should be replaced by zeros.
     """
 
-    key1 = torch.zeros([1, 2], device=DEVICE)
-    key2 = torch.zeros([3], device=DEVICE)
-    key3 = torch.zeros([4], device=DEVICE)
+    key1 = torch.zeros([1, 2])
+    key2 = torch.zeros([3])
+    key3 = torch.zeros([4])
     input = EmptyTensorDict()
 
     transform12 = FakeGradientsTransform([key1, key2])
@@ -90,9 +89,9 @@ def test_overlapping_key_sets():
 
     output = stack(input)
     expected_output = {
-        key1: torch.tensor([[[1.0, 1.0]], [[0.0, 0.0]]], device=DEVICE),
-        key2: torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], device=DEVICE),
-        key3: torch.tensor([[0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0]], device=DEVICE),
+        key1: torch.tensor([[[1.0, 1.0]], [[0.0, 0.0]]]),
+        key2: torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]),
+        key3: torch.tensor([[0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0]]),
     }
 
     assert_tensor_dicts_are_close(output, expected_output)

--- a/tests/unit/autojac/_transform/test_tensor_dict.py
+++ b/tests/unit/autojac/_transform/test_tensor_dict.py
@@ -4,7 +4,6 @@ import torch
 from pytest import mark, raises
 from torch import Tensor
 from unit._utils import ExceptionContext
-from unit.conftest import DEVICE
 
 from torchjd.autojac._transform import (
     EmptyTensorDict,
@@ -110,7 +109,4 @@ def _assert_class_checks_properly(
 
 
 def _make_tensor_dict(value_shapes: list[list[int]]) -> dict[Tensor, Tensor]:
-    return {
-        torch.zeros(key, device=DEVICE): torch.zeros(value, device=DEVICE)
-        for key, value in zip(_key_shapes, value_shapes)
-    }
+    return {torch.zeros(key): torch.zeros(value) for key, value in zip(_key_shapes, value_shapes)}

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -1,7 +1,6 @@
 import torch
 from pytest import mark, raises
 from torch.testing import assert_close
-from unit.conftest import DEVICE
 
 from torchjd import backward
 from torchjd.aggregation import MGDA, Aggregator, Mean, Random, UPGrad
@@ -11,10 +10,10 @@ from torchjd.aggregation import MGDA, Aggregator, Mean, Random, UPGrad
 def test_various_aggregators(aggregator: Aggregator):
     """Tests that backward works for various aggregators."""
 
-    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    a2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ a1 + a2.sum()
+    y1 = torch.tensor([-1.0, 1.0]) @ a1 + a2.sum()
     y2 = (a1**2).sum() + a2.norm()
 
     backward([y1, y2], aggregator)
@@ -38,8 +37,8 @@ def test_value_is_correct(
     product.
     """
 
-    J = torch.randn(shape, device=DEVICE)
-    input = torch.randn([shape[1]], requires_grad=True, device=DEVICE)
+    J = torch.randn(shape)
+    input = torch.randn([shape[1]], requires_grad=True)
     output = J @ input  # Note that the Jacobian of output w.r.t. input is J.
 
     if manually_specify_inputs:
@@ -60,10 +59,10 @@ def test_value_is_correct(
 def test_empty_inputs():
     """Tests that backward does not fill the .grad values if no input is specified."""
 
-    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    a2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ a1 + a2.sum()
+    y1 = torch.tensor([-1.0, 1.0]) @ a1 + a2.sum()
     y2 = (a1**2).sum() + a2.norm()
 
     backward([y1, y2], Mean(), inputs=[])
@@ -78,10 +77,10 @@ def test_partial_inputs():
     specified as inputs.
     """
 
-    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    a2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ a1 + a2.sum()
+    y1 = torch.tensor([-1.0, 1.0]) @ a1 + a2.sum()
     y2 = (a1**2).sum() + a2.norm()
 
     backward([y1, y2], Mean(), inputs=[a1])
@@ -93,8 +92,8 @@ def test_partial_inputs():
 def test_empty_tensors_fails():
     """Tests that backward raises an error when called with an empty list of tensors."""
 
-    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    a2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
     with raises(ValueError):
         backward([], UPGrad(), inputs=[a1, a2])
@@ -108,11 +107,11 @@ def test_multiple_tensors():
 
     aggregator = UPGrad()
 
-    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    a2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=True)
     inputs = [a1, a2]
 
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ a1 + a2.sum()
+    y1 = torch.tensor([-1.0, 1.0]) @ a1 + a2.sum()
     y2 = (a1**2).sum() + a2.norm()
 
     backward([y1, y2], aggregator, retain_graph=True)
@@ -131,10 +130,10 @@ def test_multiple_tensors():
 def test_various_valid_chunk_sizes(chunk_size):
     """Tests that backward works for various valid values of parallel_chunk_size."""
 
-    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    a2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ a1 + a2.sum()
+    y1 = torch.tensor([-1.0, 1.0]) @ a1 + a2.sum()
     y2 = (a1**2).sum() + a2.norm()
 
     backward([y1, y2], UPGrad(), parallel_chunk_size=chunk_size)
@@ -147,10 +146,10 @@ def test_various_valid_chunk_sizes(chunk_size):
 def test_non_positive_chunk_size_fails(chunk_size: int):
     """Tests that backward raises an error when using invalid chunk sizes."""
 
-    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    a2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ a1 + a2.sum()
+    y1 = torch.tensor([-1.0, 1.0]) @ a1 + a2.sum()
     y2 = (a1**2).sum() + a2.norm()
 
     with raises(ValueError):
@@ -163,7 +162,7 @@ def test_input_retaining_grad_fails():
     parameter retains grad and vmap has to be used.
     """
 
-    a = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    a = torch.tensor([1.0, 2.0], requires_grad=True)
     b = 2 * a
     b.retain_grad()
     y = 3 * b
@@ -178,7 +177,7 @@ def test_non_input_retaining_grad_fails():
     the ``tensors`` parameter retains grad and vmap has to be used.
     """
 
-    a = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    a = torch.tensor([1.0, 2.0], requires_grad=True)
     b = 2 * a
     b.retain_grad()
     y = 3 * b
@@ -198,7 +197,7 @@ def test_tensor_used_multiple_times(chunk_size: int | None):
     setup, the autograd graph is still acyclic, but the graph of tensors used becomes cyclic.
     """
 
-    a = torch.tensor(3.0, requires_grad=True, device=DEVICE)
+    a = torch.tensor(3.0, requires_grad=True)
     b = 2.0 * a
     c = a * b
     d = a * c
@@ -212,7 +211,6 @@ def test_tensor_used_multiple_times(chunk_size: int | None):
             [2.0 * 3.0 * a**2],
             [2.0 * 4.0 * a**3],
         ],
-        device=DEVICE,
     )
 
     assert_close(a.grad, aggregator(expected_jacobian).squeeze())

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -1,7 +1,6 @@
 import torch
 from pytest import mark, raises
 from torch.testing import assert_close
-from unit.conftest import DEVICE
 
 from torchjd import mtl_backward
 from torchjd.aggregation import MGDA, Aggregator, Mean, Random, UPGrad
@@ -11,11 +10,11 @@ from torchjd.aggregation import MGDA, Aggregator, Mean, Random, UPGrad
 def test_various_aggregators(aggregator: Aggregator):
     """Tests that mtl_backward works for various aggregators."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
-    f1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f1 = torch.tensor([-1.0, 1.0]) @ p0
     f2 = (p0**2).sum() + p0.norm()
     y1 = f1 * p1[0] + f2 * p1[1]
     y2 = f1 * p2[0] + f2 * p2[1]
@@ -46,12 +45,12 @@ def test_value_is_correct(
     This test should work with or without manually specifying the parameters.
     """
 
-    p0 = torch.randn([shape[1]], requires_grad=True, device=DEVICE)
-    p1 = torch.randn(shape[0], requires_grad=True, device=DEVICE)
-    p2 = torch.randn(shape[0], requires_grad=True, device=DEVICE)
-    p3 = torch.randn(shape[0], requires_grad=True, device=DEVICE)
+    p0 = torch.randn([shape[1]], requires_grad=True)
+    p1 = torch.randn(shape[0], requires_grad=True)
+    p2 = torch.randn(shape[0], requires_grad=True)
+    p3 = torch.randn(shape[0], requires_grad=True)
 
-    J = torch.randn(shape, device=DEVICE)
+    J = torch.randn(shape)
     f = J @ p0
     y1 = p1 @ f
     y2 = p2 @ f
@@ -89,9 +88,9 @@ def test_value_is_correct(
 def test_empty_tasks_fails():
     """Tests that mtl_backward raises an error when called with an empty list of tasks."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
 
-    f1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f1 = torch.tensor([-1.0, 1.0]) @ p0
     f2 = (p0**2).sum() + p0.norm()
 
     with raises(ValueError):
@@ -101,10 +100,10 @@ def test_empty_tasks_fails():
 def test_single_task():
     """Tests that mtl_backward works correctly with a single task."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.tensor([3.0, 4.0], requires_grad=True)
 
-    f1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f1 = torch.tensor([-1.0, 1.0]) @ p0
     f2 = (p0**2).sum() + p0.norm()
     y1 = f1 * p1[0] + f2 * p1[1]
 
@@ -120,11 +119,11 @@ def test_incoherent_task_number_fails():
     from the number of tasks parameters.
     """
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
-    f1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f1 = torch.tensor([-1.0, 1.0]) @ p0
     f2 = (p0**2).sum() + p0.norm()
     y1 = f1 * p1[0] + f2 * p1[1]
     y2 = f1 * p2[0] + f2 * p2[1]
@@ -150,11 +149,11 @@ def test_incoherent_task_number_fails():
 def test_empty_params():
     """Tests that mtl_backward does not fill the .grad values if no parameter is specified."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
-    f1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f1 = torch.tensor([-1.0, 1.0]) @ p0
     f2 = (p0**2).sum() + p0.norm()
     y1 = f1 * p1[0] + f2 * p1[1]
     y2 = f1 * p2[0] + f2 * p2[1]
@@ -174,14 +173,14 @@ def test_empty_params():
 def test_multiple_params_per_task():
     """Tests that mtl_backward works correctly when the tasks each have several parameters."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1_a = torch.tensor(1.0, requires_grad=True, device=DEVICE)
-    p1_b = torch.tensor([2.0, 3.0], requires_grad=True, device=DEVICE)
-    p1_c = torch.tensor([[4.0, 5.0], [6.0, 7.0]], requires_grad=True, device=DEVICE)
-    p2_a = torch.tensor(8.0, requires_grad=True, device=DEVICE)
-    p2_b = torch.tensor([9.0, 10.0], requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1_a = torch.tensor(1.0, requires_grad=True)
+    p1_b = torch.tensor([2.0, 3.0], requires_grad=True)
+    p1_c = torch.tensor([[4.0, 5.0], [6.0, 7.0]], requires_grad=True)
+    p2_a = torch.tensor(8.0, requires_grad=True)
+    p2_b = torch.tensor([9.0, 10.0], requires_grad=True)
 
-    f1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f1 = torch.tensor([-1.0, 1.0]) @ p0
     f2 = (p0**2).sum() + p0.norm()
     y1 = f1 * p1_a + (f2 * p1_b).sum() + (f1 * p1_c).sum()
     y2 = f1 * p2_a * (f2 * p2_b).sum()
@@ -208,11 +207,9 @@ def test_multiple_params_per_task():
 def test_various_shared_params(shared_params_shapes: list[tuple[int]]):
     """Tests that mtl_backward works correctly with various kinds of shared_params."""
 
-    shared_params = [
-        torch.rand(shape, requires_grad=True, device=DEVICE) for shape in shared_params_shapes
-    ]
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    shared_params = [torch.rand(shape, requires_grad=True) for shape in shared_params_shapes]
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
     features = [shared_param.sum(dim=-1) for shared_param in shared_params]
     y1 = torch.stack([f.sum() for f in features]).sum()
@@ -236,11 +233,11 @@ def test_partial_params():
     specified as inputs.
     """
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
-    f1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f1 = torch.tensor([-1.0, 1.0]) @ p0
     f2 = (p0**2).sum() + p0.norm()
     y1 = f1 * p1[0] + f2 * p1[1]
     y2 = f1 * p2[0] + f2 * p2[1]
@@ -261,11 +258,11 @@ def test_partial_params():
 def test_empty_features_fails():
     """Tests that mtl_backward expectedly raises an error when no there is no feature."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
-    f1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f1 = torch.tensor([-1.0, 1.0]) @ p0
     f2 = (p0**2).sum() + p0.norm()
     y1 = f1 * p1[0] + f2 * p1[1]
     y2 = f1 * p2[0] + f2 * p2[1]
@@ -286,11 +283,11 @@ def test_empty_features_fails():
 def test_various_single_features(shape: tuple[int, ...]):
     """Tests that mtl_backward works correctly with various kinds of feature tensors."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
-    p2 = torch.tensor([5.0, 6.0], requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.tensor([3.0, 4.0], requires_grad=True)
+    p2 = torch.tensor([5.0, 6.0], requires_grad=True)
 
-    f = torch.rand(shape, device=DEVICE) @ p0
+    f = torch.rand(shape) @ p0
 
     y1 = (f * p1[0]).sum() + (f * p1[1]).sum()
     y2 = (f * p2[0]).sum() * (f * p2[1]).sum()
@@ -317,11 +314,11 @@ def test_various_single_features(shape: tuple[int, ...]):
 def test_various_feature_lists(shapes: list[tuple[int]]):
     """Tests that mtl_backward works correctly with various kinds of feature lists."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1 = torch.arange(len(shapes), dtype=torch.float32, requires_grad=True, device=DEVICE)
-    p2 = torch.tensor(5.0, requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.arange(len(shapes), dtype=torch.float32, requires_grad=True)
+    p2 = torch.tensor(5.0, requires_grad=True)
 
-    features = [torch.rand(shape, device=DEVICE) @ p0 for shape in shapes]
+    features = [torch.rand(shape) @ p0 for shape in shapes]
 
     y1 = sum([(f * p).sum() for f, p in zip(features, p1)])
     y2 = (features[0] * p2).sum()
@@ -335,11 +332,11 @@ def test_various_feature_lists(shapes: list[tuple[int]]):
 def test_non_scalar_loss_fails():
     """Tests that mtl_backward raises an error when used with a non-scalar loss."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
-    f1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f1 = torch.tensor([-1.0, 1.0]) @ p0
     f2 = (p0**2).sum() + p0.norm()
     y1 = torch.stack([f1 * p1[0], f2 * p1[1]])  # Non-scalar
     y2 = f1 * p2[0] + f2 * p2[1]
@@ -352,11 +349,11 @@ def test_non_scalar_loss_fails():
 def test_various_valid_chunk_sizes(chunk_size):
     """Tests that mtl_backward works for various valid values of parallel_chunk_size."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
-    f1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f1 = torch.tensor([-1.0, 1.0]) @ p0
     f2 = (p0**2).sum() + p0.norm()
     y1 = f1 * p1[0] + f2 * p1[1]
     y2 = f1 * p2[0] + f2 * p2[1]
@@ -376,11 +373,11 @@ def test_various_valid_chunk_sizes(chunk_size):
 def test_non_positive_chunk_size_fails(chunk_size: int):
     """Tests that mtl_backward raises an error when using invalid chunk sizes."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
-    f1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f1 = torch.tensor([-1.0, 1.0]) @ p0
     f2 = (p0**2).sum() + p0.norm()
     y1 = f1 * p1[0] + f2 * p1[1]
     y2 = f1 * p2[0] + f2 * p2[1]
@@ -400,9 +397,9 @@ def test_shared_param_retaining_grad_fails():
     ``features`` parameter retains grad and vmap has to be used.
     """
 
-    p0 = torch.tensor(1.0, requires_grad=True, device=DEVICE)
-    p1 = torch.tensor(2.0, requires_grad=True, device=DEVICE)
-    p2 = torch.tensor(3.0, requires_grad=True, device=DEVICE)
+    p0 = torch.tensor(1.0, requires_grad=True)
+    p1 = torch.tensor(2.0, requires_grad=True)
+    p2 = torch.tensor(3.0, requires_grad=True)
 
     a = 2 * p0
     a.retain_grad()
@@ -426,9 +423,9 @@ def test_shared_activation_retaining_grad_fails():
     of the ``features`` parameter retains grad and vmap has to be used.
     """
 
-    p0 = torch.tensor(1.0, requires_grad=True, device=DEVICE)
-    p1 = torch.tensor(2.0, requires_grad=True, device=DEVICE)
-    p2 = torch.tensor(3.0, requires_grad=True, device=DEVICE)
+    p0 = torch.tensor(1.0, requires_grad=True)
+    p1 = torch.tensor(2.0, requires_grad=True)
+    p2 = torch.tensor(3.0, requires_grad=True)
 
     a = 2 * p0
     a.retain_grad()
@@ -453,12 +450,12 @@ def test_shared_activation_retaining_grad_fails():
 def test_tasks_params_overlap():
     """Tests that mtl_backward works correctly when the tasks' parameters have some overlap."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1 = torch.tensor(2.0, requires_grad=True, device=DEVICE)
-    p2 = torch.tensor(3.0, requires_grad=True, device=DEVICE)
-    p12 = torch.tensor(4.0, requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.tensor(2.0, requires_grad=True)
+    p2 = torch.tensor(3.0, requires_grad=True)
+    p12 = torch.tensor(4.0, requires_grad=True)
 
-    f = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f = torch.tensor([-1.0, 1.0]) @ p0
     y1 = f * p1 * p12
     y2 = f * p2 * p12
 
@@ -469,17 +466,17 @@ def test_tasks_params_overlap():
     assert_close(p1.grad, f * p12)
     assert_close(p12.grad, f * p1 + f * p2)
 
-    J = torch.tensor([[-p1 * p12, p1 * p12], [-p2 * p12, p2 * p12]], device=DEVICE)
+    J = torch.tensor([[-p1 * p12, p1 * p12], [-p2 * p12, p2 * p12]])
     assert_close(p0.grad, aggregator(J))
 
 
 def test_tasks_params_are_the_same():
     """Tests that mtl_backward works correctly when the tasks have the same params."""
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1 = torch.tensor(2.0, requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.tensor(2.0, requires_grad=True)
 
-    f = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f = torch.tensor([-1.0, 1.0]) @ p0
     y1 = f * p1
     y2 = f + p1
 
@@ -488,7 +485,7 @@ def test_tasks_params_are_the_same():
 
     assert_close(p1.grad, f + 1)
 
-    J = torch.tensor([[-p1, p1], [-1.0, 1.0]], device=DEVICE)
+    J = torch.tensor([[-p1, p1], [-1.0, 1.0]])
     assert_close(p0.grad, aggregator(J))
 
 
@@ -498,11 +495,11 @@ def test_task_params_is_subset_of_other_task_params():
     params.
     """
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1 = torch.tensor(2.0, requires_grad=True, device=DEVICE)
-    p2 = torch.tensor(3.0, requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.tensor(2.0, requires_grad=True)
+    p2 = torch.tensor(3.0, requires_grad=True)
 
-    f = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f = torch.tensor([-1.0, 1.0]) @ p0
     y1 = f * p1
     y2 = y1 * p2
 
@@ -512,7 +509,7 @@ def test_task_params_is_subset_of_other_task_params():
     assert_close(p2.grad, y1)
     assert_close(p1.grad, p2 * f + f)
 
-    J = torch.tensor([[-p1, p1], [-p1 * p2, p1 * p2]], device=DEVICE)
+    J = torch.tensor([[-p1, p1], [-p1 * p2, p1 * p2]])
     assert_close(p0.grad, aggregator(J))
 
 
@@ -522,11 +519,11 @@ def test_shared_params_overlapping_with_tasks_params_fails():
     task-specific params.
     """
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1 = torch.tensor(2.0, requires_grad=True, device=DEVICE)
-    p2 = torch.tensor(3.0, requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.tensor(2.0, requires_grad=True)
+    p2 = torch.tensor(3.0, requires_grad=True)
 
-    f = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f = torch.tensor([-1.0, 1.0]) @ p0
     y1 = f * p1
     y2 = p0.sum() * f * p2
 
@@ -546,11 +543,11 @@ def test_default_shared_params_overlapping_with_default_tasks_params_fails():
     overlaps with the set of task-specific params obtained by default.
     """
 
-    p0 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    p1 = torch.tensor(2.0, requires_grad=True, device=DEVICE)
-    p2 = torch.tensor(3.0, requires_grad=True, device=DEVICE)
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.tensor(2.0, requires_grad=True)
+    p2 = torch.tensor(3.0, requires_grad=True)
 
-    f = torch.tensor([-1.0, 1.0], device=DEVICE) @ p0
+    f = torch.tensor([-1.0, 1.0]) @ p0
     y1 = f * p1
     y2 = p0.sum() * f * p2
 

--- a/tests/unit/autojac/test_utils.py
+++ b/tests/unit/autojac/test_utils.py
@@ -1,7 +1,6 @@
 import torch
 from pytest import mark, raises
 from torch.nn import Linear, MSELoss, ReLU, Sequential
-from unit.conftest import DEVICE
 
 from torchjd.autojac._utils import _get_leaf_tensors
 
@@ -9,10 +8,10 @@ from torchjd.autojac._utils import _get_leaf_tensors
 def test_simple_get_leaf_tensors():
     """Tests that _get_leaf_tensors works correctly in a very simple setting."""
 
-    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    a2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ a1 + a2.sum()
+    y1 = torch.tensor([-1.0, 1.0]) @ a1 + a2.sum()
     y2 = (a1**2).sum() + a2.norm()
 
     leaves = _get_leaf_tensors(tensors=[y1, y2], excluded=set())
@@ -27,13 +26,13 @@ def test_get_leaf_tensors_excluded_1():
     is excluded from the graph traversal.
     """
 
-    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    a2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
     b1 = (a1**2).sum()
     b2 = (a2**2).sum()
 
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ a1 + b2
+    y1 = torch.tensor([-1.0, 1.0]) @ a1 + b2
     y2 = b1
 
     leaves = _get_leaf_tensors(tensors=[y1, y2], excluded={b1, b2})
@@ -48,13 +47,13 @@ def test_get_leaf_tensors_excluded_2():
     `a1` and `a2` from another path, so these two tensors should be in the result.
     """
 
-    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    a2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
     b1 = (a1**2).sum()
     b2 = (a2**2).sum()
 
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ a1 + a2.sum()
+    y1 = torch.tensor([-1.0, 1.0]) @ a1 + a2.sum()
     y2 = b1
 
     leaves = _get_leaf_tensors(tensors=[y1, y2], excluded={b1, b2})
@@ -66,10 +65,10 @@ def test_get_leaf_tensors_leaf_not_requiring_grad():
     Tests that _get_leaf_tensors does not include tensors that do not require grad in its results.
     """
 
-    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    a2 = torch.tensor([3.0, 4.0], requires_grad=False, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=False)
 
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ a1 + a2.sum()
+    y1 = torch.tensor([-1.0, 1.0]) @ a1 + a2.sum()
     y2 = (a1**2).sum() + a2.norm()
 
     leaves = _get_leaf_tensors(tensors=[y1, y2], excluded=set())
@@ -119,7 +118,7 @@ def test_get_leaf_tensors_model_excluded_2():
 def test_get_leaf_tensors_single_root():
     """Tests that _get_leaf_tensors returns no leaves when roots is the empty set."""
 
-    p = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
+    p = torch.tensor([1.0, 2.0], requires_grad=True)
     y = p * 2
 
     leaves = _get_leaf_tensors(tensors=[y], excluded=set())
@@ -136,10 +135,10 @@ def test_get_leaf_tensors_empty_roots():
 def test_get_leaf_tensors_excluded_root():
     """Tests that _get_leaf_tensors correctly excludes the root."""
 
-    a1 = torch.tensor([1.0, 2.0], requires_grad=True, device=DEVICE)
-    a2 = torch.tensor([3.0, 4.0], requires_grad=True, device=DEVICE)
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=True)
 
-    y1 = torch.tensor([-1.0, 1.0], device=DEVICE) @ a1 + a2.sum()
+    y1 = torch.tensor([-1.0, 1.0]) @ a1 + a2.sum()
     y2 = (a1**2).sum()
 
     leaves = _get_leaf_tensors(tensors=[y1, y2], excluded={y1})
@@ -150,8 +149,8 @@ def test_get_leaf_tensors_excluded_root():
 def test_get_leaf_tensors_deep(depth: int):
     """Tests that _get_leaf_tensors works when the graph is very deep."""
 
-    one = torch.tensor(1.0, requires_grad=True, device=DEVICE)
-    sum_ = torch.tensor(0.0, requires_grad=False, device=DEVICE)
+    one = torch.tensor(1.0, requires_grad=True)
+    sum_ = torch.tensor(0.0, requires_grad=False)
     for i in range(depth):
         sum_ = sum_ + one
 
@@ -162,7 +161,7 @@ def test_get_leaf_tensors_deep(depth: int):
 def test_get_leaf_tensors_leaf():
     """Tests that _get_leaf_tensors raises an error some of the provided tensors are leaves."""
 
-    a = torch.tensor(1.0, requires_grad=True, device=DEVICE)
+    a = torch.tensor(1.0, requires_grad=True)
     with raises(ValueError):
         _ = _get_leaf_tensors(tensors=[a], excluded=set())
 
@@ -172,7 +171,7 @@ def test_get_leaf_tensors_tensor_not_requiring_grad():
     Tests that _get_leaf_tensors raises an error some of the provided tensors do not require grad.
     """
 
-    a = torch.tensor(1.0, requires_grad=False, device=DEVICE) * 2
+    a = torch.tensor(1.0, requires_grad=False) * 2
     with raises(ValueError):
         _ = _get_leaf_tensors(tensors=[a], excluded=set())
 
@@ -180,8 +179,8 @@ def test_get_leaf_tensors_tensor_not_requiring_grad():
 def test_get_leaf_tensors_excluded_leaf():
     """Tests that _get_leaf_tensors raises an error some of the excluded tensors are leaves."""
 
-    a = torch.tensor(1.0, requires_grad=True, device=DEVICE) * 2
-    b = torch.tensor(2.0, requires_grad=True, device=DEVICE)
+    a = torch.tensor(1.0, requires_grad=True) * 2
+    b = torch.tensor(2.0, requires_grad=True)
     with raises(ValueError):
         _ = _get_leaf_tensors(tensors=[a], excluded={b})
 
@@ -191,7 +190,7 @@ def test_get_leaf_tensors_excluded_not_requiring_grad():
     Tests that _get_leaf_tensors raises an error some of the excluded tensors do not require grad.
     """
 
-    a = torch.tensor(1.0, requires_grad=True, device=DEVICE) * 2
-    b = torch.tensor(2.0, requires_grad=False, device=DEVICE) * 2
+    a = torch.tensor(1.0, requires_grad=True) * 2
+    b = torch.tensor(2.0, requires_grad=False) * 2
     with raises(ValueError):
         _ = _get_leaf_tensors(tensors=[a], excluded={b})

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,6 +16,7 @@ if _device_str == "cuda:0" and not torch.cuda.is_available():
     raise ValueError('Requested device "cuda:0" but cuda is not available.')
 
 DEVICE = torch.device(_device_str)
+torch.set_default_device(DEVICE)
 
 
 @fixture(autouse=True)


### PR DESCRIPTION
- **Force device to be cpu for some representation tests** => It will be easier to test them that way. That's equivalent to what we had before.
- **Use set_default_device instead of always specifying the device** => This makes our lines much shorter, and it makes it impossible to forget about the `, device=DEVICE` when instantiating a tensor.

CUDA tests still all pass and take roughly the same time as before so this works.