### PR TITLE
Remove copyright dates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Valérian Rey, Pierre Quinton
+Copyright (c) Valérian Rey, Pierre Quinton
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ author_names = [author["name"] for author in authors]
 author_name_emails = [f"{author['name']} <{author['email']}>" for author in authors]
 
 project = pyproject_config["project"]["name"]
-copyright = "2024, " + ", ".join(author_names)
+copyright = ", ".join(author_names)
 author = ", ".join(author_name_emails)
 release = pyproject_config["project"]["version"]
 


### PR DESCRIPTION
Rather than having to update the copyright date every year, I suggest to entirely get rid of them. They are not mandatory, and since git keeps track of the history of the project anyway, they are not even useful.

- **Remove date in LICENSE copyright**
- **Remove date in documentation copyright**

Note that the documentation still builds successfully, and the copyright message now looks like:
![Screenshot from 2025-02-02 12-29-25](https://github.com/user-attachments/assets/1b0641a8-a2f4-4afa-bf3b-d191a8ba90af)

