### PR TITLE
Remove exception re-raising with svd

### DIFF
--- a/src/torchjd/aggregation/_gramian_utils.py
+++ b/src/torchjd/aggregation/_gramian_utils.py
@@ -1,6 +1,5 @@
 import torch
 from torch import Tensor
-from torch.linalg import LinAlgError
 
 
 def _compute_gramian(matrix: Tensor) -> Tensor:
@@ -33,13 +32,7 @@ def _compute_normalized_gramian(matrix: Tensor, eps: float) -> Tensor:
         :math:`n` through the SVD algorithm which is efficient, therefore this is rather fast.
     """
 
-    try:
-        left_unitary_matrix, singular_values, _ = torch.linalg.svd(matrix, full_matrices=False)
-    except LinAlgError as error:  # Not sure if this can happen
-        raise ValueError(
-            f"Unexpected failure of the svd computation on matrix {matrix}. Please open an "
-            "issue on https://github.com/TorchJD/torchjd/issues and paste this error message in it."
-        ) from error
+    left_unitary_matrix, singular_values, _ = torch.linalg.svd(matrix, full_matrices=False)
     max_singular_value = torch.max(singular_values)
     if max_singular_value < eps:
         scaled_singular_values = torch.zeros_like(singular_values)


### PR DESCRIPTION
* Remove exception re-raising when torch.linalg.svd raises a LinalgError in _compute_normalized_gramian

This error is raised when the matrix contains nan values. It might also be raised for some very special ill-conditioned matrices (https://discuss.pytorch.org/t/fail-to-run-torch-linalg-svd-because-error-11/150418), but we could not reproduce this. The only point of re-raising this error was to get to know which kind of matrices could make these operations fail, but it's actually simpler to not have to maintain this.
