### PR TITLE
Add `test_stack_different_required_keys`

### DIFF
--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -1,4 +1,5 @@
 import torch
+from pytest import raises
 from torch.testing import assert_close
 
 from torchjd.autojac._transform import (
@@ -248,3 +249,17 @@ def test_equivalence_jac_grads():
     assert_close(jac_A, torch.stack([grad_1_A, grad_2_A]))
     assert_close(jac_b, torch.stack([grad_1_b, grad_2_b]))
     assert_close(jac_c, torch.stack([grad_1_c, grad_2_c]))
+
+
+def test_stack_different_required_keys():
+    """Tests that the Stack transform fails on transforms with different required keys."""
+
+    a = torch.tensor(1.0, requires_grad=True)
+    y1 = a * 2.0
+    y2 = a * 3.0
+
+    grad1 = Grad([y1], [a])
+    grad2 = Grad([y2], [a])
+
+    with raises(ValueError):
+        _ = Stack([grad1, grad2])


### PR DESCRIPTION
At first, I wanted to make this test in `test_stack.py`, but actually, it depends on other transforms: we can't specify required keys with the `FakeGradientsTransform` defined in `test_stack.py`, and I think test files of autojac currently only depend on the transforms that they test, except for `test_interactions.py` which contains tests combining multiple transforms.
The alternative would have been to create another fake transform in `test_stack.py`, for instance one that would require some keys but that would not produce any output (kind of the opposite of the `FakeGradientsTransform`). I'm not sure it's worth the effort, and I like having this test apply on a real transform like Grad, so I prefer what I did.
