### PR TITLE
Revert creation of CNAME file by github

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-torchjd.org


### PR DESCRIPTION
About what happened:
https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site

"Under "Custom domain", type your custom domain, then click Save. If you are publishing your site from a branch, this will create a commit that adds a CNAME file directly to the root of your source branch. If you are publishing from a custom GitHub Actions workflow, no CNAME file is created, and any existing CNAME file is ignored and is not required. For more information about your publishing source, see [Configuring a publishing source for your GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site)."

=> Seems like we don't even need to save for github to make a commit on main... We didn't even have time to select another branch, so this could happen again in the future when we switch to classic github pages.