### PR TITLE
Rename `TestRGW` to `TestRandom`

### DIFF
--- a/tests/unit/aggregation/test_random.py
+++ b/tests/unit/aggregation/test_random.py
@@ -6,7 +6,7 @@ from ._property_testers import ExpectedStructureProperty
 
 
 @mark.parametrize("aggregator", [Random()])
-class TestRGW(ExpectedStructureProperty):
+class TestRandom(ExpectedStructureProperty):
     pass
 
 


### PR DESCRIPTION
* Rename TestRGW to TestRandom

Currently, the random aggregator is named `Random` and not `RGW`. We do mention the paper that introduced RGW in the documentation of `Random`. I think `Random` is a clearer name, and it is much more appropriate for an aggregator, since `RGW` stands for "Random Gradient Weighting", which would be a reasonable name for a `Weighting`.

The issue that this PR solves is that the tester of `Random` is currently named `TestRGW` and not `TestRandom`.
