### PR TITLE
Isolate key checks in transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ changes that do not affect the user.
 
 - Refactored the underlying optimization problem that `UPGrad` and `DualProj` have to solve to
   project onto the dual cone. This may minimally affect the output of these aggregators.
+- Refactored internal verifications in the autojac engine so that they do not run at runtime
+  anymore. This should minimally improve the performance and reduce the memory usage of `backward`
+  and `mtl_backward`.
 
 ### Fixed
 - Fixed the behavior of `backward` and `mtl_backward` when some tensors are repeated (i.e. when they

--- a/src/torchjd/autojac/_transform/_differentiate.py
+++ b/src/torchjd/autojac/_transform/_differentiate.py
@@ -38,12 +38,6 @@ class _Differentiate(Transform[_A, _A], ABC):
         tensor_outputs should be.
         """
 
-    @property
-    def required_keys(self) -> set[Tensor]:
+    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
         # outputs in the forward direction become inputs in the backward direction, and vice-versa
-        return set(self.outputs)
-
-    @property
-    def output_keys(self) -> set[Tensor]:
-        # outputs in the forward direction become inputs in the backward direction, and vice-versa
-        return set(self.inputs)
+        return set(self.outputs), set(self.inputs)

--- a/src/torchjd/autojac/_transform/_differentiate.py
+++ b/src/torchjd/autojac/_transform/_differentiate.py
@@ -20,7 +20,7 @@ class _Differentiate(Transform[_A, _A], ABC):
         self.retain_graph = retain_graph
         self.create_graph = create_graph
 
-    def _compute(self, tensors: _A) -> _A:
+    def __call__(self, tensors: _A) -> _A:
         tensor_outputs = [tensors[output] for output in self.outputs]
 
         differentiated_tuple = self._differentiate(tensor_outputs)

--- a/src/torchjd/autojac/_transform/_differentiate.py
+++ b/src/torchjd/autojac/_transform/_differentiate.py
@@ -38,6 +38,6 @@ class _Differentiate(Transform[_A, _A], ABC):
         tensor_outputs should be.
         """
 
-    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
         # outputs in the forward direction become inputs in the backward direction, and vice-versa
         return set(self.outputs), set(self.inputs)

--- a/src/torchjd/autojac/_transform/accumulate.py
+++ b/src/torchjd/autojac/_transform/accumulate.py
@@ -10,7 +10,7 @@ class Accumulate(Transform[Gradients, EmptyTensorDict]):
     def __init__(self, required_keys: Iterable[Tensor]):
         self._required_keys = set(required_keys)
 
-    def _compute(self, gradients: Gradients) -> EmptyTensorDict:
+    def __call__(self, gradients: Gradients) -> EmptyTensorDict:
         """
         Accumulates gradients with respect to keys in their ``.grad`` field.
         """

--- a/src/torchjd/autojac/_transform/accumulate.py
+++ b/src/torchjd/autojac/_transform/accumulate.py
@@ -28,13 +28,8 @@ class Accumulate(Transform[Gradients, EmptyTensorDict]):
 
         return EmptyTensorDict()
 
-    @property
-    def required_keys(self) -> set[Tensor]:
-        return self._required_keys
-
-    @property
-    def output_keys(self) -> set[Tensor]:
-        return set()
+    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+        return self._required_keys, set()
 
 
 def _check_expects_grad(tensor: Tensor) -> None:

--- a/src/torchjd/autojac/_transform/accumulate.py
+++ b/src/torchjd/autojac/_transform/accumulate.py
@@ -28,7 +28,7 @@ class Accumulate(Transform[Gradients, EmptyTensorDict]):
 
         return EmptyTensorDict()
 
-    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
         return self._required_keys, set()
 
 

--- a/src/torchjd/autojac/_transform/aggregate.py
+++ b/src/torchjd/autojac/_transform/aggregate.py
@@ -26,8 +26,8 @@ class Aggregate(Transform[Jacobians, Gradients]):
     def __call__(self, input: Jacobians) -> Gradients:
         return self.transform(input)
 
-    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
-        return self.transform.check_keys()
+    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+        return self.transform.check_and_get_keys()
 
 
 class _AggregateMatrices(Transform[JacobianMatrices, GradientVectors]):
@@ -48,7 +48,7 @@ class _AggregateMatrices(Transform[JacobianMatrices, GradientVectors]):
         ordered_matrices = self._select_ordered_subdict(jacobian_matrices, self.key_order)
         return self._aggregate_group(ordered_matrices, self.aggregator)
 
-    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
         keys = set(self.key_order)
         return keys, keys
 
@@ -117,7 +117,7 @@ class _Matrixify(Transform[Jacobians, JacobianMatrices]):
         }
         return JacobianMatrices(jacobian_matrices)
 
-    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
         return self._required_keys, self._required_keys
 
 
@@ -132,5 +132,5 @@ class _Reshape(Transform[GradientVectors, Gradients]):
         }
         return Gradients(gradients)
 
-    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
         return self._required_keys, self._required_keys

--- a/src/torchjd/autojac/_transform/aggregate.py
+++ b/src/torchjd/autojac/_transform/aggregate.py
@@ -26,13 +26,8 @@ class Aggregate(Transform[Jacobians, Gradients]):
     def _compute(self, input: Jacobians) -> Gradients:
         return self.transform(input)
 
-    @property
-    def required_keys(self) -> set[Tensor]:
-        return self.transform.required_keys
-
-    @property
-    def output_keys(self) -> set[Tensor]:
-        return self.transform.output_keys
+    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+        return self.transform.check_keys()
 
 
 class _AggregateMatrices(Transform[JacobianMatrices, GradientVectors]):
@@ -53,13 +48,9 @@ class _AggregateMatrices(Transform[JacobianMatrices, GradientVectors]):
         ordered_matrices = self._select_ordered_subdict(jacobian_matrices, self.key_order)
         return self._aggregate_group(ordered_matrices, self.aggregator)
 
-    @property
-    def required_keys(self) -> set[Tensor]:
-        return set(self.key_order)
-
-    @property
-    def output_keys(self) -> set[Tensor]:
-        return set(self.key_order)
+    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+        keys = set(self.key_order)
+        return keys, keys
 
     @staticmethod
     def _select_ordered_subdict(
@@ -126,13 +117,8 @@ class _Matrixify(Transform[Jacobians, JacobianMatrices]):
         }
         return JacobianMatrices(jacobian_matrices)
 
-    @property
-    def required_keys(self) -> set[Tensor]:
-        return self._required_keys
-
-    @property
-    def output_keys(self) -> set[Tensor]:
-        return self._required_keys
+    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+        return self._required_keys, self._required_keys
 
 
 class _Reshape(Transform[GradientVectors, Gradients]):
@@ -146,10 +132,5 @@ class _Reshape(Transform[GradientVectors, Gradients]):
         }
         return Gradients(gradients)
 
-    @property
-    def required_keys(self) -> set[Tensor]:
-        return self._required_keys
-
-    @property
-    def output_keys(self) -> set[Tensor]:
-        return self._required_keys
+    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+        return self._required_keys, self._required_keys

--- a/src/torchjd/autojac/_transform/aggregate.py
+++ b/src/torchjd/autojac/_transform/aggregate.py
@@ -23,7 +23,7 @@ class Aggregate(Transform[Jacobians, Gradients]):
         self._aggregator_str = str(aggregator)
         self.transform = reshape << aggregate_matrices << matrixify
 
-    def _compute(self, input: Jacobians) -> Gradients:
+    def __call__(self, input: Jacobians) -> Gradients:
         return self.transform(input)
 
     def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
@@ -35,7 +35,7 @@ class _AggregateMatrices(Transform[JacobianMatrices, GradientVectors]):
         self.key_order = ordered_set(key_order)
         self.aggregator = aggregator
 
-    def _compute(self, jacobian_matrices: JacobianMatrices) -> GradientVectors:
+    def __call__(self, jacobian_matrices: JacobianMatrices) -> GradientVectors:
         """
         Concatenates the provided ``jacobian_matrices`` into a single matrix and aggregates it using
         the ``aggregator``. Returns the dictionary mapping each key from ``jacobian_matrices`` to
@@ -111,7 +111,7 @@ class _Matrixify(Transform[Jacobians, JacobianMatrices]):
     def __init__(self, required_keys: Iterable[Tensor]):
         self._required_keys = set(required_keys)
 
-    def _compute(self, jacobians: Jacobians) -> JacobianMatrices:
+    def __call__(self, jacobians: Jacobians) -> JacobianMatrices:
         jacobian_matrices = {
             key: jacobian.view(jacobian.shape[0], -1) for key, jacobian in jacobians.items()
         }
@@ -125,7 +125,7 @@ class _Reshape(Transform[GradientVectors, Gradients]):
     def __init__(self, required_keys: Iterable[Tensor]):
         self._required_keys = set(required_keys)
 
-    def _compute(self, gradient_vectors: GradientVectors) -> Gradients:
+    def __call__(self, gradient_vectors: GradientVectors) -> Gradients:
         gradients = {
             key: gradient_vector.view(key.shape)
             for key, gradient_vector in gradient_vectors.items()

--- a/src/torchjd/autojac/_transform/base.py
+++ b/src/torchjd/autojac/_transform/base.py
@@ -46,8 +46,15 @@ class Transform(Generic[_B, _C], ABC):
     @abstractmethod
     def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
         """
-        Returns a pair containing (in order) the required keys and the output keys of the Transform.
-        Checks that the transform is valid.
+        Returns a pair containing (in order) the required keys and the output keys of the Transform
+        and recursively checks that the transform is valid.
+
+        The required keys are the set of keys that the transform requires to be present in its input
+        TensorDicts. The output keys are the set of keys that will be present in the output
+        TensorDicts of the transform.
+
+        Since the computation of the required and output keys and the verification that the
+        transform is valid are sometimes intertwined operations, we do them in a single method.
         """
 
     __lshift__ = compose

--- a/src/torchjd/autojac/_transform/base.py
+++ b/src/torchjd/autojac/_transform/base.py
@@ -40,11 +40,8 @@ class Transform(Generic[_B, _C], ABC):
         return type(self).__name__
 
     @abstractmethod
-    def _compute(self, input: _B) -> _C:
-        """Applies the transform to the input."""
-
     def __call__(self, input: _B) -> _C:
-        return self._compute(input)
+        """Applies the transform to the input."""
 
     @abstractmethod
     def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
@@ -65,7 +62,7 @@ class Composition(Transform[_A, _C]):
     def __str__(self) -> str:
         return str(self.outer) + " ∘ " + str(self.inner)
 
-    def _compute(self, input: _A) -> _C:
+    def __call__(self, input: _A) -> _C:
         intermediate = self.inner(input)
         return self.outer(intermediate)
 
@@ -94,7 +91,7 @@ class Conjunction(Transform[_A, _B]):
                 strings.append(s)
         return "(" + " | ".join(strings) + ")"
 
-    def _compute(self, tensor_dict: _A) -> _B:
+    def __call__(self, tensor_dict: _A) -> _B:
         output = _union([transform(tensor_dict) for transform in self.transforms])
         return output
 

--- a/src/torchjd/autojac/_transform/diagonalize.py
+++ b/src/torchjd/autojac/_transform/diagonalize.py
@@ -27,6 +27,6 @@ class Diagonalize(Transform[Gradients, Jacobians]):
         }
         return Jacobians(diagonalized_tensors)
 
-    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
         keys = set(self.considered)
         return keys, keys

--- a/src/torchjd/autojac/_transform/diagonalize.py
+++ b/src/torchjd/autojac/_transform/diagonalize.py
@@ -27,10 +27,6 @@ class Diagonalize(Transform[Gradients, Jacobians]):
         }
         return Jacobians(diagonalized_tensors)
 
-    @property
-    def required_keys(self) -> set[Tensor]:
-        return set(self.considered)
-
-    @property
-    def output_keys(self) -> set[Tensor]:
-        return set(self.considered)
+    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+        keys = set(self.considered)
+        return keys, keys

--- a/src/torchjd/autojac/_transform/diagonalize.py
+++ b/src/torchjd/autojac/_transform/diagonalize.py
@@ -18,7 +18,7 @@ class Diagonalize(Transform[Gradients, Jacobians]):
             self.indices.append((begin, end))
             begin = end
 
-    def _compute(self, tensors: Gradients) -> Jacobians:
+    def __call__(self, tensors: Gradients) -> Jacobians:
         flattened_considered_values = [tensors[key].reshape([-1]) for key in self.considered]
         diagonal_matrix = torch.cat(flattened_considered_values).diag()
         diagonalized_tensors = {

--- a/src/torchjd/autojac/_transform/init.py
+++ b/src/torchjd/autojac/_transform/init.py
@@ -21,5 +21,5 @@ class Init(Transform[EmptyTensorDict, Gradients]):
 
         return Gradients({value: torch.ones_like(value) for value in self.values})
 
-    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
         return set(), self.values

--- a/src/torchjd/autojac/_transform/init.py
+++ b/src/torchjd/autojac/_transform/init.py
@@ -21,10 +21,5 @@ class Init(Transform[EmptyTensorDict, Gradients]):
 
         return Gradients({value: torch.ones_like(value) for value in self.values})
 
-    @property
-    def required_keys(self) -> set[Tensor]:
-        return set()
-
-    @property
-    def output_keys(self) -> set[Tensor]:
-        return self.values
+    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+        return set(), self.values

--- a/src/torchjd/autojac/_transform/init.py
+++ b/src/torchjd/autojac/_transform/init.py
@@ -11,7 +11,7 @@ class Init(Transform[EmptyTensorDict, Gradients]):
     def __init__(self, values: Iterable[Tensor]):
         self.values = set(values)
 
-    def _compute(self, input: EmptyTensorDict) -> Gradients:
+    def __call__(self, input: EmptyTensorDict) -> Gradients:
         r"""
         Computes the gradients of the ``value`` with respect to itself. Returns the result as a
         dictionary. The only key of the dictionary is ``value``. The corresponding gradient is a

--- a/src/torchjd/autojac/_transform/select.py
+++ b/src/torchjd/autojac/_transform/select.py
@@ -14,7 +14,7 @@ class Select(Transform[_A, _A]):
         if not self.keys.issubset(self._required_keys):
             raise ValueError("Parameter `keys` should be a subset of parameter `required_keys`")
 
-    def _compute(self, tensor_dict: _A) -> _A:
+    def __call__(self, tensor_dict: _A) -> _A:
         output = {key: tensor_dict[key] for key in self.keys}
         return type(tensor_dict)(output)
 

--- a/src/torchjd/autojac/_transform/select.py
+++ b/src/torchjd/autojac/_transform/select.py
@@ -18,10 +18,5 @@ class Select(Transform[_A, _A]):
         output = {key: tensor_dict[key] for key in self.keys}
         return type(tensor_dict)(output)
 
-    @property
-    def required_keys(self) -> set[Tensor]:
-        return self._required_keys
-
-    @property
-    def output_keys(self) -> set[Tensor]:
-        return self.keys
+    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+        return self._required_keys, self.keys

--- a/src/torchjd/autojac/_transform/select.py
+++ b/src/torchjd/autojac/_transform/select.py
@@ -9,14 +9,15 @@ from .base import Transform
 class Select(Transform[_A, _A]):
     def __init__(self, keys: Iterable[Tensor], required_keys: Iterable[Tensor]):
         self.keys = set(keys)
-        self._required_keys = set(required_keys)
-
-        if not self.keys.issubset(self._required_keys):
-            raise ValueError("Parameter `keys` should be a subset of parameter `required_keys`")
+        self._required_keys = required_keys
 
     def __call__(self, tensor_dict: _A) -> _A:
         output = {key: tensor_dict[key] for key in self.keys}
         return type(tensor_dict)(output)
 
     def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
-        return self._required_keys, self.keys
+        required_keys = set(self._required_keys)
+        if not self.keys.issubset(required_keys):
+            raise ValueError("Parameter `keys` should be a subset of parameter `required_keys`")
+
+        return required_keys, self.keys

--- a/src/torchjd/autojac/_transform/select.py
+++ b/src/torchjd/autojac/_transform/select.py
@@ -9,7 +9,7 @@ from .base import Transform
 class Select(Transform[_A, _A]):
     def __init__(self, keys: Iterable[Tensor], required_keys: Iterable[Tensor]):
         self.keys = set(keys)
-        self._required_keys = required_keys
+        self._required_keys = set(required_keys)
 
     def __call__(self, tensor_dict: _A) -> _A:
         output = {key: tensor_dict[key] for key in self.keys}

--- a/src/torchjd/autojac/_transform/select.py
+++ b/src/torchjd/autojac/_transform/select.py
@@ -16,7 +16,7 @@ class Select(Transform[_A, _A]):
         return type(tensor_dict)(output)
 
     def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
-        required_keys = set(self._required_keys)
+        required_keys = self._required_keys
         if not self.keys.issubset(required_keys):
             raise ValueError("Parameter `keys` should be a subset of parameter `required_keys`")
 

--- a/src/torchjd/autojac/_transform/select.py
+++ b/src/torchjd/autojac/_transform/select.py
@@ -18,5 +18,5 @@ class Select(Transform[_A, _A]):
         output = {key: tensor_dict[key] for key in self.keys}
         return type(tensor_dict)(output)
 
-    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
         return self._required_keys, self.keys

--- a/src/torchjd/autojac/_transform/stack.py
+++ b/src/torchjd/autojac/_transform/stack.py
@@ -17,8 +17,8 @@ class Stack(Transform[_A, Jacobians]):
         result = _stack(results)
         return result
 
-    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
-        keys_pairs = [transform.check_keys() for transform in self.transforms]
+    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+        keys_pairs = [transform.check_and_get_keys() for transform in self.transforms]
 
         required_keys = set(key for required_keys, _ in keys_pairs for key in required_keys)
         output_keys = set(key for _, output_keys in keys_pairs for key in output_keys)

--- a/src/torchjd/autojac/_transform/stack.py
+++ b/src/torchjd/autojac/_transform/stack.py
@@ -12,7 +12,7 @@ class Stack(Transform[_A, Jacobians]):
     def __init__(self, transforms: Sequence[Transform[_A, Gradients]]):
         self.transforms = transforms
 
-    def _compute(self, input: _A) -> Jacobians:
+    def __call__(self, input: _A) -> Jacobians:
         results = [transform(input) for transform in self.transforms]
         result = _stack(results)
         return result

--- a/src/torchjd/autojac/_transform/stack.py
+++ b/src/torchjd/autojac/_transform/stack.py
@@ -12,25 +12,22 @@ class Stack(Transform[_A, Jacobians]):
     def __init__(self, transforms: Sequence[Transform[_A, Gradients]]):
         self.transforms = transforms
 
-        self._required_keys = {key for transform in transforms for key in transform.required_keys}
-        self._output_keys = {key for transform in transforms for key in transform.output_keys}
-
-        for transform in transforms:
-            if transform.required_keys != self.required_keys:
-                raise ValueError("All transforms should require the same set of keys.")
-
     def _compute(self, input: _A) -> Jacobians:
         results = [transform(input) for transform in self.transforms]
         result = _stack(results)
         return result
 
-    @property
-    def required_keys(self) -> set[Tensor]:
-        return self._required_keys
+    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+        keys_pairs = [transform.check_keys() for transform in self.transforms]
 
-    @property
-    def output_keys(self) -> set[Tensor]:
-        return self._output_keys
+        required_keys = set(key for required_keys, _ in keys_pairs for key in required_keys)
+        output_keys = set(key for _, output_keys in keys_pairs for key in output_keys)
+
+        for transform_required_keys, _ in keys_pairs:
+            if transform_required_keys != required_keys:
+                raise ValueError("All transforms should require the same set of keys.")
+
+        return required_keys, output_keys
 
 
 def _stack(gradient_dicts: list[Gradients]) -> Jacobians:

--- a/src/torchjd/autojac/_transform/tensor_dict.py
+++ b/src/torchjd/autojac/_transform/tensor_dict.py
@@ -14,19 +14,6 @@ class TensorDict(dict[Tensor, Tensor]):
         self._check_all_pairs(tensor_dict)
         super().__init__(tensor_dict)
 
-    def check_keys_are(self, keys: set[Tensor]) -> None:
-        """
-        Checks that the keys in the mapping are the same as the provided ``keys``.
-
-        :param keys: Keys that the mapping should (exclusively) contain.
-        """
-
-        if set(keys) != set(self.keys()):
-            raise ValueError(
-                f"The keys of the {self.__class__.__name__} should be {keys}. Found self.keys = "
-                f"{self.keys()}."
-            )
-
     @staticmethod
     def _check_dict(tensor_dict: dict[Tensor, Tensor]) -> None:
         pass

--- a/src/torchjd/autojac/backward.py
+++ b/src/torchjd/autojac/backward.py
@@ -79,7 +79,11 @@ def backward(
         inputs = set(inputs)
 
     backward_transform = _create_transform(
-        tensors, aggregator, inputs, retain_graph, parallel_chunk_size
+        tensors=tensors,
+        aggregator=aggregator,
+        inputs=inputs,
+        retain_graph=retain_graph,
+        parallel_chunk_size=parallel_chunk_size,
     )
 
     backward_transform(EmptyTensorDict())

--- a/src/torchjd/autojac/mtl_backward.py
+++ b/src/torchjd/autojac/mtl_backward.py
@@ -99,13 +99,13 @@ def mtl_backward(
         raise ValueError("`losses` and `tasks_params` should have the same size.")
 
     backward_transform = _create_transform(
-        losses,
-        features,
-        aggregator,
-        tasks_params,
-        shared_params,
-        retain_graph,
-        parallel_chunk_size,
+        losses=losses,
+        features=features,
+        aggregator=aggregator,
+        tasks_params=tasks_params,
+        shared_params=shared_params,
+        retain_graph=retain_graph,
+        parallel_chunk_size=parallel_chunk_size,
     )
 
     backward_transform(EmptyTensorDict())

--- a/src/torchjd/autojac/mtl_backward.py
+++ b/src/torchjd/autojac/mtl_backward.py
@@ -120,6 +120,11 @@ def _create_transform(
     retain_graph: bool,
     parallel_chunk_size: int | None,
 ) -> Transform[EmptyTensorDict, EmptyTensorDict]:
+    """
+    Creates the backward transform for a multi-task learning problem. It is a hybrid between
+    Jacobian descent (for shared parameters) and multiple gradient descent branches (for
+    task-specific parameters).
+    """
 
     shared_params = list(shared_params)
     tasks_params = [list(task_params) for task_params in tasks_params]

--- a/src/torchjd/autojac/mtl_backward.py
+++ b/src/torchjd/autojac/mtl_backward.py
@@ -133,7 +133,7 @@ def _create_transform(
     # loss w.r.t. the task's specific parameters, and computes and backpropagates the gradient of
     # the losses w.r.t. the shared representations.
     task_transforms = [
-        _make_task_transform(
+        _create_task_transform(
             features,
             task_params,
             loss,
@@ -158,7 +158,7 @@ def _create_transform(
     return accumulate << aggregate << jac << stack
 
 
-def _make_task_transform(
+def _create_task_transform(
     features: list[Tensor],
     tasks_params: list[Tensor],
     loss: Tensor,

--- a/tests/unit/autojac/_transform/test_accumulate.py
+++ b/tests/unit/autojac/_transform/test_accumulate.py
@@ -93,3 +93,15 @@ def test_no_leaf_and_no_retains_grad_fails():
 
     with raises(ValueError):
         accumulate(input)
+
+
+def test_check_and_get_keys():
+    """Tests that the `check_and_get_keys` method works correctly."""
+
+    key = torch.tensor([1.0], requires_grad=True)
+    accumulate = Accumulate([key])
+
+    required_keys, output_keys = accumulate.check_and_get_keys()
+
+    assert required_keys == {key}
+    assert output_keys == set()

--- a/tests/unit/autojac/_transform/test_aggregate.py
+++ b/tests/unit/autojac/_transform/test_aggregate.py
@@ -142,3 +142,42 @@ def test_reshape():
     }
 
     assert_tensor_dicts_are_close(output, expected_output)
+
+
+def test_aggregate_matrices_check_and_get_keys():
+    """Tests that the `check_and_get_keys` method works correctly."""
+
+    key1 = torch.tensor([1.0])
+    key2 = torch.tensor([2.0])
+    aggregate = _AggregateMatrices(Random(), [key2, key1])
+
+    required_keys, output_keys = aggregate.check_and_get_keys()
+
+    assert required_keys == {key1, key2}
+    assert output_keys == {key1, key2}
+
+
+def test_matrixify_check_and_get_keys():
+    """Tests that the `check_and_get_keys` method works correctly."""
+
+    key1 = torch.tensor([1.0])
+    key2 = torch.tensor([2.0])
+    matrixify = _Matrixify([key1, key2])
+
+    required_keys, output_keys = matrixify.check_and_get_keys()
+
+    assert required_keys == {key1, key2}
+    assert output_keys == {key1, key2}
+
+
+def test_reshape_check_and_get_keys():
+    """Tests that the `check_and_get_keys` method works correctly."""
+
+    key1 = torch.tensor([1.0])
+    key2 = torch.tensor([2.0])
+    reshape = _Reshape([key1, key2])
+
+    required_keys, output_keys = reshape.check_and_get_keys()
+
+    assert required_keys == {key1, key2}
+    assert output_keys == {key1, key2}

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -64,10 +64,10 @@ def test_compose_checks_keys():
     t1 = FakeTransform(required_keys={a1}, output_keys={a1, a2})
     t2 = FakeTransform(required_keys={a2}, output_keys={a1})
 
-    t1 << t2
+    (t1 << t2).check_keys()
 
     with raises(ValueError):
-        t2 << t1
+        (t2 << t1).check_keys()
 
 
 def test_conjunct_checks_required_keys():
@@ -83,13 +83,13 @@ def test_conjunct_checks_required_keys():
     t2 = FakeTransform(required_keys={a1}, output_keys=set())
     t3 = FakeTransform(required_keys={a2}, output_keys=set())
 
-    t1 | t2
+    (t1 | t2).check_keys()
 
     with raises(ValueError):
-        t2 | t3
+        (t2 | t3).check_keys()
 
     with raises(ValueError):
-        t1 | t2 | t3
+        (t1 | t2 | t3).check_keys()
 
 
 def test_conjunct_checks_output_keys():
@@ -105,13 +105,13 @@ def test_conjunct_checks_output_keys():
     t2 = FakeTransform(required_keys=set(), output_keys={a1})
     t3 = FakeTransform(required_keys=set(), output_keys={a2})
 
-    t2 | t3
+    (t2 | t3).check_keys()
 
     with raises(ValueError):
-        t1 | t3
+        (t1 | t3).check_keys()
 
     with raises(ValueError):
-        t1 | t2 | t3
+        (t1 | t2 | t3).check_keys()
 
 
 def test_empty_conjunction():

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -27,7 +27,7 @@ class FakeTransform(Transform[_B, _C]):
         output_dict = {key: torch.empty(0) for key in self._output_keys}
         return typing.cast(_C, output_dict)
 
-    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
         return self._required_keys, self._output_keys
 
 
@@ -42,10 +42,10 @@ def test_compose_checks_keys():
     t1 = FakeTransform(required_keys={a1}, output_keys={a1, a2})
     t2 = FakeTransform(required_keys={a2}, output_keys={a1})
 
-    (t1 << t2).check_keys()
+    (t1 << t2).check_and_get_keys()
 
     with raises(ValueError):
-        (t2 << t1).check_keys()
+        (t2 << t1).check_and_get_keys()
 
 
 def test_conjunct_checks_required_keys():
@@ -61,13 +61,13 @@ def test_conjunct_checks_required_keys():
     t2 = FakeTransform(required_keys={a1}, output_keys=set())
     t3 = FakeTransform(required_keys={a2}, output_keys=set())
 
-    (t1 | t2).check_keys()
+    (t1 | t2).check_and_get_keys()
 
     with raises(ValueError):
-        (t2 | t3).check_keys()
+        (t2 | t3).check_and_get_keys()
 
     with raises(ValueError):
-        (t1 | t2 | t3).check_keys()
+        (t1 | t2 | t3).check_and_get_keys()
 
 
 def test_conjunct_checks_output_keys():
@@ -83,13 +83,13 @@ def test_conjunct_checks_output_keys():
     t2 = FakeTransform(required_keys=set(), output_keys={a1})
     t3 = FakeTransform(required_keys=set(), output_keys={a2})
 
-    (t2 | t3).check_keys()
+    (t2 | t3).check_and_get_keys()
 
     with raises(ValueError):
-        (t1 | t3).check_keys()
+        (t1 | t3).check_and_get_keys()
 
     with raises(ValueError):
-        (t1 | t2 | t3).check_keys()
+        (t1 | t2 | t3).check_and_get_keys()
 
 
 def test_empty_conjunction():

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -31,28 +31,6 @@ class FakeTransform(Transform[_B, _C]):
         return self._required_keys, self._output_keys
 
 
-def test_call_checks_keys():
-    """
-    Tests that a ``Transform`` checks that the provided dictionary to the `__call__` function
-    contains keys that correspond exactly to `required_keys`.
-    """
-
-    a1 = torch.randn([2])
-    a2 = torch.randn([3])
-    t = FakeTransform(required_keys={a1}, output_keys={a1, a2})
-
-    t(TensorDict({a1: a2}))
-
-    with raises(ValueError):
-        t(TensorDict({a2: a1}))
-
-    with raises(ValueError):
-        t(TensorDict({}))
-
-    with raises(ValueError):
-        t(TensorDict({a1: a2, a2: a1}))
-
-
 def test_compose_checks_keys():
     """
     Tests that the composition of ``Transform``s checks that the inner transform's `output_keys`

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -27,13 +27,8 @@ class FakeTransform(Transform[_B, _C]):
         output_dict = {key: torch.empty(0) for key in self._output_keys}
         return typing.cast(_C, output_dict)
 
-    @property
-    def required_keys(self) -> set[Tensor]:
-        return self._required_keys
-
-    @property
-    def output_keys(self) -> set[Tensor]:
-        return self._output_keys
+    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+        return self._required_keys, self._output_keys
 
 
 def test_call_checks_keys():

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -21,7 +21,7 @@ class FakeTransform(Transform[_B, _C]):
     def __str__(self):
         return "T"
 
-    def _compute(self, input: _B) -> _C:
+    def __call__(self, input: _B) -> _C:
         # Ignore the input, create a dictionary with the right keys as an output.
         # Cast the type for the purpose of type-checking.
         output_dict = {key: torch.empty(0) for key in self._output_keys}

--- a/tests/unit/autojac/_transform/test_diagonalize.py
+++ b/tests/unit/autojac/_transform/test_diagonalize.py
@@ -95,3 +95,15 @@ def test_permute_order():
     expected_output = diag(input)
 
     assert_tensor_dicts_are_close(output, expected_output)
+
+
+def test_check_and_get_keys():
+    """Tests that the `check_and_get_keys` method works correctly."""
+
+    key = torch.tensor([1.0])
+    diag = Diagonalize([key])
+
+    required_keys, output_keys = diag.check_and_get_keys()
+
+    assert required_keys == {key}
+    assert output_keys == {key}

--- a/tests/unit/autojac/_transform/test_grad.py
+++ b/tests/unit/autojac/_transform/test_grad.py
@@ -281,3 +281,19 @@ def test_create_graph():
     gradients = grad(input)
 
     assert gradients[a].requires_grad
+
+
+def test_check_and_get_keys():
+    """Tests that the `check_and_get_keys` method works correctly."""
+
+    x = torch.tensor(5.0)
+    a1 = torch.tensor(2.0, requires_grad=True)
+    a2 = torch.tensor(3.0, requires_grad=True)
+    y = torch.stack([a1 * x, a2 * x])
+
+    grad = Grad(outputs=[y], inputs=[a1, a2])
+
+    required_keys, output_keys = grad.check_and_get_keys()
+
+    assert required_keys == {y}
+    assert output_keys == {a1, a2}

--- a/tests/unit/autojac/_transform/test_init.py
+++ b/tests/unit/autojac/_transform/test_init.py
@@ -61,3 +61,15 @@ def test_conjunction_of_inits_is_init():
     expected_output = init(input)
 
     assert_tensor_dicts_are_close(output, expected_output)
+
+
+def test_check_and_get_keys():
+    """Tests that the `check_and_get_keys` method works correctly."""
+
+    key = torch.tensor([1.0])
+    init = Init([key])
+
+    required_keys, output_keys = init.check_and_get_keys()
+
+    assert required_keys == set()
+    assert output_keys == {key}

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -262,4 +262,4 @@ def test_stack_different_required_keys():
     grad2 = Grad([y2], [a])
 
     with raises(ValueError):
-        _ = Stack([grad1, grad2])
+        Stack([grad1, grad2]).check_keys()

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -262,4 +262,4 @@ def test_stack_different_required_keys():
     grad2 = Grad([y2], [a])
 
     with raises(ValueError):
-        Stack([grad1, grad2]).check_keys()
+        Stack([grad1, grad2]).check_and_get_keys()

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -251,15 +251,24 @@ def test_equivalence_jac_grads():
     assert_close(jac_c, torch.stack([grad_1_c, grad_2_c]))
 
 
-def test_stack_different_required_keys():
-    """Tests that the Stack transform fails on transforms with different required keys."""
+def test_stack_check_and_get_keys():
+    """
+    Tests that the `check_and_get_keys` method works correctly for a stack of transforms: all of
+    them should have the same `required_keys`.
+    """
 
     a = torch.tensor(1.0, requires_grad=True)
     y1 = a * 2.0
     y2 = a * 3.0
 
     grad1 = Grad([y1], [a])
-    grad2 = Grad([y2], [a])
+    grad2 = Grad([y1], [a])
+    grad3 = Grad([y2], [a])
+
+    required_keys, output_keys = Stack([grad1, grad2]).check_and_get_keys()
+
+    assert required_keys == {y1}
+    assert output_keys == {a}
 
     with raises(ValueError):
-        Stack([grad1, grad2]).check_and_get_keys()
+        Stack([grad1, grad3]).check_and_get_keys()

--- a/tests/unit/autojac/_transform/test_jac.py
+++ b/tests/unit/autojac/_transform/test_jac.py
@@ -281,3 +281,19 @@ def test_create_graph():
 
     assert jacobians[a1].requires_grad
     assert jacobians[a2].requires_grad
+
+
+def test_check_and_get_keys():
+    """Tests that the `check_and_get_keys` method works correctly."""
+
+    x = torch.tensor(5.0)
+    a1 = torch.tensor(2.0, requires_grad=True)
+    a2 = torch.tensor(3.0, requires_grad=True)
+    y = torch.stack([a1 * x, a2 * x])
+
+    jac = Jac(outputs=[y], inputs=[a1, a2], chunk_size=None)
+
+    required_keys, output_keys = jac.check_and_get_keys()
+
+    assert required_keys == {y}
+    assert output_keys == {a1, a2}

--- a/tests/unit/autojac/_transform/test_stack.py
+++ b/tests/unit/autojac/_transform/test_stack.py
@@ -20,7 +20,7 @@ class FakeGradientsTransform(Transform[EmptyTensorDict, Gradients]):
     def __call__(self, input: EmptyTensorDict) -> Gradients:
         return Gradients({key: torch.ones_like(key) for key in self.keys})
 
-    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
         return set(), self.keys
 
 

--- a/tests/unit/autojac/_transform/test_stack.py
+++ b/tests/unit/autojac/_transform/test_stack.py
@@ -20,13 +20,8 @@ class FakeGradientsTransform(Transform[EmptyTensorDict, Gradients]):
     def _compute(self, input: EmptyTensorDict) -> Gradients:
         return Gradients({key: torch.ones_like(key) for key in self.keys})
 
-    @property
-    def required_keys(self) -> set[Tensor]:
-        return set()
-
-    @property
-    def output_keys(self) -> set[Tensor]:
-        return self.keys
+    def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:
+        return set(), self.keys
 
 
 def test_single_key():

--- a/tests/unit/autojac/_transform/test_stack.py
+++ b/tests/unit/autojac/_transform/test_stack.py
@@ -17,7 +17,7 @@ class FakeGradientsTransform(Transform[EmptyTensorDict, Gradients]):
     def __init__(self, keys: Iterable[Tensor]):
         self.keys = set(keys)
 
-    def _compute(self, input: EmptyTensorDict) -> Gradients:
+    def __call__(self, input: EmptyTensorDict) -> Gradients:
         return Gradients({key: torch.ones_like(key) for key in self.keys})
 
     def check_keys(self) -> tuple[set[Tensor], set[Tensor]]:

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -5,6 +5,20 @@ from torch.testing import assert_close
 
 from torchjd import backward
 from torchjd.aggregation import MGDA, Aggregator, Mean, Random, Sum, UPGrad
+from torchjd.autojac.backward import _create_transform
+
+
+def test_check_create_transform():
+    """Tests that _create_transform creates a valid Transform"""
+
+    a1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    a2 = torch.tensor([3.0, 4.0], requires_grad=True)
+
+    y1 = torch.tensor([-1.0, 1.0]) @ a1 + a2.sum()
+    y2 = (a1**2).sum() + a2.norm()
+
+    transform = _create_transform([y1, y2], Mean(), {a1, a2}, False, None)
+    _ = transform.check_keys()
 
 
 @mark.parametrize("aggregator", [Mean(), UPGrad(), MGDA(), Random()])

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -18,7 +18,7 @@ def test_check_create_transform():
     y2 = (a1**2).sum() + a2.norm()
 
     transform = _create_transform([y1, y2], Mean(), {a1, a2}, False, None)
-    _ = transform.check_keys()
+    _ = transform.check_and_get_keys()
 
 
 @mark.parametrize("aggregator", [Mean(), UPGrad(), MGDA(), Random()])

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -18,7 +18,10 @@ def test_check_create_transform():
     y2 = (a1**2).sum() + a2.norm()
 
     transform = _create_transform([y1, y2], Mean(), {a1, a2}, False, None)
-    _ = transform.check_and_get_keys()
+    required_keys, output_keys = transform.check_and_get_keys()
+
+    assert required_keys == set()
+    assert output_keys == set()
 
 
 @mark.parametrize("aggregator", [Mean(), UPGrad(), MGDA(), Random()])

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -17,7 +17,13 @@ def test_check_create_transform():
     y1 = torch.tensor([-1.0, 1.0]) @ a1 + a2.sum()
     y2 = (a1**2).sum() + a2.norm()
 
-    transform = _create_transform([y1, y2], Mean(), {a1, a2}, False, None)
+    transform = _create_transform(
+        tensors=[y1, y2],
+        aggregator=Mean(),
+        inputs={a1, a2},
+        retain_graph=False,
+        parallel_chunk_size=None,
+    )
     required_keys, output_keys = transform.check_and_get_keys()
 
     assert required_keys == set()

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -21,7 +21,7 @@ def test_check_create_transform():
     y2 = f1 * p2[0] + f2 * p2[1]
 
     transform = _create_transform([y1, y2], [f1, f2], Mean(), [[p1], [p2]], {p0}, False, None)
-    transform.check_keys()
+    transform.check_and_get_keys()
 
 
 @mark.parametrize("aggregator", [Mean(), UPGrad(), MGDA(), Random()])

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -21,7 +21,10 @@ def test_check_create_transform():
     y2 = f1 * p2[0] + f2 * p2[1]
 
     transform = _create_transform([y1, y2], [f1, f2], Mean(), [[p1], [p2]], {p0}, False, None)
-    transform.check_and_get_keys()
+    required_keys, output_keys = transform.check_and_get_keys()
+
+    assert required_keys == set()
+    assert output_keys == set()
 
 
 @mark.parametrize("aggregator", [Mean(), UPGrad(), MGDA(), Random()])

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -5,6 +5,22 @@ from torch.testing import assert_close
 
 from torchjd import mtl_backward
 from torchjd.aggregation import MGDA, Aggregator, Mean, Random, Sum, UPGrad
+from torchjd.autojac.mtl_backward import _create_transform
+
+
+def test_check_create_transform():
+    """Tests that _create_transform creates a valid Transform"""
+
+    p0 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p1 = torch.tensor([1.0, 2.0], requires_grad=True)
+    p2 = torch.tensor([3.0, 4.0], requires_grad=True)
+
+    f1 = torch.tensor([-1.0, 1.0]) @ p0
+    f2 = (p0**2).sum() + p0.norm()
+    y1 = f1 * p1[0] + f2 * p1[1]
+    y2 = f1 * p2[0] + f2 * p2[1]
+
+    _create_transform([y1, y2], [f1, f2], Mean(), [[p1], [p2]], {p0}, False, None)
 
 
 @mark.parametrize("aggregator", [Mean(), UPGrad(), MGDA(), Random()])

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -20,7 +20,8 @@ def test_check_create_transform():
     y1 = f1 * p1[0] + f2 * p1[1]
     y2 = f1 * p2[0] + f2 * p2[1]
 
-    _create_transform([y1, y2], [f1, f2], Mean(), [[p1], [p2]], {p0}, False, None)
+    transform = _create_transform([y1, y2], [f1, f2], Mean(), [[p1], [p2]], {p0}, False, None)
+    transform.check_keys()
 
 
 @mark.parametrize("aggregator", [Mean(), UPGrad(), MGDA(), Random()])

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -20,7 +20,15 @@ def test_check_create_transform():
     y1 = f1 * p1[0] + f2 * p1[1]
     y2 = f1 * p2[0] + f2 * p2[1]
 
-    transform = _create_transform([y1, y2], [f1, f2], Mean(), [[p1], [p2]], {p0}, False, None)
+    transform = _create_transform(
+        losses=[y1, y2],
+        features=[f1, f2],
+        aggregator=Mean(),
+        tasks_params=[[p1], [p2]],
+        shared_params={p0},
+        retain_graph=False,
+        parallel_chunk_size=None,
+    )
     required_keys, output_keys = transform.check_and_get_keys()
 
     assert required_keys == set()


### PR DESCRIPTION
* Add method check_and_get_keys to all transforms
* Move checks related to keys from __init__ to check_and_get_keys, and make them recursive
* Remove required_keys and output_keys properties
* Remove check_keys_are call on the input keys in __call__ and remove check_keys_are from TensorDict
* Replace _compute with __call__
* Change some tests of __init__ into equivalent tests of check_and_get_keys
* Add new tests for check_and_get_keys
* Extract the creation of the transform in backward and mlt_backward into their _create_transform functions
* Rename _make_task_transform to _create_task_transform for uniformity
* Add test_check_create_transform for these functions
* Add changelog entry