### PR TITLE
Remove duplicate test parametrizations

### DIFF
--- a/tests/unit/aggregation/_inputs.py
+++ b/tests/unit/aggregation/_inputs.py
@@ -108,7 +108,7 @@ zero_matrices = [torch.zeros([m, n]) for m, n in _zero_matrices_shapes]
 strong_stationary_matrices = [
     _generate_strong_stationary_matrix(m, n) for m, n in _stationary_matrices_shapes
 ]
-weak_stationary_matrices = strong_stationary_matrices + [
+weak_stationary_matrices = [
     _generate_weak_stationary_matrix(m, n) for m, n in _stationary_matrices_shapes
 ]
 typical_matrices = zero_matrices + matrices + weak_stationary_matrices + strong_stationary_matrices


### PR DESCRIPTION
This takes the commit 728413b48cedbb563cdfbfdfde2718eade7774c3 from #257, which can already be applied on its own. This avoids having strong stationary matrices included twice in `typical_matrices`.
