### PR TITLE
Raise error if `solve_qp` returns `None` (#248)

### DIFF
--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -46,6 +46,10 @@ def _project_weight_vector(u: np.ndarray, G: np.ndarray, solver: Literal["quadpr
 
     m = G.shape[0]
     w = solve_qp(G, np.zeros(m), -np.eye(m), -u, solver=solver)
+
+    if w is None:  # This may happen when G has large values.
+        raise ValueError("Failed to solve the quadratic programming problem.")
+
     return w
 
 

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -1,8 +1,9 @@
+import numpy as np
 import torch
-from pytest import mark
+from pytest import mark, raises
 from torch.testing import assert_close
 
-from torchjd.aggregation._dual_cone_utils import _project_weights
+from torchjd.aggregation._dual_cone_utils import _project_weight_vector, _project_weights
 
 
 @mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100)])
@@ -67,3 +68,12 @@ def test_tensorization_shape(shape: tuple[int, ...]):
     W_matrix = _project_weights(U_matrix, G, "quadprog")
 
     assert_close(W_matrix.reshape(shape), W_tensor)
+
+
+def test_project_weight_vector_failure():
+    """Tests that `_project_weight_vector` raises an error when the input G has too large values."""
+
+    large_J = np.random.randn(10, 100) * 1e5
+    large_G = large_J @ large_J.T
+    with raises(ValueError):
+        _project_weight_vector(np.ones(10), large_G, "quadprog")


### PR DESCRIPTION
While working on removing Gramian normalization, I realized that `solve_qp` can return `None`. Since `_project_weight_vector` is supposed to return a `np.ndarray`, we thus can't just always return the result of `solve_qp`. This PR changes `_project_weight_vector` such that it raises a `ValueError` when `solve_qp` returns `None`. Note that this seems to only happen with matrices with large values (so, with Gramian normalization, this should never be an issue). I also added a test to add coverage for this behavior.

- **Make _project_weight_vector raise a ValueError when solve_qp returns None**
- **Test failure of _project_weight_vector on gramian with large values**
