### PR TITLE
Explicit dependence on gramians

### DIFF
--- a/src/torchjd/aggregation/aligned_mtl.py
+++ b/src/torchjd/aggregation/aligned_mtl.py
@@ -91,16 +91,14 @@ class _AlignedMTLWrapper(_Weighting):
     def forward(self, matrix: Tensor) -> Tensor:
         w = self.weighting(matrix)
 
-        G = matrix.T
-        B = self._compute_balance_transformation(G)
+        M = matrix @ matrix.T
+        B = self._compute_balance_transformation(M)
         alpha = B @ w
 
         return alpha
 
     @staticmethod
-    def _compute_balance_transformation(G: Tensor) -> Tensor:
-        M = G.T @ G
-
+    def _compute_balance_transformation(M: Tensor) -> Tensor:
         lambda_, V = torch.linalg.eigh(M, UPLO="U")  # More modern equivalent to torch.symeig
         tol = torch.max(lambda_) * len(M) * torch.finfo().eps
         rank = sum(lambda_ > tol)

--- a/src/torchjd/aggregation/aligned_mtl.py
+++ b/src/torchjd/aggregation/aligned_mtl.py
@@ -28,6 +28,7 @@
 import torch
 from torch import Tensor
 
+from ._gramian_utils import compute_gramian
 from ._pref_vector_utils import pref_vector_to_str_suffix, pref_vector_to_weighting
 from .bases import _WeightedAggregator, _Weighting
 from .mean import _MeanWeighting
@@ -91,7 +92,7 @@ class _AlignedMTLWrapper(_Weighting):
     def forward(self, matrix: Tensor) -> Tensor:
         w = self.weighting(matrix)
 
-        M = matrix @ matrix.T
+        M = compute_gramian(matrix)
         B = self._compute_balance_transformation(M)
         alpha = B @ w
 

--- a/src/torchjd/aggregation/cagrad.py
+++ b/src/torchjd/aggregation/cagrad.py
@@ -72,11 +72,11 @@ class _CAGradWeighting(_Weighting):
         self.norm_eps = norm_eps
 
     def forward(self, matrix: Tensor) -> Tensor:
-        gramian = normalize(compute_gramian(matrix), self.norm_eps)
+        gramian = compute_gramian(matrix)
         return self._compute_from_gramian(gramian)
 
     def _compute_from_gramian(self, gramian: Tensor) -> Tensor:
-        U, S, _ = torch.svd(gramian)
+        U, S, _ = torch.svd(normalize(gramian, self.norm_eps))
 
         reduced_matrix = U @ S.sqrt().diag()
         reduced_array = reduced_matrix.cpu().detach().numpy().astype(np.float64)

--- a/src/torchjd/aggregation/cagrad.py
+++ b/src/torchjd/aggregation/cagrad.py
@@ -73,12 +73,15 @@ class _CAGradWeighting(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         gramian = normalize(compute_gramian(matrix), self.norm_eps)
+        return self._compute_from_gramian(gramian)
+
+    def _compute_from_gramian(self, gramian: Tensor) -> Tensor:
         U, S, _ = torch.svd(gramian)
 
         reduced_matrix = U @ S.sqrt().diag()
         reduced_array = reduced_matrix.cpu().detach().numpy().astype(np.float64)
 
-        dimension = matrix.shape[0]
+        dimension = gramian.shape[0]
         reduced_g_0 = reduced_array.T @ np.ones(dimension) / dimension
         sqrt_phi = self.c * np.linalg.norm(reduced_g_0, 2)
 
@@ -97,6 +100,6 @@ class _CAGradWeighting(_Weighting):
             # We are approximately on the pareto front
             weight_array = np.zeros(dimension)
 
-        weights = torch.from_numpy(weight_array).to(device=matrix.device, dtype=matrix.dtype)
+        weights = torch.from_numpy(weight_array).to(device=gramian.device, dtype=gramian.dtype)
 
         return weights

--- a/src/torchjd/aggregation/imtl_g.py
+++ b/src/torchjd/aggregation/imtl_g.py
@@ -38,8 +38,13 @@ class _IMTLGWeighting(_Weighting):
     """
 
     def forward(self, matrix: Tensor) -> Tensor:
-        d = torch.linalg.norm(matrix, dim=1)
-        v = torch.linalg.pinv(matrix @ matrix.T) @ d
+        gramian = matrix @ matrix.T
+        return self._compute_from_gramian(gramian)
+
+    @staticmethod
+    def _compute_from_gramian(gramian: Tensor) -> Tensor:
+        d = torch.sqrt(torch.diagonal(gramian))
+        v = torch.linalg.pinv(gramian) @ d
         v_sum = v.sum()
 
         if v_sum.abs() < 1e-12:

--- a/src/torchjd/aggregation/imtl_g.py
+++ b/src/torchjd/aggregation/imtl_g.py
@@ -1,6 +1,7 @@
 import torch
 from torch import Tensor
 
+from ._gramian_utils import compute_gramian
 from .bases import _WeightedAggregator, _Weighting
 
 
@@ -38,7 +39,7 @@ class _IMTLGWeighting(_Weighting):
     """
 
     def forward(self, matrix: Tensor) -> Tensor:
-        gramian = matrix @ matrix.T
+        gramian = compute_gramian(matrix)
         return self._compute_from_gramian(gramian)
 
     @staticmethod

--- a/src/torchjd/aggregation/krum.py
+++ b/src/torchjd/aggregation/krum.py
@@ -2,6 +2,7 @@ import torch
 from torch import Tensor
 from torch.nn import functional as F
 
+from ._gramian_utils import compute_gramian
 from .bases import _WeightedAggregator, _Weighting
 
 
@@ -80,7 +81,7 @@ class _KrumWeighting(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         self._check_matrix_shape(matrix)
-        gramian = matrix @ matrix.T
+        gramian = compute_gramian(matrix)
         return self._compute_from_gramian(gramian)
 
     def _compute_from_gramian(self, gramian: Tensor) -> Tensor:

--- a/src/torchjd/aggregation/mgda.py
+++ b/src/torchjd/aggregation/mgda.py
@@ -56,7 +56,12 @@ class _MGDAWeighting(_Weighting):
         self.epsilon = epsilon
         self.max_iters = max_iters
 
-    def _frank_wolfe_solver(self, gramian: Tensor) -> Tensor:
+    def _compute_from_gramian(self, gramian: Tensor) -> Tensor:
+        """
+        This is the Frank-Wolfe solver in Algorithm 2 of `Multi-Task Learning as Multi-Objective
+        Optimization
+        <https://proceedings.neurips.cc/paper_files/paper/2018/file/432aca3a1e345e339f35a30c8f65edce-Paper.pdf>`_.
+        """
         device = gramian.device
         dtype = gramian.dtype
 
@@ -81,5 +86,5 @@ class _MGDAWeighting(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         gramian = compute_gramian(matrix)
-        weights = self._frank_wolfe_solver(gramian)
+        weights = self._compute_from_gramian(gramian)
         return weights

--- a/src/torchjd/aggregation/mgda.py
+++ b/src/torchjd/aggregation/mgda.py
@@ -56,15 +56,14 @@ class _MGDAWeighting(_Weighting):
         self.epsilon = epsilon
         self.max_iters = max_iters
 
-    def _frank_wolfe_solver(self, matrix: Tensor) -> Tensor:
-        gramian = compute_gramian(matrix)
-        device = matrix.device
-        dtype = matrix.dtype
+    def _frank_wolfe_solver(self, gramian: Tensor) -> Tensor:
+        device = gramian.device
+        dtype = gramian.dtype
 
-        alpha = torch.ones(matrix.shape[0], device=device, dtype=dtype) / matrix.shape[0]
+        alpha = torch.ones(gramian.shape[0], device=device, dtype=dtype) / gramian.shape[0]
         for i in range(self.max_iters):
             t = torch.argmin(gramian @ alpha)
-            e_t = torch.zeros(matrix.shape[0], device=device, dtype=dtype)
+            e_t = torch.zeros(gramian.shape[0], device=device, dtype=dtype)
             e_t[t] = 1.0
             a = alpha @ (gramian @ e_t)
             b = alpha @ (gramian @ alpha)
@@ -81,5 +80,6 @@ class _MGDAWeighting(_Weighting):
         return alpha
 
     def forward(self, matrix: Tensor) -> Tensor:
-        weights = self._frank_wolfe_solver(matrix)
+        gramian = compute_gramian(matrix)
+        weights = self._frank_wolfe_solver(gramian)
         return weights

--- a/src/torchjd/aggregation/pcgrad.py
+++ b/src/torchjd/aggregation/pcgrad.py
@@ -1,6 +1,7 @@
 import torch
 from torch import Tensor
 
+from ._gramian_utils import compute_gramian
 from .bases import _WeightedAggregator, _Weighting
 
 
@@ -41,18 +42,18 @@ class _PCGradWeighting(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         # Pre-compute the inner products
-        gramian = matrix @ matrix.T
+        gramian = compute_gramian(matrix)
         return self._compute_from_gramian(gramian)
 
     @staticmethod
-    def _compute_from_gramian(inner_products: Tensor) -> Tensor:
+    def _compute_from_gramian(gramian: Tensor) -> Tensor:
         # Move all computations on cpu to avoid moving memory between cpu and gpu at each iteration
-        device = inner_products.device
-        dtype = inner_products.dtype
+        device = gramian.device
+        dtype = gramian.dtype
         cpu = torch.device("cpu")
-        inner_products = inner_products.to(device=cpu)
+        gramian = gramian.to(device=cpu)
 
-        dimension = inner_products.shape[0]
+        dimension = gramian.shape[0]
         weights = torch.zeros(dimension, device=cpu, dtype=dtype)
 
         for i in range(dimension):
@@ -65,10 +66,10 @@ class _PCGradWeighting(_Weighting):
                     continue
 
                 # Compute the inner product between g_i^{PC} and g_j
-                inner_product = inner_products[j] @ current_weights
+                inner_product = gramian[j] @ current_weights
 
                 if inner_product < 0.0:
-                    current_weights[j] -= inner_product / (inner_products[j, j])
+                    current_weights[j] -= inner_product / (gramian[j, j])
 
             weights = weights + current_weights
 

--- a/src/torchjd/aggregation/pcgrad.py
+++ b/src/torchjd/aggregation/pcgrad.py
@@ -41,11 +41,14 @@ class _PCGradWeighting(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         # Pre-compute the inner products
-        inner_products = matrix @ matrix.T
+        gramian = matrix @ matrix.T
+        return self._compute_from_gramian(gramian)
 
+    @staticmethod
+    def _compute_from_gramian(inner_products: Tensor) -> Tensor:
         # Move all computations on cpu to avoid moving memory between cpu and gpu at each iteration
-        device = matrix.device
-        dtype = matrix.dtype
+        device = inner_products.device
+        dtype = inner_products.dtype
         cpu = torch.device("cpu")
         inner_products = inner_products.to(device=cpu)
 


### PR DESCRIPTION
All aggregators can be computed from the Gramian except:
- [Trimmed Mean](https://torchjd.org/docs/aggregation/trimmed_mean/)
- [GradDrop](https://torchjd.org/docs/aggregation/graddrop/)
- [ConFIG](https://torchjd.org/stable/docs/aggregation/config/)

These commits makes this dependence explicit for all aggregators that do depend on the input matrix, for the rest (mean, sum, random and constant) it can obviously be done but computing the Gramian induces extra computations.