### PR TITLE
Refactor key requirements

### DIFF
--- a/src/torchjd/autojac/_transform/__init__.py
+++ b/src/torchjd/autojac/_transform/__init__.py
@@ -1,6 +1,6 @@
 from .accumulate import Accumulate
 from .aggregate import Aggregate
-from .base import Composition, Conjunction, Transform
+from .base import Composition, Conjunction, RequirementError, Transform
 from .diagonalize import Diagonalize
 from .grad import Grad
 from .init import Init

--- a/src/torchjd/autojac/_transform/_differentiate.py
+++ b/src/torchjd/autojac/_transform/_differentiate.py
@@ -40,9 +40,9 @@ class _Differentiate(Transform[_A, _A], ABC):
 
     def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
         outputs = set(self.outputs)
-        if not outputs.issubset(input_keys):
+        if not outputs == input_keys:
             raise RequirementError(
-                f"The input_keys needs to be a super set of the outputs. Found {input_keys} and "
-                f"{outputs}"
+                f"The input_keys must match the expected outputs. Found input_keys {input_keys} and"
+                f"outputs {outputs}."
             )
         return set(self.inputs)

--- a/src/torchjd/autojac/_transform/_differentiate.py
+++ b/src/torchjd/autojac/_transform/_differentiate.py
@@ -3,7 +3,7 @@ from typing import Iterable, Sequence
 
 from torch import Tensor
 
-from .base import _A, Transform
+from .base import _A, RequirementError, Transform
 from .ordered_set import OrderedSet
 
 
@@ -38,6 +38,11 @@ class _Differentiate(Transform[_A, _A], ABC):
         tensor_outputs should be.
         """
 
-    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
-        # outputs in the forward direction become inputs in the backward direction, and vice-versa
-        return set(self.outputs), set(self.inputs)
+    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+        outputs = set(self.outputs)
+        if not outputs.issubset(input_keys):
+            raise RequirementError(
+                f"The input_keys needs to be a super set of the outputs. Found {input_keys} and "
+                f"{outputs}"
+            )
+        return set(self.inputs)

--- a/src/torchjd/autojac/_transform/accumulate.py
+++ b/src/torchjd/autojac/_transform/accumulate.py
@@ -2,7 +2,7 @@ from typing import Iterable
 
 from torch import Tensor
 
-from .base import Transform
+from .base import RequirementError, Transform
 from .tensor_dict import EmptyTensorDict, Gradients
 
 
@@ -34,7 +34,7 @@ class Accumulate(Transform[Gradients, EmptyTensorDict]):
 
 def _check_expects_grad(tensor: Tensor) -> None:
     if not _expects_grad(tensor):
-        raise ValueError(
+        raise RequirementError(
             "Cannot populate the .grad field of a Tensor that does not satisfy:"
             "`tensor.requires_grad and (tensor.is_leaf or tensor.retains_grad)`."
         )

--- a/src/torchjd/autojac/_transform/accumulate.py
+++ b/src/torchjd/autojac/_transform/accumulate.py
@@ -1,15 +1,10 @@
-from typing import Iterable
-
 from torch import Tensor
 
-from .base import RequirementError, Transform
+from .base import Transform
 from .tensor_dict import EmptyTensorDict, Gradients
 
 
 class Accumulate(Transform[Gradients, EmptyTensorDict]):
-    def __init__(self, required_keys: Iterable[Tensor]):
-        self._required_keys = set(required_keys)
-
     def __call__(self, gradients: Gradients) -> EmptyTensorDict:
         """
         Accumulates gradients with respect to keys in their ``.grad`` field.
@@ -29,11 +24,6 @@ class Accumulate(Transform[Gradients, EmptyTensorDict]):
         return EmptyTensorDict()
 
     def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
-        if not self._required_keys.issubset(input_keys):
-            raise RequirementError(
-                f"The input_keys needs to be a super set of the required_keys. Found {input_keys} "
-                f"and {self._required_keys}"
-            )
         return set()
 
 

--- a/src/torchjd/autojac/_transform/accumulate.py
+++ b/src/torchjd/autojac/_transform/accumulate.py
@@ -28,8 +28,13 @@ class Accumulate(Transform[Gradients, EmptyTensorDict]):
 
         return EmptyTensorDict()
 
-    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
-        return self._required_keys, set()
+    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+        if not self._required_keys.issubset(input_keys):
+            raise RequirementError(
+                f"The input_keys needs to be a super set of the required_keys. Found {input_keys} "
+                f"and {self._required_keys}"
+            )
+        return set()
 
 
 def _check_expects_grad(tensor: Tensor) -> None:

--- a/src/torchjd/autojac/_transform/accumulate.py
+++ b/src/torchjd/autojac/_transform/accumulate.py
@@ -39,7 +39,7 @@ class Accumulate(Transform[Gradients, EmptyTensorDict]):
 
 def _check_expects_grad(tensor: Tensor) -> None:
     if not _expects_grad(tensor):
-        raise RequirementError(
+        raise ValueError(
             "Cannot populate the .grad field of a Tensor that does not satisfy:"
             "`tensor.requires_grad and (tensor.is_leaf or tensor.retains_grad)`."
         )

--- a/src/torchjd/autojac/_transform/aggregate.py
+++ b/src/torchjd/autojac/_transform/aggregate.py
@@ -51,7 +51,8 @@ class _AggregateMatrices(Transform[JacobianMatrices, GradientVectors]):
     def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
         if not set(self.key_order) == input_keys:
             raise RequirementError(
-                f"The input_keys must match the key_order. Found {input_keys} and {self.key_order}"
+                f"The input_keys must match the key_order. Found input_keys {input_keys} and"
+                f"key_order {self.key_order}."
             )
         return input_keys
 

--- a/src/torchjd/autojac/_transform/base.py
+++ b/src/torchjd/autojac/_transform/base.py
@@ -9,6 +9,8 @@ from ._utils import _A, _B, _C, _union
 
 
 class RequirementError(ValueError):
+    """Inappropriate set of inputs keys."""
+
     pass
 
 

--- a/src/torchjd/autojac/_transform/base.py
+++ b/src/torchjd/autojac/_transform/base.py
@@ -52,11 +52,14 @@ class Transform(Generic[_B, _C], ABC):
     @abstractmethod
     def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
         """
-        Checks the keys of the Transform for the provided input_keys and returns the corresponding
-        output keys for recursion.
+        Checks that the provided input_keys satisfy the transform's requirements and returns the
+        corresponding output keys for recursion.
 
-        The output keys are the set of keys that will be present in the output TensorDict of the
-        transform given that the provided TensorDict has the provided input_keys.
+        If the provided input_keys do not satisfy the transform's requirements, raises a
+        RequirementError.
+
+        The output keys are the set of keys of the output TensorDict of the transform when the input
+        TensorDict's keys are input_keys.
         """
 
     __lshift__ = compose

--- a/src/torchjd/autojac/_transform/base.py
+++ b/src/torchjd/autojac/_transform/base.py
@@ -8,6 +8,10 @@ from torch import Tensor
 from ._utils import _A, _B, _C, _union
 
 
+class RequirementError(ValueError):
+    pass
+
+
 class Transform(Generic[_B, _C], ABC):
     r"""
     Abstract base class for all transforms. Transforms are elementary building blocks of a jacobian
@@ -77,7 +81,7 @@ class Composition(Transform[_A, _C]):
         outer_required_keys, outer_output_keys = self.outer.check_and_get_keys()
         inner_required_keys, inner_output_keys = self.inner.check_and_get_keys()
         if outer_required_keys != inner_output_keys:
-            raise ValueError(
+            raise RequirementError(
                 "The `output_keys` of `inner` must match with the `required_keys` of "
                 f"outer. Found {outer_required_keys} and {inner_output_keys}"
             )
@@ -108,12 +112,12 @@ class Conjunction(Transform[_A, _B]):
         required_keys = set(key for required_keys, _ in keys_pairs for key in required_keys)
         for transform_required_keys, _ in keys_pairs:
             if transform_required_keys != required_keys:
-                raise ValueError("All transforms should require the same set of keys.")
+                raise RequirementError("All transforms should require the same set of keys.")
 
         output_keys_with_duplicates = [key for _, output_keys in keys_pairs for key in output_keys]
         output_keys = set(output_keys_with_duplicates)
 
         if len(output_keys) != len(output_keys_with_duplicates):
-            raise ValueError("The sets of output keys of transforms should be disjoint.")
+            raise RequirementError("The sets of output keys of transforms should be disjoint.")
 
         return required_keys, output_keys

--- a/src/torchjd/autojac/_transform/base.py
+++ b/src/torchjd/autojac/_transform/base.py
@@ -80,7 +80,8 @@ class Composition(Transform[_A, _C]):
 
     def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
         intermediate_keys = self.inner.check_keys(input_keys)
-        return self.outer.check_keys(intermediate_keys)
+        output_keys = self.outer.check_keys(intermediate_keys)
+        return output_keys
 
 
 class Conjunction(Transform[_A, _B]):

--- a/src/torchjd/autojac/_transform/diagonalize.py
+++ b/src/torchjd/autojac/_transform/diagonalize.py
@@ -31,7 +31,7 @@ class Diagonalize(Transform[Gradients, Jacobians]):
         considered = set(self.considered)
         if not considered.issubset(input_keys):
             raise RequirementError(
-                f"The input_keys needs to be a super set of the considered keys. Found {input_keys} "
-                f"and {considered}"
+                f"The input_keys should be a super set of the considered keys. Found input_keys "
+                f"{input_keys} and considered keys {considered}."
             )
         return considered

--- a/src/torchjd/autojac/_transform/diagonalize.py
+++ b/src/torchjd/autojac/_transform/diagonalize.py
@@ -3,7 +3,7 @@ from typing import Iterable
 import torch
 from torch import Tensor
 
-from .base import Transform
+from .base import RequirementError, Transform
 from .ordered_set import OrderedSet
 from .tensor_dict import Gradients, Jacobians
 
@@ -27,6 +27,11 @@ class Diagonalize(Transform[Gradients, Jacobians]):
         }
         return Jacobians(diagonalized_tensors)
 
-    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
-        keys = set(self.considered)
-        return keys, keys
+    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+        considered = set(self.considered)
+        if not considered.issubset(input_keys):
+            raise RequirementError(
+                f"The input_keys needs to be a super set of the considered keys. Found {input_keys} "
+                f"and {considered}"
+            )
+        return considered

--- a/src/torchjd/autojac/_transform/diagonalize.py
+++ b/src/torchjd/autojac/_transform/diagonalize.py
@@ -29,9 +29,9 @@ class Diagonalize(Transform[Gradients, Jacobians]):
 
     def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
         considered = set(self.considered)
-        if not considered.issubset(input_keys):
+        if not considered == input_keys:
             raise RequirementError(
-                f"The input_keys should be a super set of the considered keys. Found input_keys "
-                f"{input_keys} and considered keys {considered}."
+                f"The input_keys must match the considered keys. Found input_keys {input_keys} and"
+                f"considered keys {considered}."
             )
         return considered

--- a/src/torchjd/autojac/_transform/init.py
+++ b/src/torchjd/autojac/_transform/init.py
@@ -24,6 +24,6 @@ class Init(Transform[EmptyTensorDict, Gradients]):
     def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
         if not input_keys == set():
             raise RequirementError(
-                f"The input_keys should be the empty set. Found input_keys" f"{input_keys}."
+                f"The input_keys should be the empty set. Found input_keys {input_keys}."
             )
         return self.values

--- a/src/torchjd/autojac/_transform/init.py
+++ b/src/torchjd/autojac/_transform/init.py
@@ -3,7 +3,7 @@ from typing import Iterable
 import torch
 from torch import Tensor
 
-from .base import Transform
+from .base import RequirementError, Transform
 from .tensor_dict import EmptyTensorDict, Gradients
 
 
@@ -21,5 +21,7 @@ class Init(Transform[EmptyTensorDict, Gradients]):
 
         return Gradients({value: torch.ones_like(value) for value in self.values})
 
-    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
-        return set(), self.values
+    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+        if input_keys == set():
+            raise RequirementError(f"Init expects an empty set of input_keys. Found {input_keys}")
+        return self.values

--- a/src/torchjd/autojac/_transform/init.py
+++ b/src/torchjd/autojac/_transform/init.py
@@ -22,6 +22,6 @@ class Init(Transform[EmptyTensorDict, Gradients]):
         return Gradients({value: torch.ones_like(value) for value in self.values})
 
     def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
-        if input_keys == set():
+        if not input_keys == set():
             raise RequirementError(f"The input_keys should be the empty set. Found {input_keys}.")
         return self.values

--- a/src/torchjd/autojac/_transform/init.py
+++ b/src/torchjd/autojac/_transform/init.py
@@ -23,5 +23,7 @@ class Init(Transform[EmptyTensorDict, Gradients]):
 
     def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
         if not input_keys == set():
-            raise RequirementError(f"The input_keys should be the empty set. Found {input_keys}.")
+            raise RequirementError(
+                f"The input_keys should be the empty set. Found input_keys" f"{input_keys}."
+            )
         return self.values

--- a/src/torchjd/autojac/_transform/init.py
+++ b/src/torchjd/autojac/_transform/init.py
@@ -23,5 +23,5 @@ class Init(Transform[EmptyTensorDict, Gradients]):
 
     def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
         if input_keys == set():
-            raise RequirementError(f"Init expects an empty set of input_keys. Found {input_keys}")
+            raise RequirementError(f"The input_keys should be the empty set. Found {input_keys}.")
         return self.values

--- a/src/torchjd/autojac/_transform/select.py
+++ b/src/torchjd/autojac/_transform/select.py
@@ -7,19 +7,17 @@ from .base import RequirementError, Transform
 
 
 class Select(Transform[_A, _A]):
-    def __init__(self, keys: Iterable[Tensor], required_keys: Iterable[Tensor]):
+    def __init__(self, keys: Iterable[Tensor]):
         self.keys = set(keys)
-        self._required_keys = set(required_keys)
 
     def __call__(self, tensor_dict: _A) -> _A:
         output = {key: tensor_dict[key] for key in self.keys}
         return type(tensor_dict)(output)
 
-    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
-        required_keys = self._required_keys
-        if not self.keys.issubset(required_keys):
+    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+        if not self.keys.issubset(input_keys):
             raise RequirementError(
-                "Parameter `keys` should be a subset of parameter `required_keys`"
+                f"The input_keys needs to be a super set of the keys to select. Found {input_keys} "
+                f"and {self.keys}"
             )
-
-        return required_keys, self.keys
+        return self.keys

--- a/src/torchjd/autojac/_transform/select.py
+++ b/src/torchjd/autojac/_transform/select.py
@@ -17,7 +17,7 @@ class Select(Transform[_A, _A]):
     def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
         if not self.keys.issubset(input_keys):
             raise RequirementError(
-                f"The input_keys needs to be a super set of the keys to select. Found {input_keys} "
-                f"and {self.keys}"
+                f"The input_keys should be a super set of the keys to select. Found input_keys "
+                f"{input_keys} and keys to select {self.keys}."
             )
         return self.keys

--- a/src/torchjd/autojac/_transform/select.py
+++ b/src/torchjd/autojac/_transform/select.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from torch import Tensor
 
 from ._utils import _A
-from .base import Transform
+from .base import RequirementError, Transform
 
 
 class Select(Transform[_A, _A]):
@@ -18,6 +18,8 @@ class Select(Transform[_A, _A]):
     def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
         required_keys = self._required_keys
         if not self.keys.issubset(required_keys):
-            raise ValueError("Parameter `keys` should be a subset of parameter `required_keys`")
+            raise RequirementError(
+                "Parameter `keys` should be a subset of parameter `required_keys`"
+            )
 
         return required_keys, self.keys

--- a/src/torchjd/autojac/_transform/stack.py
+++ b/src/torchjd/autojac/_transform/stack.py
@@ -4,7 +4,7 @@ import torch
 from torch import Tensor
 
 from ._utils import _A, _materialize, dicts_union
-from .base import Transform
+from .base import RequirementError, Transform
 from .tensor_dict import Gradients, Jacobians
 
 
@@ -25,7 +25,7 @@ class Stack(Transform[_A, Jacobians]):
 
         for transform_required_keys, _ in keys_pairs:
             if transform_required_keys != required_keys:
-                raise ValueError("All transforms should require the same set of keys.")
+                raise RequirementError("All transforms should require the same set of keys.")
 
         return required_keys, output_keys
 

--- a/src/torchjd/autojac/backward.py
+++ b/src/torchjd/autojac/backward.py
@@ -112,6 +112,6 @@ def _create_transform(
     aggregate = Aggregate(aggregator, inputs)
 
     # Transform that accumulates the result in the .grad field of the inputs.
-    accumulate = Accumulate(inputs)
+    accumulate = Accumulate()
 
     return accumulate << aggregate << jac << diag << init

--- a/src/torchjd/autojac/mtl_backward.py
+++ b/src/torchjd/autojac/mtl_backward.py
@@ -155,7 +155,7 @@ def _create_transform(
     aggregate = Aggregate(aggregator, shared_params)
 
     # Transform that accumulates the result in the .grad field of the shared parameters.
-    accumulate = Accumulate(shared_params)
+    accumulate = Accumulate()
 
     return accumulate << aggregate << jac << stack
 
@@ -179,7 +179,7 @@ def _create_task_transform(
 
     # Transform that accumulates the gradients w.r.t. the task-specific parameters into their
     # .grad fields.
-    accumulate = Accumulate(task_params) << Select(task_params)
+    accumulate = Accumulate() << Select(task_params)
 
     # Transform that backpropagates the gradients of the losses w.r.t. the features.
     backpropagate = Select(features)

--- a/src/torchjd/autojac/mtl_backward.py
+++ b/src/torchjd/autojac/mtl_backward.py
@@ -179,10 +179,10 @@ def _create_task_transform(
 
     # Transform that accumulates the gradients w.r.t. the task-specific parameters into their
     # .grad fields.
-    accumulate = Accumulate(task_params) << Select(task_params, to_differentiate)
+    accumulate = Accumulate(task_params) << Select(task_params)
 
     # Transform that backpropagates the gradients of the losses w.r.t. the features.
-    backpropagate = Select(features, to_differentiate)
+    backpropagate = Select(features)
 
     # Transform that accumulates the gradient of the losses w.r.t. the task-specific parameters into
     # their .grad fields and backpropagates the gradient of the losses w.r.t. to the features.

--- a/tests/unit/autojac/_transform/test_accumulate.py
+++ b/tests/unit/autojac/_transform/test_accumulate.py
@@ -95,8 +95,8 @@ def test_no_leaf_and_no_retains_grad_fails():
         accumulate(input)
 
 
-def test_check_and_get_keys():
-    """Tests that the `check_and_get_keys` method works correctly."""
+def test_check_keys():
+    """Tests that the `check_keys` method works correctly."""
 
     key = torch.tensor([1.0], requires_grad=True)
     accumulate = Accumulate()

--- a/tests/unit/autojac/_transform/test_accumulate.py
+++ b/tests/unit/autojac/_transform/test_accumulate.py
@@ -20,7 +20,7 @@ def test_single_accumulation():
     value3 = torch.ones([2, 3])
     input = Gradients({key1: value1, key2: value2, key3: value3})
 
-    accumulate = Accumulate([key1, key2, key3])
+    accumulate = Accumulate()
 
     output = accumulate(input)
     expected_output = {}
@@ -48,7 +48,7 @@ def test_multiple_accumulation(iterations: int):
     value3 = torch.ones([2, 3])
     input = Gradients({key1: value1, key2: value2, key3: value3})
 
-    accumulate = Accumulate([key1, key2, key3])
+    accumulate = Accumulate()
 
     for i in range(iterations):
         accumulate(input)
@@ -73,7 +73,7 @@ def test_no_requires_grad_fails():
     value = torch.ones([1])
     input = Gradients({key: value})
 
-    accumulate = Accumulate([key])
+    accumulate = Accumulate()
 
     with raises(ValueError):
         accumulate(input)
@@ -89,7 +89,7 @@ def test_no_leaf_and_no_retains_grad_fails():
     value = torch.ones([1])
     input = Gradients({key: value})
 
-    accumulate = Accumulate([key])
+    accumulate = Accumulate()
 
     with raises(ValueError):
         accumulate(input)
@@ -99,9 +99,8 @@ def test_check_and_get_keys():
     """Tests that the `check_and_get_keys` method works correctly."""
 
     key = torch.tensor([1.0], requires_grad=True)
-    accumulate = Accumulate([key])
+    accumulate = Accumulate()
 
-    required_keys, output_keys = accumulate.check_and_get_keys()
+    output_keys = accumulate.check_keys({key})
 
-    assert required_keys == {key}
     assert output_keys == set()

--- a/tests/unit/autojac/_transform/test_accumulate.py
+++ b/tests/unit/autojac/_transform/test_accumulate.py
@@ -102,5 +102,4 @@ def test_check_keys():
     accumulate = Accumulate()
 
     output_keys = accumulate.check_keys({key})
-
     assert output_keys == set()

--- a/tests/unit/autojac/_transform/test_aggregate.py
+++ b/tests/unit/autojac/_transform/test_aggregate.py
@@ -7,7 +7,12 @@ from torch import Tensor
 from unit.conftest import DEVICE
 
 from torchjd.aggregation import Random
-from torchjd.autojac._transform import GradientVectors, JacobianMatrices, Jacobians
+from torchjd.autojac._transform import (
+    GradientVectors,
+    JacobianMatrices,
+    Jacobians,
+    RequirementError,
+)
 from torchjd.autojac._transform.aggregate import _AggregateMatrices, _Matrixify, _Reshape
 
 from ._dict_assertions import assert_tensor_dicts_are_close
@@ -145,15 +150,25 @@ def test_reshape():
 
 
 def test_aggregate_matrices_check_keys():
-    """Tests that the `check_keys` method works correctly."""
+    """
+    Tests that the `check_keys` method works correctly: the input_keys must match the stored
+    key_order.
+    """
 
     key1 = torch.tensor([1.0])
     key2 = torch.tensor([2.0])
+    key3 = torch.tensor([2.0])
     aggregate = _AggregateMatrices(Random(), [key2, key1])
 
     output_keys = aggregate.check_keys({key1, key2})
 
     assert output_keys == {key1, key2}
+
+    with raises(RequirementError):
+        aggregate.check_keys({key1})
+
+    with raises(RequirementError):
+        aggregate.check_keys({key1, key2, key3})
 
 
 def test_matrixify_check_keys():

--- a/tests/unit/autojac/_transform/test_aggregate.py
+++ b/tests/unit/autojac/_transform/test_aggregate.py
@@ -109,7 +109,7 @@ def test_matrixify():
     value3 = torch.tensor([[[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]] * n_outputs)
     input = Jacobians({key1: value1, key2: value2, key3: value3})
 
-    matrixify = _Matrixify([key1, key2, key3])
+    matrixify = _Matrixify()
 
     output = matrixify(input)
     expected_output = {
@@ -132,7 +132,7 @@ def test_reshape():
     value3 = torch.tensor([3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
     input = GradientVectors({key1: value1, key2: value2, key3: value3})
 
-    reshape = _Reshape([key1, key2, key3])
+    reshape = _Reshape()
 
     output = reshape(input)
     expected_output = {
@@ -151,9 +151,8 @@ def test_aggregate_matrices_check_and_get_keys():
     key2 = torch.tensor([2.0])
     aggregate = _AggregateMatrices(Random(), [key2, key1])
 
-    required_keys, output_keys = aggregate.check_and_get_keys()
+    output_keys = aggregate.check_keys({key1, key2})
 
-    assert required_keys == {key1, key2}
     assert output_keys == {key1, key2}
 
 
@@ -162,11 +161,10 @@ def test_matrixify_check_and_get_keys():
 
     key1 = torch.tensor([1.0])
     key2 = torch.tensor([2.0])
-    matrixify = _Matrixify([key1, key2])
+    matrixify = _Matrixify()
 
-    required_keys, output_keys = matrixify.check_and_get_keys()
+    output_keys = matrixify.check_keys({key1, key2})
 
-    assert required_keys == {key1, key2}
     assert output_keys == {key1, key2}
 
 
@@ -175,9 +173,8 @@ def test_reshape_check_and_get_keys():
 
     key1 = torch.tensor([1.0])
     key2 = torch.tensor([2.0])
-    reshape = _Reshape([key1, key2])
+    reshape = _Reshape()
 
-    required_keys, output_keys = reshape.check_and_get_keys()
+    output_keys = reshape.check_keys({key1, key2})
 
-    assert required_keys == {key1, key2}
     assert output_keys == {key1, key2}

--- a/tests/unit/autojac/_transform/test_aggregate.py
+++ b/tests/unit/autojac/_transform/test_aggregate.py
@@ -144,8 +144,8 @@ def test_reshape():
     assert_tensor_dicts_are_close(output, expected_output)
 
 
-def test_aggregate_matrices_check_and_get_keys():
-    """Tests that the `check_and_get_keys` method works correctly."""
+def test_aggregate_matrices_check_keys():
+    """Tests that the `check_keys` method works correctly."""
 
     key1 = torch.tensor([1.0])
     key2 = torch.tensor([2.0])
@@ -156,8 +156,8 @@ def test_aggregate_matrices_check_and_get_keys():
     assert output_keys == {key1, key2}
 
 
-def test_matrixify_check_and_get_keys():
-    """Tests that the `check_and_get_keys` method works correctly."""
+def test_matrixify_check_keys():
+    """Tests that the `check_keys` method works correctly."""
 
     key1 = torch.tensor([1.0])
     key2 = torch.tensor([2.0])
@@ -168,8 +168,8 @@ def test_matrixify_check_and_get_keys():
     assert output_keys == {key1, key2}
 
 
-def test_reshape_check_and_get_keys():
-    """Tests that the `check_and_get_keys` method works correctly."""
+def test_reshape_check_keys():
+    """Tests that the `check_keys` method works correctly."""
 
     key1 = torch.tensor([1.0])
     key2 = torch.tensor([2.0])

--- a/tests/unit/autojac/_transform/test_aggregate.py
+++ b/tests/unit/autojac/_transform/test_aggregate.py
@@ -161,7 +161,6 @@ def test_aggregate_matrices_check_keys():
     aggregate = _AggregateMatrices(Random(), [key2, key1])
 
     output_keys = aggregate.check_keys({key1, key2})
-
     assert output_keys == {key1, key2}
 
     with raises(RequirementError):
@@ -179,7 +178,6 @@ def test_matrixify_check_keys():
     matrixify = _Matrixify()
 
     output_keys = matrixify.check_keys({key1, key2})
-
     assert output_keys == {key1, key2}
 
 
@@ -191,5 +189,4 @@ def test_reshape_check_keys():
     reshape = _Reshape()
 
     output_keys = reshape.check_keys({key1, key2})
-
     assert output_keys == {key1, key2}

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -69,10 +69,10 @@ def test_conjunct_check_keys_1():
 
     assert output_keys == set()
 
-    with raises(ValueError):
+    with raises(RequirementError):
         (t2 | t3).check_keys({a1, a2})
 
-    with raises(ValueError):
+    with raises(RequirementError):
         (t1 | t2 | t3).check_keys({a1, a2})
 
 
@@ -93,10 +93,10 @@ def test_conjunct_check_keys_2():
 
     assert output_keys == {a1, a2}
 
-    with raises(ValueError):
+    with raises(RequirementError):
         (t1 | t3).check_keys(set())
 
-    with raises(ValueError):
+    with raises(RequirementError):
         (t1 | t2 | t3).check_keys(set())
 
 

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -35,8 +35,8 @@ class FakeTransform(Transform[_B, _C]):
 
 def test_composition_check_keys():
     """
-    Tests that `check_keys` works correctly for a composition of transforms: the inner
-    transform's `output_keys` has to match with the outer transform's `required_keys`.
+    Tests that `check_keys` works correctly for a composition of transforms: the inner transform's
+    `output_keys` has to match with the outer transform's `required_keys`.
     """
 
     a1 = torch.randn([2])
@@ -54,8 +54,8 @@ def test_composition_check_keys():
 
 def test_conjunct_check_keys_1():
     """
-    Tests that `check_keys` works correctly for a conjunction of transforms: all transforms
-    should successfully check their keys.
+    Tests that `check_keys` works correctly for a conjunction of transforms: all transforms should
+    successfully check their keys.
     """
 
     a1 = torch.randn([2])
@@ -78,8 +78,8 @@ def test_conjunct_check_keys_1():
 
 def test_conjunct_check_keys_2():
     """
-    Tests that `check_keys` works correctly for a conjunction of transforms: their
-    `output_keys` should be disjoint.
+    Tests that `check_keys` works correctly for a conjunction of transforms: their `output_keys`
+    should be disjoint.
     """
 
     a1 = torch.randn([2])

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -45,7 +45,6 @@ def test_composition_check_keys():
     t2 = FakeTransform(required_keys={a2}, output_keys={a1})
 
     output_keys = (t1 << t2).check_keys({a2})
-
     assert output_keys == {a1, a2}
 
     # Inner Transform fails its check
@@ -71,7 +70,6 @@ def test_conjunct_check_keys_1():
     t3 = FakeTransform(required_keys={a2}, output_keys=set())
 
     output_keys = (t1 | t2).check_keys({a1})
-
     assert output_keys == set()
 
     with raises(RequirementError):
@@ -95,7 +93,6 @@ def test_conjunct_check_keys_2():
     t3 = FakeTransform(required_keys=set(), output_keys={a2})
 
     output_keys = (t2 | t3).check_keys(set())
-
     assert output_keys == {a1, a2}
 
     with raises(RequirementError):

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -48,7 +48,12 @@ def test_composition_check_keys():
 
     assert output_keys == {a1, a2}
 
-    with raises(ValueError):
+    # Inner Transform fails its check
+    with raises(RequirementError):
+        (t1 << t2).check_keys({a1})
+
+    # Outer Transform fails its check
+    with raises(RequirementError):
         (t2 << t1).check_keys({a1, a2})
 
 

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -36,7 +36,7 @@ class FakeTransform(Transform[_B, _C]):
 def test_composition_check_keys():
     """
     Tests that `check_keys` works correctly for a composition of transforms: the inner transform's
-    `output_keys` has to match with the outer transform's `required_keys`.
+    `output_keys` has to satisfy the outer transform's requirements.
     """
 
     a1 = torch.randn([2])

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -11,7 +11,7 @@ from torchjd.autojac._transform.tensor_dict import TensorDict
 
 class FakeTransform(Transform[_B, _C]):
     """
-    Fake ``Transform`` to test `required_keys` and `output_keys` when composing and conjuncting.
+    Fake ``Transform`` to test `check_keys` when composing and conjuncting.
     """
 
     def __init__(self, required_keys: set[Tensor], output_keys: set[Tensor]):
@@ -28,6 +28,7 @@ class FakeTransform(Transform[_B, _C]):
         return typing.cast(_C, output_dict)
 
     def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+        # Arbitrary requirement for testing purposes.
         if not input_keys == self._required_keys:
             raise RequirementError()
         return self._output_keys

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -54,7 +54,7 @@ def test_composition_check_keys():
 
     # Outer Transform fails its check
     with raises(RequirementError):
-        (t2 << t1).check_keys({a1, a2})
+        (t2 << t1).check_keys({a1})
 
 
 def test_conjunct_check_keys_1():

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -33,9 +33,9 @@ class FakeTransform(Transform[_B, _C]):
         return self._output_keys
 
 
-def test_composition_check_and_get_keys():
+def test_composition_check_keys():
     """
-    Tests that `check_and_get_keys` works correctly for a composition of transforms: the inner
+    Tests that `check_keys` works correctly for a composition of transforms: the inner
     transform's `output_keys` has to match with the outer transform's `required_keys`.
     """
 
@@ -52,9 +52,9 @@ def test_composition_check_and_get_keys():
         (t2 << t1).check_keys({a1, a2})
 
 
-def test_conjunct_check_and_get_keys_1():
+def test_conjunct_check_keys_1():
     """
-    Tests that `check_and_get_keys` works correctly for a conjunction of transforms: all transforms
+    Tests that `check_keys` works correctly for a conjunction of transforms: all transforms
     should successfully check their keys.
     """
 
@@ -76,9 +76,9 @@ def test_conjunct_check_and_get_keys_1():
         (t1 | t2 | t3).check_keys({a1, a2})
 
 
-def test_conjunct_check_and_get_keys_2():
+def test_conjunct_check_keys_2():
     """
-    Tests that `check_and_get_keys` works correctly for a conjunction of transforms: their
+    Tests that `check_keys` works correctly for a conjunction of transforms: their
     `output_keys` should be disjoint.
     """
 

--- a/tests/unit/autojac/_transform/test_diagonalize.py
+++ b/tests/unit/autojac/_transform/test_diagonalize.py
@@ -97,8 +97,8 @@ def test_permute_order():
     assert_tensor_dicts_are_close(output, expected_output)
 
 
-def test_check_and_get_keys():
-    """Tests that the `check_and_get_keys` method works correctly."""
+def test_check_keys():
+    """Tests that the `check_keys` method works correctly."""
 
     key = torch.tensor([1.0])
     diag = Diagonalize([key])

--- a/tests/unit/autojac/_transform/test_diagonalize.py
+++ b/tests/unit/autojac/_transform/test_diagonalize.py
@@ -109,7 +109,6 @@ def test_check_keys():
     diag = Diagonalize([key1])
 
     output_keys = diag.check_keys({key1})
-
     assert output_keys == {key1}
 
     with raises(RequirementError):

--- a/tests/unit/autojac/_transform/test_diagonalize.py
+++ b/tests/unit/autojac/_transform/test_diagonalize.py
@@ -100,8 +100,8 @@ def test_permute_order():
 
 def test_check_keys():
     """
-    Tests that the `check_keys` method works correctly. The input_keys must the stored considered
-    keys.
+    Tests that the `check_keys` method works correctly. The input_keys must match the stored
+    considered keys.
     """
 
     key1 = torch.tensor([1.0])

--- a/tests/unit/autojac/_transform/test_diagonalize.py
+++ b/tests/unit/autojac/_transform/test_diagonalize.py
@@ -1,6 +1,7 @@
 import torch
+from pytest import raises
 
-from torchjd.autojac._transform import Diagonalize, Gradients
+from torchjd.autojac._transform import Diagonalize, Gradients, RequirementError
 
 from ._dict_assertions import assert_tensor_dicts_are_close
 
@@ -98,11 +99,21 @@ def test_permute_order():
 
 
 def test_check_keys():
-    """Tests that the `check_keys` method works correctly."""
+    """
+    Tests that the `check_keys` method works correctly. The input_keys must the stored considered
+    keys.
+    """
 
-    key = torch.tensor([1.0])
-    diag = Diagonalize([key])
+    key1 = torch.tensor([1.0])
+    key2 = torch.tensor([1.0])
+    diag = Diagonalize([key1])
 
-    output_keys = diag.check_keys({key})
+    output_keys = diag.check_keys({key1})
 
-    assert output_keys == {key}
+    assert output_keys == {key1}
+
+    with raises(RequirementError):
+        diag.check_keys(set())
+
+    with raises(RequirementError):
+        diag.check_keys({key1, key2})

--- a/tests/unit/autojac/_transform/test_diagonalize.py
+++ b/tests/unit/autojac/_transform/test_diagonalize.py
@@ -103,7 +103,6 @@ def test_check_and_get_keys():
     key = torch.tensor([1.0])
     diag = Diagonalize([key])
 
-    required_keys, output_keys = diag.check_and_get_keys()
+    output_keys = diag.check_keys({key})
 
-    assert required_keys == {key}
     assert output_keys == {key}

--- a/tests/unit/autojac/_transform/test_grad.py
+++ b/tests/unit/autojac/_transform/test_grad.py
@@ -1,7 +1,7 @@
 import torch
 from pytest import raises
 
-from torchjd.autojac._transform import Grad, Gradients
+from torchjd.autojac._transform import Grad, Gradients, RequirementError
 
 from ._dict_assertions import assert_tensor_dicts_are_close
 
@@ -284,7 +284,10 @@ def test_create_graph():
 
 
 def test_check_keys():
-    """Tests that the `check_keys` method works correctly."""
+    """
+    Tests that the `check_keys` method works correctly: the input_keys should match the stored
+    outputs.
+    """
 
     x = torch.tensor(5.0)
     a1 = torch.tensor(2.0, requires_grad=True)
@@ -296,3 +299,9 @@ def test_check_keys():
     output_keys = grad.check_keys({y})
 
     assert output_keys == {a1, a2}
+
+    with raises(RequirementError):
+        grad.check_keys({y, x})
+
+    with raises(RequirementError):
+        grad.check_keys(set())

--- a/tests/unit/autojac/_transform/test_grad.py
+++ b/tests/unit/autojac/_transform/test_grad.py
@@ -283,8 +283,8 @@ def test_create_graph():
     assert gradients[a].requires_grad
 
 
-def test_check_and_get_keys():
-    """Tests that the `check_and_get_keys` method works correctly."""
+def test_check_keys():
+    """Tests that the `check_keys` method works correctly."""
 
     x = torch.tensor(5.0)
     a1 = torch.tensor(2.0, requires_grad=True)

--- a/tests/unit/autojac/_transform/test_grad.py
+++ b/tests/unit/autojac/_transform/test_grad.py
@@ -293,7 +293,6 @@ def test_check_and_get_keys():
 
     grad = Grad(outputs=[y], inputs=[a1, a2])
 
-    required_keys, output_keys = grad.check_and_get_keys()
+    output_keys = grad.check_keys({y})
 
-    assert required_keys == {y}
     assert output_keys == {a1, a2}

--- a/tests/unit/autojac/_transform/test_grad.py
+++ b/tests/unit/autojac/_transform/test_grad.py
@@ -297,7 +297,6 @@ def test_check_keys():
     grad = Grad(outputs=[y], inputs=[a1, a2])
 
     output_keys = grad.check_keys({y})
-
     assert output_keys == {a1, a2}
 
     with raises(RequirementError):

--- a/tests/unit/autojac/_transform/test_init.py
+++ b/tests/unit/autojac/_transform/test_init.py
@@ -65,7 +65,7 @@ def test_conjunction_of_inits_is_init():
 
 
 def test_check_keys():
-    """Tests that the `check_keys` method works correctly."""
+    """Tests that the `check_keys` method works correctly: the input_keys should be empty."""
 
     key = torch.tensor([1.0])
     init = Init([key])

--- a/tests/unit/autojac/_transform/test_init.py
+++ b/tests/unit/autojac/_transform/test_init.py
@@ -71,7 +71,6 @@ def test_check_keys():
     init = Init([key])
 
     output_keys = init.check_keys(set())
-
     assert output_keys == {key}
 
     with raises(RequirementError):

--- a/tests/unit/autojac/_transform/test_init.py
+++ b/tests/unit/autojac/_transform/test_init.py
@@ -69,7 +69,6 @@ def test_check_and_get_keys():
     key = torch.tensor([1.0])
     init = Init([key])
 
-    required_keys, output_keys = init.check_and_get_keys()
+    output_keys = init.check_keys(set())
 
-    assert required_keys == set()
     assert output_keys == {key}

--- a/tests/unit/autojac/_transform/test_init.py
+++ b/tests/unit/autojac/_transform/test_init.py
@@ -1,6 +1,7 @@
 import torch
+from pytest import raises
 
-from torchjd.autojac._transform import EmptyTensorDict, Init
+from torchjd.autojac._transform import EmptyTensorDict, Init, RequirementError
 
 from ._dict_assertions import assert_tensor_dicts_are_close
 
@@ -72,3 +73,6 @@ def test_check_keys():
     output_keys = init.check_keys(set())
 
     assert output_keys == {key}
+
+    with raises(RequirementError):
+        init.check_keys({key})

--- a/tests/unit/autojac/_transform/test_init.py
+++ b/tests/unit/autojac/_transform/test_init.py
@@ -63,8 +63,8 @@ def test_conjunction_of_inits_is_init():
     assert_tensor_dicts_are_close(output, expected_output)
 
 
-def test_check_and_get_keys():
-    """Tests that the `check_and_get_keys` method works correctly."""
+def test_check_keys():
+    """Tests that the `check_keys` method works correctly."""
 
     key = torch.tensor([1.0])
     init = Init([key])

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -12,6 +12,7 @@ from torchjd.autojac._transform import (
     Init,
     Jac,
     Jacobians,
+    RequirementError,
     Select,
     Stack,
     TensorDict,
@@ -269,5 +270,5 @@ def test_stack_check_keys():
 
     assert output_keys == {a}
 
-    with raises(ValueError):
+    with raises(RequirementError):
         Stack([grad1, grad3]).check_keys({y1, y2})

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -255,20 +255,24 @@ def test_equivalence_jac_grads():
 def test_stack_check_keys():
     """
     Tests that the `check_keys` method works correctly for a stack of transforms: all of them should
-    have the same `required_keys`.
+    successfully check their keys.
     """
 
-    a = torch.tensor(1.0, requires_grad=True)
-    y1 = a * 2.0
-    y2 = a * 3.0
+    y1 = torch.tensor(1.0)
+    y2 = torch.tensor(1.0)
 
-    grad1 = Grad([y1], [a])
-    grad2 = Grad([y1], [a])
-    grad3 = Grad([y2], [a])
+    select1 = Select([y1])
+    select2 = Select([y1])
+    select3 = Select([y2])
 
-    output_keys = Stack([grad1, grad2]).check_keys({y1})
-
-    assert output_keys == {a}
+    output_keys = Stack([select1, select2]).check_keys({y1})
+    assert output_keys == {y1}
 
     with raises(RequirementError):
-        Stack([grad1, grad3]).check_keys({y1, y2})
+        Stack([select1, select2]).check_keys({y2})
+
+    output_keys = Stack([select1, select3]).check_keys({y1, y2})
+    assert output_keys == {y1, y2}
+
+    with raises(RequirementError):
+        Stack([select1, select3]).check_keys({y1})

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -195,7 +195,7 @@ def test_conjunction_accumulate_select():
     input = Gradients({key: value})
 
     select = Select([])
-    accumulate = Accumulate([key])
+    accumulate = Accumulate()
     conjunction = accumulate | select
 
     output = conjunction(input)

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -1,5 +1,4 @@
 import torch
-from pytest import raises
 from torch.testing import assert_close
 
 from torchjd.autojac._transform import (
@@ -39,8 +38,8 @@ def test_jac_is_stack_of_grads():
 
     grad1 = Grad(outputs=[y1], inputs=[a1, a2])
     grad2 = Grad(outputs=[y2], inputs=[a1, a2])
-    select1 = Select([y1], [y1, y2])
-    select2 = Select([y2], [y1, y2])
+    select1 = Select([y1])
+    select2 = Select([y2])
     stack_of_grads = Stack([grad1 << select1, grad2 << select2])
 
     jacobians = jac_diag(input)
@@ -83,8 +82,8 @@ def test_multiple_differentiations():
 
     grad1 = Grad([y1], [a1])
     grad2 = Grad([y2], [a2])
-    select1 = Select([y1], [y1, y2])
-    select2 = Select([y2], [y1, y2])
+    select1 = Select([y1])
+    select2 = Select([y2])
     init = Init([y1, y2])
     transform = ((grad1 << select1) | (grad2 << select2)) << init
 
@@ -119,9 +118,9 @@ def test_simple_conjunction():
     x3 = torch.tensor(4.0)
     input = TensorDict({x1: torch.ones_like(x1), x2: torch.ones_like(x2), x3: torch.ones_like(x3)})
 
-    select1 = Select([x1], [x1, x2, x3])
-    select2 = Select([x2], [x1, x2, x3])
-    select3 = Select([x3], [x1, x2, x3])
+    select1 = Select([x1])
+    select2 = Select([x2])
+    select3 = Select([x3])
     conjunction = Conjunction([select1, select2, select3])
 
     output = conjunction(input)
@@ -140,8 +139,8 @@ def test_conjunction_is_commutative():
     x2 = torch.tensor([1.0, 3.0, 5.0])
     input = TensorDict({x1: torch.ones_like(x1), x2: torch.ones_like(x2)})
 
-    a = Select([x1], [x1, x2])
-    b = Select([x2], [x1, x2])
+    a = Select([x1])
+    b = Select([x2])
     flipped_conjunction = Conjunction([b, a])
     conjunction = Conjunction([a, b])
 
@@ -169,10 +168,10 @@ def test_conjunction_is_associative():
         }
     )
 
-    a = Select([x1], [x1, x2, x3, x4])
-    b = Select([x2], [x1, x2, x3, x4])
-    c = Select([x3], [x1, x2, x3, x4])
-    d = Select([x4], [x1, x2, x3, x4])
+    a = Select([x1])
+    b = Select([x2])
+    c = Select([x3])
+    d = Select([x4])
 
     parenthesized_conjunction = Conjunction([a, Conjunction([Conjunction([b, c]), d])])
     conjunction = Conjunction([a, b, c, d])
@@ -195,7 +194,7 @@ def test_conjunction_accumulate_select():
     value = torch.ones_like(key)
     input = Gradients({key: value})
 
-    select = Select([], [key])
+    select = Select([])
     accumulate = Accumulate([key])
     conjunction = accumulate | select
 
@@ -265,10 +264,10 @@ def test_stack_check_and_get_keys():
     grad2 = Grad([y1], [a])
     grad3 = Grad([y2], [a])
 
-    required_keys, output_keys = Stack([grad1, grad2]).check_and_get_keys()
+    output_keys = Stack([grad1, grad2]).check_keys({y1})
 
-    assert required_keys == {y1}
     assert output_keys == {a}
 
-    with raises(ValueError):
-        Stack([grad1, grad3]).check_and_get_keys()
+    output_keys = Stack([grad1, grad3]).check_keys({y1, y2})
+
+    assert output_keys == {a}

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -1,4 +1,5 @@
 import torch
+from pytest import raises
 from torch.testing import assert_close
 
 from torchjd.autojac._transform import (
@@ -268,6 +269,5 @@ def test_stack_check_and_get_keys():
 
     assert output_keys == {a}
 
-    output_keys = Stack([grad1, grad3]).check_keys({y1, y2})
-
-    assert output_keys == {a}
+    with raises(ValueError):
+        Stack([grad1, grad3]).check_keys({y1, y2})

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -251,9 +251,9 @@ def test_equivalence_jac_grads():
     assert_close(jac_c, torch.stack([grad_1_c, grad_2_c]))
 
 
-def test_stack_check_and_get_keys():
+def test_stack_check_keys():
     """
-    Tests that the `check_and_get_keys` method works correctly for a stack of transforms: all of
+    Tests that the `check_keys` method works correctly for a stack of transforms: all of
     them should have the same `required_keys`.
     """
 

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -253,8 +253,8 @@ def test_equivalence_jac_grads():
 
 def test_stack_check_keys():
     """
-    Tests that the `check_keys` method works correctly for a stack of transforms: all of
-    them should have the same `required_keys`.
+    Tests that the `check_keys` method works correctly for a stack of transforms: all of them should
+    have the same `required_keys`.
     """
 
     a = torch.tensor(1.0, requires_grad=True)

--- a/tests/unit/autojac/_transform/test_jac.py
+++ b/tests/unit/autojac/_transform/test_jac.py
@@ -283,8 +283,8 @@ def test_create_graph():
     assert jacobians[a2].requires_grad
 
 
-def test_check_and_get_keys():
-    """Tests that the `check_and_get_keys` method works correctly."""
+def test_check_keys():
+    """Tests that the `check_keys` method works correctly."""
 
     x = torch.tensor(5.0)
     a1 = torch.tensor(2.0, requires_grad=True)

--- a/tests/unit/autojac/_transform/test_jac.py
+++ b/tests/unit/autojac/_transform/test_jac.py
@@ -1,7 +1,7 @@
 import torch
 from pytest import mark, raises
 
-from torchjd.autojac._transform import Jac, Jacobians
+from torchjd.autojac._transform import Jac, Jacobians, RequirementError
 
 from ._dict_assertions import assert_tensor_dicts_are_close
 
@@ -284,7 +284,10 @@ def test_create_graph():
 
 
 def test_check_keys():
-    """Tests that the `check_keys` method works correctly."""
+    """
+    Tests that the `check_keys` method works correctly: the input_keys should match the stored
+    outputs.
+    """
 
     x = torch.tensor(5.0)
     a1 = torch.tensor(2.0, requires_grad=True)
@@ -296,3 +299,9 @@ def test_check_keys():
     output_keys = jac.check_keys({y})
 
     assert output_keys == {a1, a2}
+
+    with raises(RequirementError):
+        jac.check_keys({y, x})
+
+    with raises(RequirementError):
+        jac.check_keys(set())

--- a/tests/unit/autojac/_transform/test_jac.py
+++ b/tests/unit/autojac/_transform/test_jac.py
@@ -297,7 +297,6 @@ def test_check_keys():
     jac = Jac(outputs=[y], inputs=[a1, a2], chunk_size=None)
 
     output_keys = jac.check_keys({y})
-
     assert output_keys == {a1, a2}
 
     with raises(RequirementError):

--- a/tests/unit/autojac/_transform/test_jac.py
+++ b/tests/unit/autojac/_transform/test_jac.py
@@ -293,7 +293,6 @@ def test_check_and_get_keys():
 
     jac = Jac(outputs=[y], inputs=[a1, a2], chunk_size=None)
 
-    required_keys, output_keys = jac.check_and_get_keys()
+    output_keys = jac.check_keys({y})
 
-    assert required_keys == {y}
     assert output_keys == {a1, a2}

--- a/tests/unit/autojac/_transform/test_select.py
+++ b/tests/unit/autojac/_transform/test_select.py
@@ -56,9 +56,9 @@ def test_conjunction_of_selects_is_select():
     assert_tensor_dicts_are_close(output, expected_output)
 
 
-def test_check_and_get_keys():
+def test_check_keys():
     """
-    Tests that the `check_and_get_keys` method works correctly: the set of keys to select should
+    Tests that the `check_keys` method works correctly: the set of keys to select should
     be a subset of the set of required_keys.
     """
 

--- a/tests/unit/autojac/_transform/test_select.py
+++ b/tests/unit/autojac/_transform/test_select.py
@@ -58,8 +58,8 @@ def test_conjunction_of_selects_is_select():
 
 def test_check_keys():
     """
-    Tests that the `check_keys` method works correctly: the set of keys to select should
-    be a subset of the set of required_keys.
+    Tests that the `check_keys` method works correctly: the set of keys to select should be a subset
+    of the set of required_keys.
     """
 
     key1 = torch.tensor([1.0])

--- a/tests/unit/autojac/_transform/test_select.py
+++ b/tests/unit/autojac/_transform/test_select.py
@@ -67,7 +67,6 @@ def test_check_keys():
     key3 = torch.tensor([3.0])
 
     output_keys = Select([key1, key2]).check_keys({key1, key2, key3})
-
     assert output_keys == {key1, key2}
 
     with raises(RequirementError):

--- a/tests/unit/autojac/_transform/test_stack.py
+++ b/tests/unit/autojac/_transform/test_stack.py
@@ -9,10 +9,7 @@ from ._dict_assertions import assert_tensor_dicts_are_close
 
 
 class FakeGradientsTransform(Transform[EmptyTensorDict, Gradients]):
-    """
-    Transform that produces gradients filled with ones, for testing purposes. Note that it does the
-    same thing as Init, but it does not depend on Init.
-    """
+    """Transform that produces gradients filled with ones, for testing purposes."""
 
     def __init__(self, keys: Iterable[Tensor]):
         self.keys = set(keys)

--- a/tests/unit/autojac/_transform/test_stack.py
+++ b/tests/unit/autojac/_transform/test_stack.py
@@ -20,8 +20,8 @@ class FakeGradientsTransform(Transform[EmptyTensorDict, Gradients]):
     def __call__(self, input: EmptyTensorDict) -> Gradients:
         return Gradients({key: torch.ones_like(key) for key in self.keys})
 
-    def check_and_get_keys(self) -> tuple[set[Tensor], set[Tensor]]:
-        return set(), self.keys
+    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+        return self.keys
 
 
 def test_single_key():

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -24,9 +24,8 @@ def test_check_create_transform():
         retain_graph=False,
         parallel_chunk_size=None,
     )
-    required_keys, output_keys = transform.check_and_get_keys()
+    output_keys = transform.check_keys(set())
 
-    assert required_keys == set()
     assert output_keys == set()
 
 

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -25,7 +25,6 @@ def test_check_create_transform():
         parallel_chunk_size=None,
     )
     output_keys = transform.check_keys(set())
-
     assert output_keys == set()
 
 

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -24,6 +24,7 @@ def test_check_create_transform():
         retain_graph=False,
         parallel_chunk_size=None,
     )
+
     output_keys = transform.check_keys(set())
     assert output_keys == set()
 

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -29,8 +29,8 @@ def test_check_create_transform():
         retain_graph=False,
         parallel_chunk_size=None,
     )
-    output_keys = transform.check_keys(set())
 
+    output_keys = transform.check_keys(set())
     assert output_keys == set()
 
 

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -29,9 +29,8 @@ def test_check_create_transform():
         retain_graph=False,
         parallel_chunk_size=None,
     )
-    required_keys, output_keys = transform.check_and_get_keys()
+    output_keys = transform.check_keys(set())
 
-    assert required_keys == set()
     assert output_keys == set()
 
 


### PR DESCRIPTION
* Add RequirementError
* Refactor check_and_get_keys into check_keys
* Update tests accordingly
* Remove the required_keys parameter from Select, Accumulate, _Matrixify and _Reshape and update their instantiations

Note: originally, an idea was to have a method output_keys taking a set of keys as input and returning the output_keys given the provided input_keys (what check_keys does but without the check), and to have a requirement method taking a set of keys as input and returning a boolean as output (whether the given set of input satisfies the requirement of the transform or not). Even though this structure seems better in terms of single responsibility principle, it has the drawbacks of being inefficient, because the requirement method of a Composition would trigger the computation of the requirement method of the child + the computation of the output_keys method of the child. The number of method calls would thus scale quadratically with the number of transforms composed together. With the current structure, this does not happen, which makes it much more efficient with little-to-no downside.

TODO:
Add tests for new RequirementError messages and update the docstrings accordingly:
- [x] Composition: test the two ways of failing the check
- [x] Stack
- [x] Conjunct
- [x] _AggregateMatrices: test the failing case
- [x] Diagonalize: test the failing case
- [x] Select: test the failing case
- [x] Differentiate: test the failing case
- [x] Init: test the failing case

Also:
- [x] Verify that all ValueError where changed to RequirementError
- [x] Verify formatting of tests
- [x] Verify that imports are relative