### PR TITLE
Fix `Grad` behavior on empty outputs

### DIFF
--- a/src/torchjd/autojac/_transform/grad.py
+++ b/src/torchjd/autojac/_transform/grad.py
@@ -37,12 +37,7 @@ class Grad(_Differentiate[Gradients]):
             return tuple()
 
         if len(outputs) == 0:
-            return tuple(
-                [
-                    torch.empty(input.shape, device=input.device, dtype=input.dtype)
-                    for input in inputs
-                ]
-            )
+            return tuple([torch.zeros_like(input) for input in inputs])
 
         optional_grads = torch.autograd.grad(
             outputs,


### PR DESCRIPTION
* Make Grad._differentiate return a tuple of zero tensors when its outputs parameter is of length 0

When `outputs` is an empty list, we are implicitly summing no gradients. The identity element w.r.t. the summation of tensors of the same shape as the inputs is tensors of zeros of the same shape as the inputs, not tensors of nan values like we had. This is an internal fix since there is currently no way to call Grad with empty outputs with the current public interface of torchjd.
