### PR TITLE
Use diff code block in README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ The main way to use TorchJD is to replace the usual call to `loss.backward()` by
 The following example shows how to use TorchJD to train a multi-task model with Jacobian descent,
 using [UPGrad](https://torchjd.org/docs/aggregation/upgrad/).
 
-```python
+```diff
 import torch
 from torch.nn import Linear, MSELoss, ReLU, Sequential
 from torch.optim import SGD
 
-from torchjd import mtl_backward
-from torchjd.aggregation import UPGrad
++from torchjd import mtl_backward
++from torchjd.aggregation import UPGrad
 
 shared_module = Sequential(Linear(10, 5), ReLU(), Linear(5, 3), ReLU())
 task1_module = Linear(3, 1)
@@ -78,7 +78,7 @@ params = [
 
 loss_fn = MSELoss()
 optimizer = SGD(params, lr=0.1)
-aggregator = UPGrad()
++aggregator = UPGrad()
 
 inputs = torch.randn(8, 16, 10)  # 8 batches of 16 random input vectors of length 10
 task1_targets = torch.randn(8, 16, 1)  # 8 batches of 16 targets for the first task
@@ -92,7 +92,9 @@ for input, target1, target2 in zip(inputs, task1_targets, task2_targets):
     loss2 = loss_fn(output2, target2)
 
     optimizer.zero_grad()
-    mtl_backward(losses=[loss1, loss2], features=features, aggregator=aggregator)
+-   loss = loss1 + loss2
+-   loss.backward()
++   mtl_backward(losses=[loss1, loss2], features=features, aggregator=aggregator)
     optimizer.step()
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,42 +60,42 @@ The following example shows how to use TorchJD to train a multi-task model with 
 using [UPGrad](https://torchjd.org/docs/aggregation/upgrad/).
 
 ```diff
-import torch
-from torch.nn import Linear, MSELoss, ReLU, Sequential
-from torch.optim import SGD
+  import torch
+  from torch.nn import Linear, MSELoss, ReLU, Sequential
+  from torch.optim import SGD
 
-+from torchjd import mtl_backward
-+from torchjd.aggregation import UPGrad
++ from torchjd import mtl_backward
++ from torchjd.aggregation import UPGrad
 
-shared_module = Sequential(Linear(10, 5), ReLU(), Linear(5, 3), ReLU())
-task1_module = Linear(3, 1)
-task2_module = Linear(3, 1)
-params = [
-    *shared_module.parameters(),
-    *task1_module.parameters(),
-    *task2_module.parameters(),
-]
+  shared_module = Sequential(Linear(10, 5), ReLU(), Linear(5, 3), ReLU())
+  task1_module = Linear(3, 1)
+  task2_module = Linear(3, 1)
+  params = [
+      *shared_module.parameters(),
+      *task1_module.parameters(),
+      *task2_module.parameters(),
+  ]
 
-loss_fn = MSELoss()
-optimizer = SGD(params, lr=0.1)
-+aggregator = UPGrad()
+  loss_fn = MSELoss()
+  optimizer = SGD(params, lr=0.1)
++ aggregator = UPGrad()
 
-inputs = torch.randn(8, 16, 10)  # 8 batches of 16 random input vectors of length 10
-task1_targets = torch.randn(8, 16, 1)  # 8 batches of 16 targets for the first task
-task2_targets = torch.randn(8, 16, 1)  # 8 batches of 16 targets for the second task
+  inputs = torch.randn(8, 16, 10)  # 8 batches of 16 random input vectors of length 10
+  task1_targets = torch.randn(8, 16, 1)  # 8 batches of 16 targets for the first task
+  task2_targets = torch.randn(8, 16, 1)  # 8 batches of 16 targets for the second task
 
-for input, target1, target2 in zip(inputs, task1_targets, task2_targets):
-    features = shared_module(input)
-    output1 = task1_module(features)
-    output2 = task2_module(features)
-    loss1 = loss_fn(output1, target1)
-    loss2 = loss_fn(output2, target2)
+  for input, target1, target2 in zip(inputs, task1_targets, task2_targets):
+      features = shared_module(input)
+      output1 = task1_module(features)
+      output2 = task2_module(features)
+      loss1 = loss_fn(output1, target1)
+      loss2 = loss_fn(output2, target2)
 
-    optimizer.zero_grad()
--   loss = loss1 + loss2
--   loss.backward()
-+   mtl_backward(losses=[loss1, loss2], features=features, aggregator=aggregator)
-    optimizer.step()
+      optimizer.zero_grad()
+-     loss = loss1 + loss2
+-     loss.backward()
++     mtl_backward(losses=[loss1, loss2], features=features, aggregator=aggregator)
+      optimizer.step()
 ```
 
 > [!NOTE]


### PR DESCRIPTION
This PR proposes to use a  diff code block rather than a python code block for the MTL usage example of the REAMDE.md. It also marks the extra lines coming from using torchjd with a +, and it adds two lines that torchjd prevents, markes with a -.
Lastly, it increases the indentation of the example by 2 spaces to separate the + and - signs from the content.

I think this makes it much clearer for the users what they need to change in their code to use torchjd, and it really shows how easy it is to get started. The downside is that we lose the python syntax highlighting, but I really think that it's not the point of this example to show how to do standard MTL. So for me this, not having the python syntax highlighting could almost be seen as an improvement in itself.

BEFORE:
![Screenshot from 2025-01-25 13-44-18](https://github.com/user-attachments/assets/1a465e02-397d-4e90-8cd2-9b863d7542b1)

AFTER (no additional indentation):
![Screenshot from 2025-01-25 13-44-04](https://github.com/user-attachments/assets/2404f3c1-e238-4125-ad0b-19a29e96485a)

AFTER (+2 spaces identation):
![Screenshot from 2025-01-25 13-55-14](https://github.com/user-attachments/assets/c4fb6c4d-c46a-4d44-9eae-c462dd88f32a)

Proposed commit message:
```
docs(readme): use diff code block for usage example
```