### PR TITLE
Move `_union` into `Conjunction.__call__`

### DIFF
--- a/src/torchjd/autojac/_transform/_utils.py
+++ b/src/torchjd/autojac/_transform/_utils.py
@@ -3,7 +3,7 @@ from typing import Hashable, Iterable, Sequence, TypeVar
 import torch
 from torch import Tensor
 
-from .tensor_dict import EmptyTensorDict, TensorDict, _least_common_ancestor
+from .tensor_dict import TensorDict
 
 _KeyType = TypeVar("_KeyType", bound=Hashable)
 _ValueType = TypeVar("_ValueType")
@@ -38,12 +38,3 @@ def _materialize(
         else:
             tensors.append(optional_tensor)
     return tuple(tensors)
-
-
-def _union(tensor_dicts: Iterable[_A]) -> _A:
-    output_type: type[_A] = EmptyTensorDict
-    output: _A = EmptyTensorDict()
-    for tensor_dict in tensor_dicts:
-        output_type = _least_common_ancestor(output_type, type(tensor_dict))
-        output |= tensor_dict
-    return output_type(output)


### PR DESCRIPTION
Since `_union` is only used in `Conjunction.__call__`, it makes sence to define it in `base.py` (where `Conjunction` is defined). Further, since `base.py` contains several classes, it makes sence to make `_union` a static method of specifically the `Conjunction` class. Lastly, since `Conjunction.__call__` is almost a trivial call to `_union`, it makes sense to have no `_union` method but to directly compute this union in the `__call__` method of `Conjunction`. This is kind of the opposite of a factorization, but it should enhance code readability since it limits the back-and-forth required to understand a piece of code.

Do you agree @PierreQuinton?