### PR TITLE
Fix differentiation with repeated tensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ changes that do not affect the user.
   project onto the dual cone. This may minimally affect the output of these aggregators.
 
 ### Fixed
+- Fixed the behavior of `backward` and `mtl_backward` when some tensors are repeated (i.e. when they
+  appear several times in the list of tensors provided as argument). Instead of raising an exception
+  in these cases, we are now aligned with the behavior of `torch.autograd.backward`. Repeated
+  tensors that we differentiate lead to repeated rows in the Jacobian, prior to aggregation, and
+  repeated tensors with respect to which we differentiate count only once.
 - Removed arbitrary exception handling in `IMTLG` and `AlignedMTL` when the computation fails. In
   practice, this fix should only affect some matrices with extremely large values, which should
   not usually happen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ changes that do not affect the user.
 
 ### Fixed
 - Fixed the behavior of `backward` and `mtl_backward` when some tensors are repeated (i.e. when they
-  appear several times in the list of tensors provided as argument). Instead of raising an exception
+  appear several times in the list of tensors provided as arguments). Instead of raising an exception
   in these cases, we are now aligned with the behavior of `torch.autograd.backward`. Repeated
   tensors that we differentiate lead to repeated rows in the Jacobian, prior to aggregation, and
   repeated tensors with respect to which we differentiate count only once.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ changes that do not affect the user.
 
 ### Fixed
 - Fixed the behavior of `backward` and `mtl_backward` when some tensors are repeated (i.e. when they
-  appear several times in the list of tensors provided as arguments). Instead of raising an exception
+  appear several times in a list of tensors provided as argument). Instead of raising an exception
   in these cases, we are now aligned with the behavior of `torch.autograd.backward`. Repeated
   tensors that we differentiate lead to repeated rows in the Jacobian, prior to aggregation, and
   repeated tensors with respect to which we differentiate count only once.

--- a/src/torchjd/autojac/_transform/_differentiate.py
+++ b/src/torchjd/autojac/_transform/_differentiate.py
@@ -15,7 +15,7 @@ class _Differentiate(Transform[_A, _A], ABC):
         retain_graph: bool,
         create_graph: bool,
     ):
-        self.outputs = ordered_set(outputs)
+        self.outputs = list(outputs)
         self.inputs = ordered_set(inputs)
         self.retain_graph = retain_graph
         self.create_graph = create_graph

--- a/src/torchjd/autojac/_transform/_utils.py
+++ b/src/torchjd/autojac/_transform/_utils.py
@@ -16,14 +16,7 @@ _C = TypeVar("_C", bound=TensorDict)
 
 
 def ordered_set(elements: Iterable[_KeyType]) -> _OrderedSet[_KeyType]:
-    elements = list(elements)
-    result = OrderedDict.fromkeys(elements, None)
-    if len(elements) != len(result):
-        raise ValueError(
-            f"Parameter `elements` should contain unique elements. Found `elements = {elements}`."
-        )
-
-    return result
+    return OrderedDict.fromkeys(elements, None)
 
 
 def dicts_union(dicts: Iterable[dict[_KeyType, _ValueType]]) -> dict[_KeyType, _ValueType]:


### PR DESCRIPTION
- **Add tests with repeated tensors for backward**
- **Add tests with repeated tensors for mtl_backward**
- **Remove check of uniqueness of the elements provided to ordered_set**
- **Remove casting outputs to ordered_set in _Differentiate**
- **Add changelog entry**
