### PR TITLE
Move `dict_union`

### DIFF
--- a/src/torchjd/autojac/_transform/_utils.py
+++ b/src/torchjd/autojac/_transform/_utils.py
@@ -13,13 +13,6 @@ _B = TypeVar("_B", bound=TensorDict)
 _C = TypeVar("_C", bound=TensorDict)
 
 
-def dicts_union(dicts: Iterable[dict[_KeyType, _ValueType]]) -> dict[_KeyType, _ValueType]:
-    result = {}
-    for d in dicts:
-        result |= d
-    return result
-
-
 def _materialize(
     optional_tensors: Sequence[Tensor | None], inputs: Sequence[Tensor]
 ) -> tuple[Tensor, ...]:


### PR DESCRIPTION
* Move dict_union from _utils.py to stack.py and make it "protected"

Since `dict_union` is only used in `stacks.py`, I think it's better to define it there. It makes less back-and-forth when reading the code, and it reduces the number of things that `_utils.py` has to contain.

Because it's now a local helper function, it should also become protected. This PR thus also makes it "protected".