### PR TITLE
Add casts to correct dtypes when converting a Tensor to a np.array

### DIFF
--- a/src/torchjd/aggregation/cagrad.py
+++ b/src/torchjd/aggregation/cagrad.py
@@ -76,7 +76,7 @@ class _CAGradWeighting(_Weighting):
         U, S, _ = torch.svd(gramian)
 
         reduced_matrix = U @ S.sqrt().diag()
-        reduced_array = reduced_matrix.cpu().detach().numpy()
+        reduced_array = reduced_matrix.cpu().detach().numpy().astype(np.float64)
 
         dimension = matrix.shape[0]
         reduced_g_0 = reduced_array.T @ np.ones(dimension) / dimension

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -107,10 +107,10 @@ class _DualProjWrapper(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         weights = self.weighting(matrix)
-        weights_array = weights.cpu().detach().numpy()
+        weights_array = weights.cpu().detach().numpy().astype(np.float64)
 
         gramian = _compute_normalized_gramian(matrix, self.norm_eps)
-        gramian_array = gramian.cpu().detach().numpy()
+        gramian_array = gramian.cpu().detach().numpy().astype(np.float64)
         dimension = gramian.shape[0]
 
         # Because of numerical errors, `gramian_array` might have slightly negative eigenvalue(s),

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -109,7 +109,7 @@ class _UPGradWrapper(_Weighting):
 
     def _compute_lagrangian(self, matrix: Tensor, weights: Tensor) -> Tensor:
         gramian = _compute_normalized_gramian(matrix, self.norm_eps)
-        gramian_array = gramian.cpu().detach().numpy()
+        gramian_array = gramian.cpu().detach().numpy().astype(np.float64)
         dimension = gramian.shape[0]
 
         regularization_array = self.reg_eps * np.eye(dimension)


### PR DESCRIPTION
- Fix #235 

The strategy was to set the type of a cast to a numpy array whenever the array was used in an operation that cast the type. So this makes every cast explicit.