### PR TITLE
Refactor dual cone projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ changes that do not affect the user.
 
 ## [Unreleased]
 
+### Changed
+
+- Refactored the underlying optimization problem that `UPGrad` and `DualProj` have to solve to
+  project onto the dual cone. This may minimally affect the output of these aggregators.
+
 ## [0.5.0] - 2025-02-01
 
 ### Added

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -27,13 +27,17 @@ def _get_projection_weights(
 
     gramian_array = gramian.cpu().detach().numpy().astype(np.float64)
 
-    lagrangian_rows = []
+    lagrange_multipliers_rows = []
     for weight_array in weights_list:
-        lagrangian_rows.append(_get_lagrange_multipliers(gramian_array, weight_array, solver))
+        lagrange_multipliers_rows.append(
+            _get_lagrange_multipliers(gramian_array, weight_array, solver)
+        )
 
-    lagrangian_array = np.stack(lagrangian_rows).T.reshape(shape)
-    lagrangian = torch.from_numpy(lagrangian_array).to(device=gramian.device, dtype=gramian.dtype)
-    return lagrangian + weights
+    lagrange_array = np.stack(lagrange_multipliers_rows).T.reshape(shape)
+    lagrange_multipliers = torch.from_numpy(lagrange_array).to(
+        device=gramian.device, dtype=gramian.dtype
+    )
+    return lagrange_multipliers + weights
 
 
 def _get_lagrange_multipliers(

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -6,7 +6,7 @@ from qpsolvers import solve_qp
 from torch import Tensor
 
 
-def _weights_of_projection_onto_dual_cone(
+def _get_projection_weights(
     gramian: Tensor, weights: Tensor, solver: Literal["quadprog"]
 ) -> Tensor:
     """
@@ -29,14 +29,14 @@ def _weights_of_projection_onto_dual_cone(
 
     lagrangian_rows = []
     for weight_array in weights_list:
-        lagrangian_rows.append(_lagrange_multipliers(gramian_array, weight_array, solver))
+        lagrangian_rows.append(_get_lagrange_multipliers(gramian_array, weight_array, solver))
 
     lagrangian_array = np.stack(lagrangian_rows).T.reshape(shape)
     lagrangian = torch.from_numpy(lagrangian_array).to(device=gramian.device, dtype=gramian.dtype)
     return lagrangian + weights
 
 
-def _lagrange_multipliers(
+def _get_lagrange_multipliers(
     gramian_array: np.array, weight_array: np.array, solver: Literal["quadprog"]
 ) -> np.array:
     """

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -9,14 +9,36 @@ from torch import Tensor
 def _get_projection_weights(
     gramian: Tensor, weights: Tensor, solver: Literal["quadprog"]
 ) -> Tensor:
-    """
-    Computes the weights of the projection of some weights onto the dual cone of a matrix whose
-    gramian is provided. Specifically, this solves for $w$ in the problem defined by (5) in
-    Proposition 1 of [1] when the gramian is $JJ^\top$ and $v$ is given by weights.
-    This is a vectorized version, therefore weights can be a matrix made of columns of weights.
+    r"""
+    Computes the projection weights of a tensor of weights onto the dual cone of a matrix, given
+    its Gramian matrix.
 
+    Specifically, as stated in Proposition 1 of [1], let:
+    - `J` be a matrix,
+    - `G = J J^\top` its Gramian,
+    - `u` a vector.
+
+    The projection of `J^\top u` onto the dual cone of `J` is `J^\top w`, where `w` is the solution
+    to the optimization problem:
+
+        minimize        v^\top G v
+        subject to      u \preceq v
+
+    This function calculates `w` when provided with `G` and `u`.
+
+    Reference:
     [1] `Jacobian Descent For Multi-Objective Optimization <https://arxiv.org/pdf/2406.16232>`_.
+
+    **Note:** This function is tensorized, meaning `weights` can be a tensor with additional batch
+    dimensions rather than a single vector.
+
+
+    :param gramian: The Gramian matrix with shape `[n, n]`.
+    :param weights: A tensor of weights to be projected with shape `[*, n]`.
+    :param solver: The quadratic programming solver to use.
+    :return: A tensor of projection weights with shape `[*, n]`, corresponding to `weights`.
     """
+
     lagrange_multipliers = _get_lagrange_multipliers(gramian, weights, solver)
     return lagrange_multipliers + weights
 

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -29,11 +29,10 @@ def _get_lagrange_multipliers(
 
     gramian_array = gramian.cpu().detach().numpy().astype(np.float64)
 
-    lagrange_multipliers_rows = []
-    for weight_array in weights_matrix:
-        lagrange_multipliers_rows.append(
-            _get_lagrange_multipliers_array(gramian_array, weight_array, solver)
-        )
+    lagrange_multipliers_rows = [
+        _get_lagrange_multipliers_array(gramian_array, weight_array, solver)
+        for weight_array in weights_matrix
+    ]
 
     lagrange_array = np.stack(lagrange_multipliers_rows).T
     lagrange_multipliers = torch.from_numpy(lagrange_array).to(

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -15,7 +15,7 @@ def _weights_of_projection_onto_dual_cone(
     Proposition 1 of [1] when the gramian is $JJ^\top$ and $v$ is given by weights.
     This is a vectorized version, therefore weights can be a matrix made of columns of weights.
 
-    [1] Jacobian Descent For Multi-Objective Optimization, Quinton and Rey.
+    [1] `Jacobian Descent For Multi-Objective Optimization <https://arxiv.org/pdf/2406.16232>`_.
     """
     shape = weights.shape
     if len(shape) == 1:

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -32,7 +32,6 @@ def _project_weight_vector(u: np.ndarray, G: np.ndarray, solver: Literal["quadpr
     `\pi_J(J^T u) = J^T w`.
 
     By Proposition 1 of [1], this is equivalent to solving for `v` the following quadratic program:
-
     minimize        v^T G v
     subject to      u \preceq v
 

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -60,7 +60,7 @@ def _get_projection_weight_vector(
     gramian: np.array, weight_vector: np.array, solver: Literal["quadprog"]
 ) -> np.array:
     r"""
-    Solves the problem
+    Solves for `v` the quadratic problem
 
         minimize        v^\top G v
         subject to      u \preceq v

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -24,11 +24,12 @@ def _get_projection_weights(
 def _get_lagrange_multipliers(
     gramian: Tensor, weights: Tensor, solver: Literal["quadprog"]
 ) -> Tensor:
+    weights_array = weights.cpu().detach().numpy().astype(np.float64)
     shape = weights.shape
     if len(shape) == 1:
-        weights_list = [weights.cpu().detach().numpy().astype(np.float64)]
+        weights_list = [weights_array]
     elif len(shape) == 2:
-        weights_list = [weight.cpu().detach().numpy().astype(np.float64) for weight in weights.T]
+        weights_list = [weight for weight in weights_array.T]
     else:
         raise ValueError(f"Expect vector or matrix of weights, found shape {shape}")
 

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -32,7 +32,7 @@ def _get_lagrange_multipliers(
         for weight_vector in weight_matrix
     ]
 
-    lagrange_multiplier_matrix = np.stack(lagrange_multiplier_vectors).T
+    lagrange_multiplier_matrix = np.stack(lagrange_multiplier_vectors)
     lagrange_multipliers = (
         torch.from_numpy(lagrange_multiplier_matrix)
         .to(device=gramian.device, dtype=gramian.dtype)

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -1,0 +1,61 @@
+from typing import Literal
+
+import numpy as np
+import torch
+from qpsolvers import solve_qp
+from torch import Tensor
+
+
+def _weights_of_projection_onto_dual_cone(
+    gramian: Tensor, weights: Tensor, reg_eps: float, solver: Literal["quadprog"]
+) -> Tensor:
+    """
+    Computes the weights of the projection of some weights onto the dual cone of a matrix whose
+    gramian is provided. Specifically, this solves for $w$ in the problem defined by (5) in
+    Proposition 1 of [1] when the gramian is $JJ^\top$ and $v$ is given by weights.
+    This is a vectorized version, therefore weights can be a matrix made of columns of weights.
+
+    [1] Jacobian Descent For Multi-Objective Optimization, Quinton and Rey.
+    """
+    shape = weights.shape
+    if len(shape) == 1:
+        weights_list = [weights]
+    elif len(shape) == 2:
+        weights_list = [weight for weight in weights.T]
+    else:
+        raise ValueError(f"Expect vector or matrix of weights, found shape {shape}")
+
+    gramian_array = gramian.cpu().detach().numpy().astype(np.float64)
+    dimension = gramian.shape[0]
+
+    # Because of numerical errors, `gramian_array` might have slightly negative eigenvalue(s),
+    # which makes quadprog misbehave. Adding a regularization term which is a small proportion
+    # of the identity matrix ensures that the gramian is positive definite.
+    regularization_array = reg_eps * np.eye(dimension)
+    regularized_gramian_array = gramian_array + regularization_array
+
+    lagrangian_rows = []
+    for weight in weights_list:
+        weight_array = weight.cpu().detach().numpy().astype(np.float64)
+        lagrangian_rows.append(
+            _lagrange_multipliers(regularized_gramian_array, weight_array, solver)
+        )
+
+    lagrangian_array = np.stack(lagrangian_rows).T.reshape(shape)
+    lagrangian = torch.from_numpy(lagrangian_array).to(device=gramian.device, dtype=gramian.dtype)
+    return lagrangian + weights
+
+
+def _lagrange_multipliers(
+    gramian_array: np.array, weight_array: np.array, solver: Literal["quadprog"]
+) -> np.array:
+    """
+    Solves the dual of the projection of a vector of weights onto the dual cone of the matrix J
+    whose gramian is given.
+    """
+    dimension = gramian_array.shape[0]
+    P = gramian_array
+    q = gramian_array @ weight_array
+    G = -np.eye(dimension)
+    h = np.zeros(dimension)
+    return solve_qp(P, q, G, h, solver=solver)

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -6,24 +6,23 @@ from qpsolvers import solve_qp
 from torch import Tensor
 
 
-def _project_weights(weights: Tensor, gramian: Tensor, solver: Literal["quadprog"]) -> Tensor:
+def _project_weights(U: Tensor, G: Tensor, solver: Literal["quadprog"]) -> Tensor:
     """
-    Computes the tensor of weights corresponding to the projection of the vectors in `weights` onto
-    the rows of a matrix `J`, whose Gramian is provided.
+    Computes the tensor of weights corresponding to the projection of the vectors in `U` onto the
+    rows of a matrix whose Gramian is provided.
 
-    :param weights: The tensor of weights corresponding to the vectors to project, of shape
-        `[..., m]`.
-    :param gramian: The Gramian matrix of shape `[m, m]`.
+    :param U: The tensor of weights corresponding to the vectors to project, of shape `[..., m]`.
+    :param G: The Gramian matrix of shape `[m, m]`.
     :param solver: The quadratic programming solver to use.
-    :return: A tensor of projection weights with the same shape as `weights`.
+    :return: A tensor of projection weights with the same shape as `U`.
     """
 
-    G = _to_array(gramian)
-    U = _to_array(weights)
+    G_ = _to_array(G)
+    U_ = _to_array(U)
 
-    W = np.apply_along_axis(lambda u: _project_weight_vector(u, G, solver), axis=-1, arr=U)
+    W = np.apply_along_axis(lambda u: _project_weight_vector(u, G_, solver), axis=-1, arr=U_)
 
-    return torch.as_tensor(W, device=gramian.device, dtype=gramian.dtype)
+    return torch.as_tensor(W, device=G.device, dtype=G.dtype)
 
 
 def _project_weight_vector(u: np.ndarray, G: np.ndarray, solver: Literal["quadprog"]) -> np.ndarray:

--- a/src/torchjd/aggregation/_gramian_utils.py
+++ b/src/torchjd/aggregation/_gramian_utils.py
@@ -10,12 +10,12 @@ def _compute_gramian(matrix: Tensor) -> Tensor:
     return matrix @ matrix.T
 
 
-def _normalize_and_regularize(matrix: Tensor, norm_eps: float, reg_eps: float):
-    normalized_gramian = _normalize(matrix, norm_eps)
+def _compute_regularized_normalized_gramian(matrix: Tensor, norm_eps: float, reg_eps: float):
+    normalized_gramian = _compute_normalized_gramian(matrix, norm_eps)
     return _regularize(normalized_gramian, reg_eps)
 
 
-def _normalize(matrix: Tensor, eps: float) -> Tensor:
+def _compute_normalized_gramian(matrix: Tensor, eps: float) -> Tensor:
     r"""
     Computes :math:`\frac{1}{\sigma_\max^2} J J^T` for an input matrix :math:`J`, where
     :math:`{\sigma_\max^2}` is :math:`J`'s largest singular value.

--- a/src/torchjd/aggregation/_gramian_utils.py
+++ b/src/torchjd/aggregation/_gramian_utils.py
@@ -51,5 +51,7 @@ def _compute_normalized_regularized_gramian(matrix: Tensor, norm_eps: float, reg
 
 
 def _regularize_gramian(gramian: Tensor, reg_eps: float) -> Tensor:
+    # Because of numerical errors, `gramian` might have slightly negative eigenvalue(s).
+    # Adding a regularization term which is a small proportion of the identity matrix ensures that the gramian is positive definite.
     regularization_matrix = reg_eps * torch.eye(gramian.shape[0])
     return gramian + regularization_matrix

--- a/src/torchjd/aggregation/_gramian_utils.py
+++ b/src/torchjd/aggregation/_gramian_utils.py
@@ -15,7 +15,7 @@ def _normalize_and_regularize(matrix: Tensor, norm_eps: float, reg_eps: float):
     return _regularize(normalized_gramian, reg_eps)
 
 
-def _normalize(matrix: Tensor, norm_eps: float) -> Tensor:
+def _normalize(matrix: Tensor, eps: float) -> Tensor:
     r"""
     Computes :math:`\frac{1}{\sigma_\max^2} J J^T` for an input matrix :math:`J`, where
     :math:`{\sigma_\max^2}` is :math:`J`'s largest singular value.
@@ -40,7 +40,7 @@ def _normalize(matrix: Tensor, norm_eps: float) -> Tensor:
             "issue on https://github.com/TorchJD/torchjd/issues and paste this error message in it."
         ) from error
     max_singular_value = torch.max(singular_values)
-    if max_singular_value < norm_eps:
+    if max_singular_value < eps:
         scaled_singular_values = torch.zeros_like(singular_values)
     else:
         scaled_singular_values = singular_values / max_singular_value
@@ -50,8 +50,8 @@ def _normalize(matrix: Tensor, norm_eps: float) -> Tensor:
     return normalized_gramian
 
 
-def _regularize(gramian: Tensor, reg_eps: float) -> Tensor:
+def _regularize(gramian: Tensor, eps: float) -> Tensor:
     # Because of numerical errors, `gramian` might have slightly negative eigenvalue(s).
     # Adding a regularization term which is a small proportion of the identity matrix ensures that the gramian is positive definite.
-    regularization_matrix = reg_eps * torch.eye(gramian.shape[0])
+    regularization_matrix = eps * torch.eye(gramian.shape[0])
     return gramian + regularization_matrix

--- a/src/torchjd/aggregation/_gramian_utils.py
+++ b/src/torchjd/aggregation/_gramian_utils.py
@@ -10,6 +10,11 @@ def _compute_gramian(matrix: Tensor) -> Tensor:
     return matrix @ matrix.T
 
 
+def _normalize_and_regularize(matrix: Tensor, norm_eps: float, reg_eps: float):
+    normalized_gramian = _normalize(matrix, norm_eps)
+    return _regularize(normalized_gramian, reg_eps)
+
+
 def _normalize(matrix: Tensor, norm_eps: float) -> Tensor:
     r"""
     Computes :math:`\frac{1}{\sigma_\max^2} J J^T` for an input matrix :math:`J`, where
@@ -43,11 +48,6 @@ def _normalize(matrix: Tensor, norm_eps: float) -> Tensor:
         left_unitary_matrix @ torch.diag(scaled_singular_values**2) @ left_unitary_matrix.T
     )
     return normalized_gramian
-
-
-def _normalize_and_regularize(matrix: Tensor, norm_eps: float, reg_eps: float):
-    normalized_gramian = _normalize(matrix, norm_eps)
-    return _regularize(normalized_gramian, reg_eps)
 
 
 def _regularize(gramian: Tensor, reg_eps: float) -> Tensor:

--- a/src/torchjd/aggregation/_gramian_utils.py
+++ b/src/torchjd/aggregation/_gramian_utils.py
@@ -10,7 +10,7 @@ def _compute_gramian(matrix: Tensor) -> Tensor:
     return matrix @ matrix.T
 
 
-def _compute_normalized_gramian(matrix: Tensor, norm_eps: float) -> Tensor:
+def _normalize(matrix: Tensor, norm_eps: float) -> Tensor:
     r"""
     Computes :math:`\frac{1}{\sigma_\max^2} J J^T` for an input matrix :math:`J`, where
     :math:`{\sigma_\max^2}` is :math:`J`'s largest singular value.
@@ -45,12 +45,12 @@ def _compute_normalized_gramian(matrix: Tensor, norm_eps: float) -> Tensor:
     return normalized_gramian
 
 
-def _compute_normalized_regularized_gramian(matrix: Tensor, norm_eps: float, reg_eps: float):
-    normalized_gramian = _compute_normalized_gramian(matrix, norm_eps)
-    return _regularize_gramian(normalized_gramian, reg_eps)
+def _normalize_and_regularize(matrix: Tensor, norm_eps: float, reg_eps: float):
+    normalized_gramian = _normalize(matrix, norm_eps)
+    return _regularize(normalized_gramian, reg_eps)
 
 
-def _regularize_gramian(gramian: Tensor, reg_eps: float) -> Tensor:
+def _regularize(gramian: Tensor, reg_eps: float) -> Tensor:
     # Because of numerical errors, `gramian` might have slightly negative eigenvalue(s).
     # Adding a regularization term which is a small proportion of the identity matrix ensures that the gramian is positive definite.
     regularization_matrix = reg_eps * torch.eye(gramian.shape[0])

--- a/src/torchjd/aggregation/_gramian_utils.py
+++ b/src/torchjd/aggregation/_gramian_utils.py
@@ -53,5 +53,7 @@ def _normalize(matrix: Tensor, eps: float) -> Tensor:
 def _regularize(gramian: Tensor, eps: float) -> Tensor:
     # Because of numerical errors, `gramian` might have slightly negative eigenvalue(s).
     # Adding a regularization term which is a small proportion of the identity matrix ensures that the gramian is positive definite.
-    regularization_matrix = eps * torch.eye(gramian.shape[0])
+    regularization_matrix = eps * torch.eye(
+        gramian.shape[0], dtype=gramian.dtype, device=gramian.device
+    )
     return gramian + regularization_matrix

--- a/src/torchjd/aggregation/_gramian_utils.py
+++ b/src/torchjd/aggregation/_gramian_utils.py
@@ -45,11 +45,11 @@ def _compute_normalized_gramian(matrix: Tensor, norm_eps: float) -> Tensor:
     return normalized_gramian
 
 
-def _regularize_gramian(gramian: Tensor, reg_eps: float) -> Tensor:
-    regularization_matrix = reg_eps * torch.eye(gramian.shape[0])
-    return gramian + regularization_matrix
-
-
 def _compute_normalized_regularized_gramian(matrix: Tensor, norm_eps: float, reg_eps: float):
     normalized_gramian = _compute_normalized_gramian(matrix, norm_eps)
     return _regularize_gramian(normalized_gramian, reg_eps)
+
+
+def _regularize_gramian(gramian: Tensor, reg_eps: float) -> Tensor:
+    regularization_matrix = reg_eps * torch.eye(gramian.shape[0])
+    return gramian + regularization_matrix

--- a/src/torchjd/aggregation/_gramian_utils.py
+++ b/src/torchjd/aggregation/_gramian_utils.py
@@ -7,6 +7,7 @@ def _compute_gramian(matrix: Tensor) -> Tensor:
     """
     Computes the `Gramian matrix <https://en.wikipedia.org/wiki/Gram_matrix>`_ of a given matrix.
     """
+
     return matrix @ matrix.T
 
 

--- a/src/torchjd/aggregation/_gramian_utils.py
+++ b/src/torchjd/aggregation/_gramian_utils.py
@@ -43,3 +43,13 @@ def _compute_normalized_gramian(matrix: Tensor, norm_eps: float) -> Tensor:
         left_unitary_matrix @ torch.diag(scaled_singular_values**2) @ left_unitary_matrix.T
     )
     return normalized_gramian
+
+
+def _regularize_gramian(gramian: Tensor, reg_eps: float) -> Tensor:
+    regularization_matrix = reg_eps * torch.eye(gramian.shape[0])
+    return gramian + regularization_matrix
+
+
+def _compute_normalized_regularized_gramian(matrix: Tensor, norm_eps: float, reg_eps: float):
+    normalized_gramian = _compute_normalized_gramian(matrix, norm_eps)
+    return _regularize_gramian(normalized_gramian, reg_eps)

--- a/src/torchjd/aggregation/_gramian_utils.py
+++ b/src/torchjd/aggregation/_gramian_utils.py
@@ -51,8 +51,14 @@ def _compute_normalized_gramian(matrix: Tensor, eps: float) -> Tensor:
 
 
 def _regularize(gramian: Tensor, eps: float) -> Tensor:
-    # Because of numerical errors, `gramian` might have slightly negative eigenvalue(s).
-    # Adding a regularization term which is a small proportion of the identity matrix ensures that the gramian is positive definite.
+    """
+    Adds a regularization term to the gramian to enforce positive definiteness.
+
+    Because of numerical errors, `gramian` might have slightly negative eigenvalue(s). Adding a
+    regularization term which is a small proportion of the identity matrix ensures that the gramian
+    is positive definite.
+    """
+
     regularization_matrix = eps * torch.eye(
         gramian.shape[0], dtype=gramian.dtype, device=gramian.device
     )

--- a/src/torchjd/aggregation/cagrad.py
+++ b/src/torchjd/aggregation/cagrad.py
@@ -3,7 +3,7 @@ import numpy as np
 import torch
 from torch import Tensor
 
-from ._gramian_utils import _compute_normalized_gramian
+from ._gramian_utils import _normalize
 from .bases import _WeightedAggregator, _Weighting
 
 
@@ -72,7 +72,7 @@ class _CAGradWeighting(_Weighting):
         self.norm_eps = norm_eps
 
     def forward(self, matrix: Tensor) -> Tensor:
-        gramian = _compute_normalized_gramian(matrix, self.norm_eps)
+        gramian = _normalize(matrix, self.norm_eps)
         U, S, _ = torch.svd(gramian)
 
         reduced_matrix = U @ S.sqrt().diag()

--- a/src/torchjd/aggregation/cagrad.py
+++ b/src/torchjd/aggregation/cagrad.py
@@ -3,7 +3,7 @@ import numpy as np
 import torch
 from torch import Tensor
 
-from ._gramian_utils import _normalize
+from ._gramian_utils import _compute_normalized_gramian
 from .bases import _WeightedAggregator, _Weighting
 
 
@@ -72,7 +72,7 @@ class _CAGradWeighting(_Weighting):
         self.norm_eps = norm_eps
 
     def forward(self, matrix: Tensor) -> Tensor:
-        gramian = _normalize(matrix, self.norm_eps)
+        gramian = _compute_normalized_gramian(matrix, self.norm_eps)
         U, S, _ = torch.svd(gramian)
 
         reduced_matrix = U @ S.sqrt().diag()

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -3,7 +3,7 @@ from typing import Literal
 import torch
 from torch import Tensor
 
-from ._dual_cone_utils import _get_projection_weights
+from ._dual_cone_utils import _project_weights
 from ._gramian_utils import _compute_regularized_normalized_gramian
 from ._pref_vector_utils import (
     _check_pref_vector,
@@ -108,4 +108,4 @@ class _DualProjWrapper(_Weighting):
         with torch.no_grad():
             weights = self.weighting(matrix)
             gramian = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
-            return _get_projection_weights(gramian, weights, self.solver)
+            return _project_weights(weights, gramian, self.solver)

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -106,6 +106,7 @@ class _DualProjWrapper(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         with torch.no_grad():
-            weights = self.weighting(matrix)
-            gramian = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
-            return _project_weights(weights, gramian, self.solver)
+            u = self.weighting(matrix)
+            G = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
+            w = _project_weights(u, G, self.solver)
+            return w

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -1,5 +1,6 @@
 from typing import Literal
 
+import torch
 from torch import Tensor
 
 from ._dual_cone_utils import _get_projection_weights
@@ -104,6 +105,7 @@ class _DualProjWrapper(_Weighting):
         self.solver = solver
 
     def forward(self, matrix: Tensor) -> Tensor:
-        weights = self.weighting(matrix)
-        gramian = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
-        return _get_projection_weights(gramian, weights, self.solver)
+        with torch.no_grad():
+            weights = self.weighting(matrix)
+            gramian = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
+            return _get_projection_weights(gramian, weights, self.solver)

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -3,7 +3,7 @@ from typing import Literal
 from torch import Tensor
 
 from ._dual_cone_utils import _weights_of_projection_onto_dual_cone
-from ._gramian_utils import _compute_normalized_gramian
+from ._gramian_utils import _compute_normalized_regularized_gramian
 from ._pref_vector_utils import (
     _check_pref_vector,
     _pref_vector_to_str_suffix,
@@ -105,5 +105,5 @@ class _DualProjWrapper(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         weights = self.weighting(matrix)
-        gramian = _compute_normalized_gramian(matrix, self.norm_eps)
-        return _weights_of_projection_onto_dual_cone(gramian, weights, self.reg_eps, self.solver)
+        gramian = _compute_normalized_regularized_gramian(matrix, self.norm_eps, self.reg_eps)
+        return _weights_of_projection_onto_dual_cone(gramian, weights, self.solver)

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -1,6 +1,5 @@
 from typing import Literal
 
-import torch
 from torch import Tensor
 
 from ._dual_cone_utils import _project_weights
@@ -105,8 +104,7 @@ class _DualProjWrapper(_Weighting):
         self.solver = solver
 
     def forward(self, matrix: Tensor) -> Tensor:
-        with torch.no_grad():
-            u = self.weighting(matrix)
-            G = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
-            w = _project_weights(u, G, self.solver)
-            return w
+        u = self.weighting(matrix)
+        G = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
+        w = _project_weights(u, G, self.solver)
+        return w

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -3,7 +3,7 @@ from typing import Literal
 from torch import Tensor
 
 from ._dual_cone_utils import _get_projection_weights
-from ._gramian_utils import _normalize_and_regularize
+from ._gramian_utils import _compute_regularized_normalized_gramian
 from ._pref_vector_utils import (
     _check_pref_vector,
     _pref_vector_to_str_suffix,
@@ -105,5 +105,5 @@ class _DualProjWrapper(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         weights = self.weighting(matrix)
-        gramian = _normalize_and_regularize(matrix, self.norm_eps, self.reg_eps)
+        gramian = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
         return _get_projection_weights(gramian, weights, self.solver)

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -2,7 +2,7 @@ from typing import Literal
 
 from torch import Tensor
 
-from ._dual_cone_utils import _weights_of_projection_onto_dual_cone
+from ._dual_cone_utils import _get_projection_weights
 from ._gramian_utils import _compute_normalized_regularized_gramian
 from ._pref_vector_utils import (
     _check_pref_vector,
@@ -106,4 +106,4 @@ class _DualProjWrapper(_Weighting):
     def forward(self, matrix: Tensor) -> Tensor:
         weights = self.weighting(matrix)
         gramian = _compute_normalized_regularized_gramian(matrix, self.norm_eps, self.reg_eps)
-        return _weights_of_projection_onto_dual_cone(gramian, weights, self.solver)
+        return _get_projection_weights(gramian, weights, self.solver)

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -3,7 +3,7 @@ from typing import Literal
 from torch import Tensor
 
 from ._dual_cone_utils import _get_projection_weights
-from ._gramian_utils import _compute_normalized_regularized_gramian
+from ._gramian_utils import _normalize_and_regularize
 from ._pref_vector_utils import (
     _check_pref_vector,
     _pref_vector_to_str_suffix,
@@ -105,5 +105,5 @@ class _DualProjWrapper(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         weights = self.weighting(matrix)
-        gramian = _compute_normalized_regularized_gramian(matrix, self.norm_eps, self.reg_eps)
+        gramian = _normalize_and_regularize(matrix, self.norm_eps, self.reg_eps)
         return _get_projection_weights(gramian, weights, self.solver)

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -4,7 +4,7 @@ import torch
 from torch import Tensor
 
 from ._dual_cone_utils import _get_projection_weights
-from ._gramian_utils import _compute_normalized_regularized_gramian
+from ._gramian_utils import _normalize_and_regularize
 from ._pref_vector_utils import (
     _check_pref_vector,
     _pref_vector_to_str_suffix,
@@ -101,7 +101,7 @@ class _UPGradWrapper(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         weights = self.weighting(matrix)
-        gramian = _compute_normalized_regularized_gramian(matrix, self.norm_eps, self.reg_eps)
+        gramian = _normalize_and_regularize(matrix, self.norm_eps, self.reg_eps)
         projection_weights_matrix = _get_projection_weights(
             gramian, torch.diag(weights), self.solver
         )

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -100,8 +100,7 @@ class _UPGradWrapper(_Weighting):
         self.solver = solver
 
     def forward(self, matrix: Tensor) -> Tensor:
-        u = self.weighting(matrix)
-        U = torch.diag(u)
+        U = torch.diag(self.weighting(matrix))
         G = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
         W = _project_weights(U, G, self.solver)
         return torch.sum(W, dim=0)

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -3,7 +3,7 @@ from typing import Literal
 import torch
 from torch import Tensor
 
-from ._dual_cone_utils import _get_projection_weights
+from ._dual_cone_utils import _project_weights
 from ._gramian_utils import _compute_regularized_normalized_gramian
 from ._pref_vector_utils import (
     _check_pref_vector,
@@ -103,7 +103,5 @@ class _UPGradWrapper(_Weighting):
         with torch.no_grad():
             weights = self.weighting(matrix)
             gramian = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
-            projection_weights_matrix = _get_projection_weights(
-                gramian, torch.diag(weights), self.solver
-            )
+            projection_weights_matrix = _project_weights(torch.diag(weights), gramian, self.solver)
             return torch.sum(projection_weights_matrix, dim=0)

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -100,9 +100,10 @@ class _UPGradWrapper(_Weighting):
         self.solver = solver
 
     def forward(self, matrix: Tensor) -> Tensor:
-        weights = self.weighting(matrix)
-        gramian = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
-        projection_weights_matrix = _get_projection_weights(
-            gramian, torch.diag(weights), self.solver
-        )
-        return torch.sum(projection_weights_matrix, dim=0)
+        with torch.no_grad():
+            weights = self.weighting(matrix)
+            gramian = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
+            projection_weights_matrix = _get_projection_weights(
+                gramian, torch.diag(weights), self.solver
+            )
+            return torch.sum(projection_weights_matrix, dim=0)

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -3,7 +3,7 @@ from typing import Literal
 import torch
 from torch import Tensor
 
-from ._dual_cone_utils import _weights_of_projection_onto_dual_cone
+from ._dual_cone_utils import _get_projection_weights
 from ._gramian_utils import _compute_normalized_regularized_gramian
 from ._pref_vector_utils import (
     _check_pref_vector,
@@ -102,7 +102,7 @@ class _UPGradWrapper(_Weighting):
     def forward(self, matrix: Tensor) -> Tensor:
         weights = self.weighting(matrix)
         gramian = _compute_normalized_regularized_gramian(matrix, self.norm_eps, self.reg_eps)
-        projection_weights_matrix = _weights_of_projection_onto_dual_cone(
+        projection_weights_matrix = _get_projection_weights(
             gramian, torch.diag(weights), self.solver
         )
         return torch.sum(projection_weights_matrix, dim=1)

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -101,7 +101,8 @@ class _UPGradWrapper(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         with torch.no_grad():
-            weights = self.weighting(matrix)
-            gramian = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
-            projection_weights_matrix = _project_weights(torch.diag(weights), gramian, self.solver)
-            return torch.sum(projection_weights_matrix, dim=0)
+            u = self.weighting(matrix)
+            U = torch.diag(u)
+            G = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
+            W = _project_weights(U, G, self.solver)
+            return torch.sum(W, dim=0)

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -4,7 +4,7 @@ import torch
 from torch import Tensor
 
 from ._dual_cone_utils import _weights_of_projection_onto_dual_cone
-from ._gramian_utils import _compute_normalized_gramian
+from ._gramian_utils import _compute_normalized_regularized_gramian
 from ._pref_vector_utils import (
     _check_pref_vector,
     _pref_vector_to_str_suffix,
@@ -101,8 +101,8 @@ class _UPGradWrapper(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         weights = self.weighting(matrix)
-        gramian = _compute_normalized_gramian(matrix, self.norm_eps)
+        gramian = _compute_normalized_regularized_gramian(matrix, self.norm_eps, self.reg_eps)
         projection_weights_matrix = _weights_of_projection_onto_dual_cone(
-            gramian, torch.diag(weights), self.reg_eps, self.solver
+            gramian, torch.diag(weights), self.solver
         )
         return torch.sum(projection_weights_matrix, dim=1)

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -4,7 +4,7 @@ import torch
 from torch import Tensor
 
 from ._dual_cone_utils import _get_projection_weights
-from ._gramian_utils import _normalize_and_regularize
+from ._gramian_utils import _compute_regularized_normalized_gramian
 from ._pref_vector_utils import (
     _check_pref_vector,
     _pref_vector_to_str_suffix,
@@ -101,7 +101,7 @@ class _UPGradWrapper(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         weights = self.weighting(matrix)
-        gramian = _normalize_and_regularize(matrix, self.norm_eps, self.reg_eps)
+        gramian = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
         projection_weights_matrix = _get_projection_weights(
             gramian, torch.diag(weights), self.solver
         )

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -105,4 +105,4 @@ class _UPGradWrapper(_Weighting):
         projection_weights_matrix = _get_projection_weights(
             gramian, torch.diag(weights), self.solver
         )
-        return torch.sum(projection_weights_matrix, dim=1)
+        return torch.sum(projection_weights_matrix, dim=0)

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -100,9 +100,8 @@ class _UPGradWrapper(_Weighting):
         self.solver = solver
 
     def forward(self, matrix: Tensor) -> Tensor:
-        with torch.no_grad():
-            u = self.weighting(matrix)
-            U = torch.diag(u)
-            G = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
-            W = _project_weights(U, G, self.solver)
-            return torch.sum(W, dim=0)
+        u = self.weighting(matrix)
+        U = torch.diag(u)
+        G = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
+        W = _project_weights(U, G, self.solver)
+        return torch.sum(W, dim=0)

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -1,10 +1,9 @@
 from typing import Literal
 
-import numpy as np
 import torch
-from qpsolvers import solve_qp
 from torch import Tensor
 
+from ._dual_cone_utils import _weights_of_projection_onto_dual_cone
 from ._gramian_utils import _compute_normalized_gramian
 from ._pref_vector_utils import (
     _check_pref_vector,
@@ -102,36 +101,8 @@ class _UPGradWrapper(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         weights = self.weighting(matrix)
-        lagrangian = self._compute_lagrangian(matrix, weights)
-        lagrangian_weights = torch.sum(lagrangian, dim=0)
-        result_weights = lagrangian_weights + weights
-        return result_weights
-
-    def _compute_lagrangian(self, matrix: Tensor, weights: Tensor) -> Tensor:
         gramian = _compute_normalized_gramian(matrix, self.norm_eps)
-        gramian_array = gramian.cpu().detach().numpy().astype(np.float64)
-        dimension = gramian.shape[0]
-
-        regularization_array = self.reg_eps * np.eye(dimension)
-        regularized_gramian_array = gramian_array + regularization_array
-
-        P = regularized_gramian_array
-        G = -np.eye(dimension)
-        h = np.zeros(dimension)
-
-        lagrangian_rows = []
-        for i in range(dimension):
-            weight = weights[i].item()
-            if weight <= 0.0:
-                # In this case, the solution to the quadratic program is always 0,
-                # so we don't need to run solve_qp.
-                lagrangian_rows.append(np.zeros([dimension]))
-            else:
-                q = weight * regularized_gramian_array[i, :]
-                lagrangian_rows.append(solve_qp(P, q, G, h, solver=self.solver))
-
-        lagrangian_array = np.stack(lagrangian_rows)
-        lagrangian = torch.from_numpy(lagrangian_array).to(
-            device=gramian.device, dtype=gramian.dtype
+        projection_weights_matrix = _weights_of_projection_onto_dual_cone(
+            gramian, torch.diag(weights), self.reg_eps, self.solver
         )
-        return lagrangian
+        return torch.sum(projection_weights_matrix, dim=1)

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -52,6 +52,11 @@ def test_solution_weights(shape: tuple[int, int]):
 
 @mark.parametrize("shape", [(5, 2, 3), (1, 3, 6, 9), (2, 1, 1, 5, 8), (3, 1)])
 def test_tensorization_shape(shape: tuple[int, ...]):
+    """
+    Tests that applying `_project_weights` on a tensor is equivalent to applying it on the tensor
+    reshaped as matrix and to reshape the result back to the original tensor's shape.
+    """
+
     matrix = torch.randn([shape[-1], shape[-1]])
     U_tensor = torch.randn(shape)
     U_matrix = U_tensor.reshape([-1, shape[-1]])

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -1,0 +1,29 @@
+import torch
+from pytest import mark
+from torch.testing import assert_close
+
+from torchjd.aggregation._dual_cone_utils import _weights_of_projection_onto_dual_cone
+
+
+@mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100)])
+def test_lagrangian_satisfies_kkt_conditions(shape: tuple[int, int]):
+    matrix = torch.randn(shape)
+    weights = torch.rand(shape[0])
+
+    gramian = matrix @ matrix.T
+
+    projection_weights = _weights_of_projection_onto_dual_cone(gramian, weights, 0.0, "quadprog")
+    lagrange_multiplier = projection_weights - weights
+
+    positive_lagrange_multiplier = lagrange_multiplier[lagrange_multiplier >= 0.0]
+    assert_close(
+        positive_lagrange_multiplier.norm(), lagrange_multiplier.norm(), atol=1e-05, rtol=0
+    )
+
+    constraint = gramian @ projection_weights
+
+    positive_constraint = constraint[constraint >= 0]
+    assert_close(positive_constraint.norm(), constraint.norm(), atol=1e-04, rtol=0)
+
+    slackness = lagrange_multiplier @ constraint
+    assert_close(slackness, torch.zeros_like(slackness), atol=3e-03, rtol=0)

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -2,7 +2,7 @@ import torch
 from pytest import mark, raises
 from torch.testing import assert_close
 
-from torchjd.aggregation._dual_cone_utils import _weights_of_projection_onto_dual_cone
+from torchjd.aggregation._dual_cone_utils import _get_projection_weights
 
 
 @mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100)])
@@ -12,7 +12,7 @@ def test_lagrangian_satisfies_kkt_conditions(shape: tuple[int, int]):
 
     gramian = matrix @ matrix.T
 
-    projection_weights = _weights_of_projection_onto_dual_cone(gramian, weights, "quadprog")
+    projection_weights = _get_projection_weights(gramian, weights, "quadprog")
     lagrange_multiplier = projection_weights - weights
 
     positive_lagrange_multiplier = lagrange_multiplier[lagrange_multiplier >= 0.0]
@@ -36,7 +36,7 @@ def test_lagrangian_satisfies_kkt_conditions_matrix_weights(shape: tuple[int, in
 
     gramian = matrix @ matrix.T
 
-    projection_weights = _weights_of_projection_onto_dual_cone(gramian, weights_matrix, "quadprog")
+    projection_weights = _get_projection_weights(gramian, weights_matrix, "quadprog")
     lagrange_multiplier = projection_weights - weights_matrix
 
     positive_lagrange_multiplier = lagrange_multiplier[lagrange_multiplier >= 0.0]
@@ -55,6 +55,4 @@ def test_lagrangian_satisfies_kkt_conditions_matrix_weights(shape: tuple[int, in
 
 def test_weights_of_projection_onto_dual_cone_invalid_shape():
     with raises(ValueError):
-        _weights_of_projection_onto_dual_cone(
-            torch.zeros([5, 5]), torch.zeros([5, 2, 3]), "quadprog"
-        )
+        _get_projection_weights(torch.zeros([5, 5]), torch.zeros([5, 2, 3]), "quadprog")

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -2,7 +2,7 @@ import torch
 from pytest import mark
 from torch.testing import assert_close
 
-from torchjd.aggregation._dual_cone_utils import _get_projection_weights
+from torchjd.aggregation._dual_cone_utils import _project_weights
 
 
 @mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100)])
@@ -35,7 +35,7 @@ def test_solution_weights(shape: tuple[int, int]):
 
     gramian = matrix @ matrix.T
 
-    projection_weights = _get_projection_weights(gramian, weights, "quadprog")
+    projection_weights = _project_weights(weights, gramian, "quadprog")
     dual_gap = projection_weights - weights
 
     # Dual feasibility
@@ -61,7 +61,7 @@ def test_tensorization_shape(shape: tuple[int, ...]):
 
     gramian = matrix @ matrix.T
 
-    projection_weight_tensor = _get_projection_weights(gramian, weight_tensor, "quadprog")
-    projection_weight_matrix = _get_projection_weights(gramian, weight_matrix, "quadprog")
+    projection_weight_tensor = _project_weights(weight_tensor, gramian, "quadprog")
+    projection_weight_matrix = _project_weights(weight_matrix, gramian, "quadprog")
 
     assert_close(projection_weight_matrix.reshape(shape), projection_weight_tensor)

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -44,12 +44,12 @@ def test_lagrangian_satisfies_kkt_conditions_matrix_weights(shape: tuple[int, in
         positive_lagrange_multiplier.norm(), lagrange_multiplier.norm(), atol=1e-05, rtol=0
     )
 
-    constraint = gramian @ projection_weights
+    constraint = gramian @ projection_weights.T
 
     positive_constraint = constraint[constraint >= 0]
     assert_close(positive_constraint.norm(), constraint.norm(), atol=1e-04, rtol=0)
 
-    slackness = torch.trace(constraint @ lagrange_multiplier.T)
+    slackness = torch.trace(lagrange_multiplier @ constraint)
     assert_close(slackness, torch.zeros_like(slackness), atol=3e-03, rtol=0)
 
 

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -30,19 +30,19 @@ def test_solution_weights(shape: tuple[int, int]):
     Reference:
     [1] `Jacobian Descent For Multi-Objective Optimization <https://arxiv.org/pdf/2406.16232>`_.
     """
-    matrix = torch.randn(shape)
-    weights = torch.rand(shape[0])
 
-    gramian = matrix @ matrix.T
+    J = torch.randn(shape)
+    G = J @ J.T
+    u = torch.rand(shape[0])
 
-    projection_weights = _project_weights(weights, gramian, "quadprog")
-    dual_gap = projection_weights - weights
+    w = _project_weights(u, G, "quadprog")
+    dual_gap = w - u
 
     # Dual feasibility
     dual_gap_positive_part = dual_gap[dual_gap >= 0.0]
     assert_close(dual_gap_positive_part.norm(), dual_gap.norm(), atol=1e-05, rtol=0)
 
-    primal_gap = gramian @ projection_weights
+    primal_gap = G @ w
 
     # Primal feasibility
     primal_gap_positive_part = primal_gap[primal_gap >= 0]
@@ -56,12 +56,12 @@ def test_solution_weights(shape: tuple[int, int]):
 @mark.parametrize("shape", [(5, 2, 3), (1, 3, 6, 9), (2, 1, 1, 5, 8), (3, 1)])
 def test_tensorization_shape(shape: tuple[int, ...]):
     matrix = torch.randn([shape[-1], shape[-1]])
-    weight_tensor = torch.randn(shape)
-    weight_matrix = weight_tensor.reshape([-1, shape[-1]])
+    U_tensor = torch.randn(shape)
+    U_matrix = U_tensor.reshape([-1, shape[-1]])
 
-    gramian = matrix @ matrix.T
+    G = matrix @ matrix.T
 
-    projection_weight_tensor = _project_weights(weight_tensor, gramian, "quadprog")
-    projection_weight_matrix = _project_weights(weight_matrix, gramian, "quadprog")
+    W_tensor = _project_weights(U_tensor, G, "quadprog")
+    W_matrix = _project_weights(U_matrix, G, "quadprog")
 
-    assert_close(projection_weight_matrix.reshape(shape), projection_weight_tensor)
+    assert_close(W_matrix.reshape(shape), W_tensor)

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -1,5 +1,5 @@
 import torch
-from pytest import mark
+from pytest import mark, raises
 from torch.testing import assert_close
 
 from torchjd.aggregation._dual_cone_utils import _weights_of_projection_onto_dual_cone
@@ -27,3 +27,34 @@ def test_lagrangian_satisfies_kkt_conditions(shape: tuple[int, int]):
 
     slackness = lagrange_multiplier @ constraint
     assert_close(slackness, torch.zeros_like(slackness), atol=3e-03, rtol=0)
+
+
+@mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100)])
+def test_lagrangian_satisfies_kkt_conditions_matrix_weights(shape: tuple[int, int]):
+    matrix = torch.randn(shape)
+    weights_matrix = torch.diag(torch.rand(shape[0]))
+
+    gramian = matrix @ matrix.T
+
+    projection_weights = _weights_of_projection_onto_dual_cone(gramian, weights_matrix, "quadprog")
+    lagrange_multiplier = projection_weights - weights_matrix
+
+    positive_lagrange_multiplier = lagrange_multiplier[lagrange_multiplier >= 0.0]
+    assert_close(
+        positive_lagrange_multiplier.norm(), lagrange_multiplier.norm(), atol=1e-05, rtol=0
+    )
+
+    constraint = gramian @ projection_weights
+
+    positive_constraint = constraint[constraint >= 0]
+    assert_close(positive_constraint.norm(), constraint.norm(), atol=1e-04, rtol=0)
+
+    slackness = torch.trace(constraint @ lagrange_multiplier.T)
+    assert_close(slackness, torch.zeros_like(slackness), atol=3e-03, rtol=0)
+
+
+def test_weights_of_projection_onto_dual_cone_invalid_shape():
+    with raises(ValueError):
+        _weights_of_projection_onto_dual_cone(
+            torch.zeros([5, 5]), torch.zeros([5, 2, 3]), "quadprog"
+        )

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -1,5 +1,5 @@
 import torch
-from pytest import mark, raises
+from pytest import mark
 from torch.testing import assert_close
 
 from torchjd.aggregation._dual_cone_utils import _get_projection_weights
@@ -27,32 +27,3 @@ def test_lagrangian_satisfies_kkt_conditions(shape: tuple[int, int]):
 
     slackness = lagrange_multiplier @ constraint
     assert_close(slackness, torch.zeros_like(slackness), atol=3e-03, rtol=0)
-
-
-@mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100)])
-def test_lagrangian_satisfies_kkt_conditions_matrix_weights(shape: tuple[int, int]):
-    matrix = torch.randn(shape)
-    weights_matrix = torch.diag(torch.rand(shape[0]))
-
-    gramian = matrix @ matrix.T
-
-    projection_weights = _get_projection_weights(gramian, weights_matrix, "quadprog")
-    lagrange_multiplier = projection_weights - weights_matrix
-
-    positive_lagrange_multiplier = lagrange_multiplier[lagrange_multiplier >= 0.0]
-    assert_close(
-        positive_lagrange_multiplier.norm(), lagrange_multiplier.norm(), atol=1e-05, rtol=0
-    )
-
-    constraint = gramian @ projection_weights.T
-
-    positive_constraint = constraint[constraint >= 0]
-    assert_close(positive_constraint.norm(), constraint.norm(), atol=1e-04, rtol=0)
-
-    slackness = torch.trace(lagrange_multiplier @ constraint)
-    assert_close(slackness, torch.zeros_like(slackness), atol=3e-03, rtol=0)
-
-
-def test_weights_of_projection_onto_dual_cone_invalid_shape():
-    with raises(ValueError):
-        _get_projection_weights(torch.zeros([5, 5]), torch.zeros([5, 2, 3]), "quadprog")

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -12,7 +12,7 @@ def test_lagrangian_satisfies_kkt_conditions(shape: tuple[int, int]):
 
     gramian = matrix @ matrix.T
 
-    projection_weights = _weights_of_projection_onto_dual_cone(gramian, weights, 0.0, "quadprog")
+    projection_weights = _weights_of_projection_onto_dual_cone(gramian, weights, "quadprog")
     lagrange_multiplier = projection_weights - weights
 
     positive_lagrange_multiplier = lagrange_multiplier[lagrange_multiplier >= 0.0]

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -8,24 +8,21 @@ from torchjd.aggregation._dual_cone_utils import _project_weights
 @mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100)])
 def test_solution_weights(shape: tuple[int, int]):
     r"""
-    Tests that `_get_projection_weights` returns valid weights corresponding to the projection onto
-    the dual cone of a matrix with the specified shape.
+    Tests that `_project_weights` returns valid weights corresponding to the projection onto the
+    dual cone of a matrix with the specified shape.
 
     Validation is performed by verifying that the solution satisfies the `KKT conditions
     <https://en.wikipedia.org/wiki/Karush%E2%80%93Kuhn%E2%80%93Tucker_conditions>`_ for the
-    quadratic program that projects vectors onto the dual cone of a matrix.
-    Specifically, the solution should satisfy the equivalent set of conditions described in Lemma 4
-    of [1].
+    quadratic program that projects vectors onto the dual cone of a matrix. Specifically, the
+    solution should satisfy the equivalent set of conditions described in Lemma 4 of [1].
 
-    Let:
-    - `u` be a vector of weights,
-    - `G` a positive semi-definite matrix,
-    - Consider the quadratic problem of minimizing `v^\top G v` subject to `u \preceq v`.
+    Let `u` be a vector of weights and `G` a positive semi-definite matrix. Consider the quadratic
+    problem of minimizing `v^T G v` subject to `u \preceq v`.
 
     Then `w` is a solution if and only if it satisfies the following three conditions:
     1. **Dual feasibility:** `u \preceq w`
     2. **Primal feasibility:** `0 \preceq G w`
-    3. **Complementary slackness:** `u^\top G w = w^\top G w`
+    3. **Complementary slackness:** `u^T G w = w^T G w`
 
     Reference:
     [1] `Jacobian Descent For Multi-Objective Optimization <https://arxiv.org/pdf/2406.16232>`_.

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -51,3 +51,17 @@ def test_solution_weights(shape: tuple[int, int]):
     # Complementary slackness
     slackness = dual_gap @ primal_gap
     assert_close(slackness, torch.zeros_like(slackness), atol=3e-03, rtol=0)
+
+
+@mark.parametrize("shape", [(5, 2, 3), (1, 3, 6, 9), (2, 1, 1, 5, 8), (3, 1)])
+def test_tensorization_shape(shape: tuple[int, ...]):
+    matrix = torch.randn([shape[-1], shape[-1]])
+    weight_tensor = torch.randn(shape)
+    weight_matrix = weight_tensor.reshape([-1, shape[-1]])
+
+    gramian = matrix @ matrix.T
+
+    projection_weight_tensor = _get_projection_weights(gramian, weight_tensor, "quadprog")
+    projection_weight_matrix = _get_projection_weights(gramian, weight_matrix, "quadprog")
+
+    assert_close(projection_weight_matrix.reshape(shape), projection_weight_tensor)

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -6,24 +6,48 @@ from torchjd.aggregation._dual_cone_utils import _get_projection_weights
 
 
 @mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100)])
-def test_lagrangian_satisfies_kkt_conditions(shape: tuple[int, int]):
+def test_solution_weights(shape: tuple[int, int]):
+    r"""
+    Tests that `_get_projection_weights` returns valid weights corresponding to the projection onto
+    the dual cone of a matrix with the specified shape.
+
+    Validation is performed by verifying that the solution satisfies the `KKT conditions
+    <https://en.wikipedia.org/wiki/Karush%E2%80%93Kuhn%E2%80%93Tucker_conditions>`_ for the
+    quadratic program that projects vectors onto the dual cone of a matrix.
+    Specifically, the solution should satisfy the equivalent set of conditions described in Lemma 4
+    of [1].
+
+    Let:
+    - `u` be a vector of weights,
+    - `G` a positive semi-definite matrix,
+    - Consider the quadratic problem of minimizing `v^\top G v` subject to `u \preceq v`.
+
+    Then `w` is a solution if and only if it satisfies the following three conditions:
+    1. **Dual feasibility:** `u \preceq w`
+    2. **Primal feasibility:** `0 \preceq G w`
+    3. **Complementary slackness:** `u^\top G w = w^\top G w`
+
+    Reference:
+    [1] `Jacobian Descent For Multi-Objective Optimization <https://arxiv.org/pdf/2406.16232>`_.
+    """
     matrix = torch.randn(shape)
     weights = torch.rand(shape[0])
 
     gramian = matrix @ matrix.T
 
     projection_weights = _get_projection_weights(gramian, weights, "quadprog")
-    lagrange_multiplier = projection_weights - weights
+    dual_gap = projection_weights - weights
 
-    positive_lagrange_multiplier = lagrange_multiplier[lagrange_multiplier >= 0.0]
-    assert_close(
-        positive_lagrange_multiplier.norm(), lagrange_multiplier.norm(), atol=1e-05, rtol=0
-    )
+    # Dual feasibility
+    dual_gap_positive_part = dual_gap[dual_gap >= 0.0]
+    assert_close(dual_gap_positive_part.norm(), dual_gap.norm(), atol=1e-05, rtol=0)
 
-    constraint = gramian @ projection_weights
+    primal_gap = gramian @ projection_weights
 
-    positive_constraint = constraint[constraint >= 0]
-    assert_close(positive_constraint.norm(), constraint.norm(), atol=1e-04, rtol=0)
+    # Primal feasibility
+    primal_gap_positive_part = primal_gap[primal_gap >= 0]
+    assert_close(primal_gap_positive_part.norm(), primal_gap.norm(), atol=1e-04, rtol=0)
 
-    slackness = lagrange_multiplier @ constraint
+    # Complementary slackness
+    slackness = dual_gap @ primal_gap
     assert_close(slackness, torch.zeros_like(slackness), atol=3e-03, rtol=0)

--- a/tests/unit/aggregation/test_upgrad.py
+++ b/tests/unit/aggregation/test_upgrad.py
@@ -1,10 +1,7 @@
 import torch
 from pytest import mark
-from torch.testing import assert_close
 
 from torchjd.aggregation import UPGrad
-from torchjd.aggregation.mean import _MeanWeighting
-from torchjd.aggregation.upgrad import _UPGradWrapper
 
 from ._property_testers import (
     ExpectedStructureProperty,
@@ -16,31 +13,6 @@ from ._property_testers import (
 @mark.parametrize("aggregator", [UPGrad()])
 class TestUPGrad(ExpectedStructureProperty, NonConflictingProperty, PermutationInvarianceProperty):
     pass
-
-
-@mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100)])
-def test_upgrad_lagrangian_satisfies_kkt_conditions(shape: tuple[int, int]):
-    matrix = torch.randn(shape)
-    weights = torch.rand(shape[0])
-
-    gramian = matrix @ matrix.T
-
-    W = _UPGradWrapper(_MeanWeighting(), norm_eps=0.0001, reg_eps=0.0, solver="quadprog")
-
-    lagrange_multiplier = W._compute_lagrangian(matrix, weights)
-
-    positive_lagrange_multiplier = lagrange_multiplier[lagrange_multiplier >= 0]
-    assert_close(
-        positive_lagrange_multiplier.norm(), lagrange_multiplier.norm(), atol=1e-05, rtol=0
-    )
-
-    constraint = gramian @ (torch.diag(weights) + lagrange_multiplier.T)
-
-    positive_constraint = constraint[constraint >= 0]
-    assert_close(positive_constraint.norm(), constraint.norm(), atol=1e-04, rtol=0)
-
-    slackness = torch.trace(lagrange_multiplier @ constraint)
-    assert_close(slackness, torch.zeros_like(slackness), atol=3e-03, rtol=0)
 
 
 def test_representations():


### PR DESCRIPTION
Both `DualProj` and `UPGrad` rely on projections onto the dual cone, this PR factorizes the computation of such projections into one utility in the aggregation package.