### PR TITLE
Use cholesky factor for qpsolvers

### DIFF
--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -5,8 +5,12 @@ import torch
 from qpsolvers import solve_qp
 from torch import Tensor
 
+from torchjd.aggregation._gramian_utils import _compute_regularized_normalized_gramian
 
-def _project_weights(U: Tensor, G: Tensor, solver: Literal["quadprog"]) -> Tensor:
+
+def _project_weights(
+    U: Tensor, matrix: Tensor, solver: Literal["quadprog"], norm_eps: float, reg_eps: float
+) -> Tensor:
     """
     Computes the tensor of weights corresponding to the projection of the vectors in `U` onto the
     rows of a matrix whose Gramian is provided.
@@ -16,6 +20,8 @@ def _project_weights(U: Tensor, G: Tensor, solver: Literal["quadprog"]) -> Tenso
     :param solver: The quadratic programming solver to use.
     :return: A tensor of projection weights with the same shape as `U`.
     """
+
+    G = _compute_regularized_normalized_gramian(matrix, norm_eps, reg_eps)
 
     G_ = _to_array(G)
     U_ = _to_array(U)

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -3,7 +3,6 @@ from typing import Literal
 from torch import Tensor
 
 from ._dual_cone_utils import _project_weights
-from ._gramian_utils import _compute_regularized_normalized_gramian
 from ._pref_vector_utils import (
     _check_pref_vector,
     _pref_vector_to_str_suffix,
@@ -105,6 +104,5 @@ class _DualProjWrapper(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         u = self.weighting(matrix)
-        G = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
-        w = _project_weights(u, G, self.solver)
+        w = _project_weights(u, matrix, self.solver, self.norm_eps, self.reg_eps)
         return w

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -4,7 +4,6 @@ import torch
 from torch import Tensor
 
 from ._dual_cone_utils import _project_weights
-from ._gramian_utils import _compute_regularized_normalized_gramian
 from ._pref_vector_utils import (
     _check_pref_vector,
     _pref_vector_to_str_suffix,
@@ -101,6 +100,5 @@ class _UPGradWrapper(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         U = torch.diag(self.weighting(matrix))
-        G = _compute_regularized_normalized_gramian(matrix, self.norm_eps, self.reg_eps)
-        W = _project_weights(U, G, self.solver)
+        W = _project_weights(U, matrix, self.solver, self.norm_eps, self.reg_eps)
         return torch.sum(W, dim=0)

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -47,7 +47,7 @@ def test_solution_weights(shape: tuple[int, int]):
 
     # Complementary slackness
     slackness = dual_gap @ primal_gap
-    assert_close(slackness, torch.zeros_like(slackness), atol=3e-03, rtol=0)
+    assert_close(slackness, torch.zeros_like(slackness), atol=1e-04, rtol=0)
 
 
 @mark.parametrize("shape", [(5, 2, 3), (1, 3, 6, 9), (2, 1, 1, 5, 8), (3, 1)])

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -32,7 +32,7 @@ def test_solution_weights(shape: tuple[int, int]):
     G = J @ J.T
     u = torch.rand(shape[0])
 
-    w = _project_weights(u, G, "quadprog")
+    w = _project_weights(u, J, "quadprog", 0.0, 0.0)
     dual_gap = w - u
 
     # Dual feasibility
@@ -61,9 +61,7 @@ def test_tensorization_shape(shape: tuple[int, ...]):
     U_tensor = torch.randn(shape)
     U_matrix = U_tensor.reshape([-1, shape[-1]])
 
-    G = matrix @ matrix.T
-
-    W_tensor = _project_weights(U_tensor, G, "quadprog")
-    W_matrix = _project_weights(U_matrix, G, "quadprog")
+    W_tensor = _project_weights(U_tensor, matrix, "quadprog", 0.0, 0.0)
+    W_matrix = _project_weights(U_matrix, matrix, "quadprog", 0.0, 0.0)
 
     assert_close(W_matrix.reshape(shape), W_tensor)


### PR DESCRIPTION
This experiments with the implementation of dual cone projection via the Cholesky decomposition of the Gramian, it can be computed with the QR decomposition of the matrix.
Note that the KKT condition tests work, so we are solving the right problem. The tests that fail are related to tall matrices (larger number of rows than columns) or with nans. We can in principle add a normalization step if we scale the rows of R and scale back the rows of W.