### PR TITLE
Improve typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,6 @@ changes that do not affect the user.
 
 ### Fixed
 
-- Fixed the behavior of `backward` and `mtl_backward` when some tensors are repeated (i.e. when they
-  appear several times in a list of tensors provided as argument). Instead of raising an exception
-  in these cases, we are now aligned with the behavior of `torch.autograd.backward`. Repeated
-  tensors that we differentiate lead to repeated rows in the Jacobian, prior to aggregation, and
-  repeated tensors with respect to which we differentiate count only once.
 - Fixed an issue with `backward` and `mtl_backward` that could make the ordering of the columns of
   the Jacobians non-deterministic, and that could thus lead to slightly non-deterministic results
   with some aggregators.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ changes that do not affect the user.
 - Refactored internal verifications in the autojac engine so that they do not run at runtime
   anymore. This should minimally improve the performance and reduce the memory usage of `backward`
   and `mtl_backward`.
+- Refactored internal typing in the autojac engine so that fewer casts are made and so that code is
+  simplified. This should slightly improve the performance of `backward` and `mtl_backward`.
 - Improved the implementation of `ConFIG` to be simpler and safer when normalizing vectors. It
   should slightly improve the performance of `ConFIG` and minimally affect its behavior.
 

--- a/src/torchjd/autojac/_transform/_differentiate.py
+++ b/src/torchjd/autojac/_transform/_differentiate.py
@@ -20,8 +20,8 @@ class Differentiate(Transform[_A, _A], ABC):
         # torch.autograd.grad is *exactly* equivariant to input permutations and invariant to
         # output (with their corresponding grad_output) permutations.
 
-        self.outputs = outputs
-        self.inputs = inputs
+        self.outputs = list(outputs)
+        self.inputs = list(inputs)
         self.retain_graph = retain_graph
         self.create_graph = create_graph
 

--- a/src/torchjd/autojac/_transform/_differentiate.py
+++ b/src/torchjd/autojac/_transform/_differentiate.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Iterable, Sequence
+from typing import Sequence
 
 from torch import Tensor
 
@@ -11,13 +11,17 @@ from .tensor_dict import _A
 class Differentiate(Transform[_A, _A], ABC):
     def __init__(
         self,
-        outputs: Iterable[Tensor],
-        inputs: Iterable[Tensor],
+        outputs: OrderedSet[Tensor],
+        inputs: OrderedSet[Tensor],
         retain_graph: bool,
         create_graph: bool,
     ):
-        self.outputs = list(outputs)
-        self.inputs = OrderedSet(inputs)
+        # The order of outputs and inputs only matters because we have no guarantee that
+        # torch.autograd.grad is *exactly* equivariant to input permutations and invariant to
+        # output (with their corresponding grad_output) permutations.
+
+        self.outputs = outputs
+        self.inputs = inputs
         self.retain_graph = retain_graph
         self.create_graph = create_graph
 

--- a/src/torchjd/autojac/_transform/grad.py
+++ b/src/torchjd/autojac/_transform/grad.py
@@ -1,18 +1,19 @@
-from typing import Iterable, Sequence
+from typing import Sequence
 
 import torch
 from torch import Tensor
 
 from ._differentiate import Differentiate
 from ._materialize import materialize
+from .ordered_set import OrderedSet
 from .tensor_dict import Gradients
 
 
 class Grad(Differentiate[Gradients]):
     def __init__(
         self,
-        outputs: Iterable[Tensor],
-        inputs: Iterable[Tensor],
+        outputs: OrderedSet[Tensor],
+        inputs: OrderedSet[Tensor],
         retain_graph: bool = False,
         create_graph: bool = False,
     ):

--- a/src/torchjd/autojac/_transform/grad.py
+++ b/src/torchjd/autojac/_transform/grad.py
@@ -31,22 +31,19 @@ class Grad(Differentiate[Gradients]):
             the same shape as the corresponding output.
         """
 
-        outputs = list(self.outputs)
-        inputs = list(self.inputs)
-
-        if len(inputs) == 0:
+        if len(self.inputs) == 0:
             return tuple()
 
-        if len(outputs) == 0:
-            return tuple([torch.zeros_like(input) for input in inputs])
+        if len(self.outputs) == 0:
+            return tuple([torch.zeros_like(input) for input in self.inputs])
 
         optional_grads = torch.autograd.grad(
-            outputs,
-            inputs,
+            self.outputs,
+            self.inputs,
             grad_outputs=grad_outputs,
             retain_graph=self.retain_graph,
             create_graph=self.create_graph,
             allow_unused=True,
         )
-        grads = materialize(optional_grads, inputs)
+        grads = materialize(optional_grads, self.inputs)
         return grads

--- a/src/torchjd/autojac/_transform/init.py
+++ b/src/torchjd/autojac/_transform/init.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Set
 
 import torch
 from torch import Tensor
@@ -8,8 +8,8 @@ from .tensor_dict import EmptyTensorDict, Gradients
 
 
 class Init(Transform[EmptyTensorDict, Gradients]):
-    def __init__(self, values: Iterable[Tensor]):
-        self.values = set(values)
+    def __init__(self, values: Set[Tensor]):
+        self.values = values
 
     def __call__(self, input: EmptyTensorDict) -> Gradients:
         r"""
@@ -26,4 +26,4 @@ class Init(Transform[EmptyTensorDict, Gradients]):
             raise RequirementError(
                 f"The input_keys should be the empty set. Found input_keys {input_keys}."
             )
-        return self.values
+        return set(self.values)

--- a/src/torchjd/autojac/_transform/jac.py
+++ b/src/torchjd/autojac/_transform/jac.py
@@ -1,21 +1,22 @@
 import math
 from functools import partial
 from itertools import accumulate
-from typing import Callable, Iterable, Sequence
+from typing import Callable, Sequence
 
 import torch
 from torch import Size, Tensor
 
 from ._differentiate import Differentiate
 from ._materialize import materialize
+from .ordered_set import OrderedSet
 from .tensor_dict import Jacobians
 
 
 class Jac(Differentiate[Jacobians]):
     def __init__(
         self,
-        outputs: Iterable[Tensor],
-        inputs: Iterable[Tensor],
+        outputs: OrderedSet[Tensor],
+        inputs: OrderedSet[Tensor],
         chunk_size: int | None,
         retain_graph: bool = False,
         create_graph: bool = False,

--- a/src/torchjd/autojac/_transform/ordered_set.py
+++ b/src/torchjd/autojac/_transform/ordered_set.py
@@ -1,10 +1,11 @@
 from collections import OrderedDict
+from collections.abc import Set
 from typing import Hashable, Iterable, TypeVar
 
 _KeyType = TypeVar("_KeyType", bound=Hashable)
 
 
-class OrderedSet(OrderedDict[_KeyType, None]):
+class OrderedSet(OrderedDict[_KeyType, None], Set[_KeyType]):
     """Ordered collection of distinct elements."""
 
     def __init__(self, elements: Iterable[_KeyType]):

--- a/src/torchjd/autojac/_transform/select.py
+++ b/src/torchjd/autojac/_transform/select.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Set
 
 from torch import Tensor
 
@@ -7,17 +7,18 @@ from .tensor_dict import _A
 
 
 class Select(Transform[_A, _A]):
-    def __init__(self, keys: Iterable[Tensor]):
-        self.keys = set(keys)
+    def __init__(self, keys: Set[Tensor]):
+        self.keys = keys
 
     def __call__(self, tensor_dict: _A) -> _A:
         output = {key: tensor_dict[key] for key in self.keys}
         return type(tensor_dict)(output)
 
     def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
-        if not self.keys.issubset(input_keys):
+        keys = set(self.keys)
+        if not keys.issubset(input_keys):
             raise RequirementError(
                 f"The input_keys should be a super set of the keys to select. Found input_keys "
-                f"{input_keys} and keys to select {self.keys}."
+                f"{input_keys} and keys to select {keys}."
             )
-        return self.keys
+        return keys

--- a/src/torchjd/autojac/_utils.py
+++ b/src/torchjd/autojac/_utils.py
@@ -15,12 +15,19 @@ def check_optional_positive_chunk_size(parallel_chunk_size: int | None) -> None:
         )
 
 
-def as_tensor_list(tensors: Sequence[Tensor] | Tensor) -> list[Tensor]:
+def as_checked_ordered_set(
+    tensors: Sequence[Tensor] | Tensor, variable_name: str
+) -> OrderedSet[Tensor]:
     if isinstance(tensors, Tensor):
-        output = [tensors]
-    else:
-        output = list(tensors)
-    return output
+        tensors = [tensors]
+
+    original_length = len(tensors)
+    output = OrderedSet(tensors)
+
+    if len(output) != original_length:
+        raise ValueError(f"`{variable_name}` should contain unique elements.")
+
+    return OrderedSet(tensors)
 
 
 def get_leaf_tensors(tensors: Iterable[Tensor], excluded: Iterable[Tensor]) -> OrderedSet[Tensor]:

--- a/src/torchjd/autojac/backward.py
+++ b/src/torchjd/autojac/backward.py
@@ -6,7 +6,7 @@ from torchjd.aggregation import Aggregator
 
 from ._transform import Accumulate, Aggregate, Diagonalize, EmptyTensorDict, Init, Jac, Transform
 from ._transform.ordered_set import OrderedSet
-from ._utils import as_tensor_list, check_optional_positive_chunk_size, get_leaf_tensors
+from ._utils import as_checked_ordered_set, check_optional_positive_chunk_size, get_leaf_tensors
 
 
 def backward(
@@ -69,7 +69,7 @@ def backward(
     """
     check_optional_positive_chunk_size(parallel_chunk_size)
 
-    tensors = as_tensor_list(tensors)
+    tensors = as_checked_ordered_set(tensors, "tensors")
 
     if len(tensors) == 0:
         raise ValueError("`tensors` cannot be empty")
@@ -91,7 +91,7 @@ def backward(
 
 
 def _create_transform(
-    tensors: list[Tensor],
+    tensors: OrderedSet[Tensor],
     aggregator: Aggregator,
     inputs: OrderedSet[Tensor],
     retain_graph: bool,
@@ -103,7 +103,7 @@ def _create_transform(
     init = Init(tensors)
 
     # Transform that turns the gradients into Jacobians.
-    diag = Diagonalize(OrderedSet(tensors))
+    diag = Diagonalize(tensors)
 
     # Transform that computes the required Jacobians.
     jac = Jac(tensors, inputs, parallel_chunk_size, retain_graph)

--- a/src/torchjd/autojac/mtl_backward.py
+++ b/src/torchjd/autojac/mtl_backward.py
@@ -169,7 +169,7 @@ def _create_task_transform(
 ) -> Transform[EmptyTensorDict, Gradients]:
     # Tensors with respect to which we compute the gradients.
     to_differentiate = OrderedSet(task_params)  # Re-instantiate set to avoid modifying input
-    to_differentiate.update(OrderedSet(features))
+    to_differentiate.update(features)
 
     # Transform that initializes the gradient output to 1.
     init = Init(loss)

--- a/src/torchjd/autojac/mtl_backward.py
+++ b/src/torchjd/autojac/mtl_backward.py
@@ -17,7 +17,7 @@ from ._transform import (
     Transform,
 )
 from ._transform.ordered_set import OrderedSet
-from ._utils import as_tensor_list, check_optional_positive_chunk_size, get_leaf_tensors
+from ._utils import as_checked_ordered_set, check_optional_positive_chunk_size, get_leaf_tensors
 
 
 def mtl_backward(
@@ -81,7 +81,8 @@ def mtl_backward(
 
     check_optional_positive_chunk_size(parallel_chunk_size)
 
-    features = as_tensor_list(features)
+    losses = as_checked_ordered_set(losses, "losses")
+    features = as_checked_ordered_set(features, "features")
 
     if shared_params is None:
         shared_params = get_leaf_tensors(tensors=features, excluded=[])
@@ -117,8 +118,8 @@ def mtl_backward(
 
 
 def _create_transform(
-    losses: Sequence[Tensor],
-    features: list[Tensor],
+    losses: OrderedSet[Tensor],
+    features: OrderedSet[Tensor],
     aggregator: Aggregator,
     tasks_params: list[OrderedSet[Tensor]],
     shared_params: OrderedSet[Tensor],
@@ -138,7 +139,7 @@ def _create_transform(
         _create_task_transform(
             features,
             task_params,
-            loss,
+            OrderedSet([loss]),
             retain_graph,
         )
         for task_params, loss in zip(tasks_params, losses)
@@ -161,9 +162,9 @@ def _create_transform(
 
 
 def _create_task_transform(
-    features: list[Tensor],
+    features: OrderedSet[Tensor],
     task_params: OrderedSet[Tensor],
-    loss: Tensor,
+    loss: OrderedSet[Tensor],  # contains a single scalar loss
     retain_graph: bool,
 ) -> Transform[EmptyTensorDict, Gradients]:
     # Tensors with respect to which we compute the gradients.
@@ -171,11 +172,11 @@ def _create_task_transform(
     to_differentiate.update(OrderedSet(features))
 
     # Transform that initializes the gradient output to 1.
-    init = Init([loss])
+    init = Init(loss)
 
     # Transform that computes the gradients of the loss w.r.t. the task-specific parameters and
     # the features.
-    grad = Grad([loss], to_differentiate, retain_graph)
+    grad = Grad(loss, to_differentiate, retain_graph)
 
     # Transform that accumulates the gradients w.r.t. the task-specific parameters into their
     # .grad fields.

--- a/tests/unit/autojac/_transform/test_init.py
+++ b/tests/unit/autojac/_transform/test_init.py
@@ -15,7 +15,7 @@ def test_single_input():
     key = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     input = EmptyTensorDict()
 
-    init = Init([key])
+    init = Init({key})
 
     output = init(input)
     expected_output = {key: torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])}
@@ -33,7 +33,7 @@ def test_multiple_inputs():
     key2 = torch.tensor([1.0, 3.0, 5.0])
     input = EmptyTensorDict()
 
-    init = Init([key1, key2])
+    init = Init({key1, key2})
 
     output = init(input)
     expected = {
@@ -53,10 +53,10 @@ def test_conjunction_of_inits_is_init():
     x2 = torch.tensor(6.0)
     input = EmptyTensorDict()
 
-    init1 = Init([x1])
-    init2 = Init([x2])
+    init1 = Init({x1})
+    init2 = Init({x2})
     conjunction_of_inits = init1 | init2
-    init = Init([x1, x2])
+    init = Init({x1, x2})
 
     output = conjunction_of_inits(input)
     expected_output = init(input)
@@ -68,7 +68,7 @@ def test_check_keys():
     """Tests that the `check_keys` method works correctly: the input_keys should be empty."""
 
     key = torch.tensor([1.0])
-    init = Init([key])
+    init = Init({key})
 
     output_keys = init.check_keys(set())
     assert output_keys == {key}

--- a/tests/unit/autojac/_transform/test_jac.py
+++ b/tests/unit/autojac/_transform/test_jac.py
@@ -2,6 +2,7 @@ import torch
 from pytest import mark, raises
 
 from torchjd.autojac._transform import Jac, Jacobians, RequirementError
+from torchjd.autojac._transform.ordered_set import OrderedSet
 
 from ._dict_assertions import assert_tensor_dicts_are_close
 
@@ -20,7 +21,7 @@ def test_single_input(chunk_size: int | None):
     y = torch.stack([a1 * x, a2 * x])
     input = Jacobians({y: torch.eye(2)})
 
-    jac = Jac(outputs=[y], inputs=[a1, a2], chunk_size=chunk_size)
+    jac = Jac(outputs=OrderedSet([y]), inputs=OrderedSet([a1, a2]), chunk_size=chunk_size)
 
     jacobians = jac(input)
     expected_jacobians = {
@@ -42,7 +43,7 @@ def test_empty_inputs_1(chunk_size: int | None):
     y = torch.stack([y1, y2])
     input = Jacobians({y: torch.eye(2)})
 
-    jac = Jac(outputs=[y], inputs=[], chunk_size=chunk_size)
+    jac = Jac(outputs=OrderedSet([y]), inputs=OrderedSet([]), chunk_size=chunk_size)
 
     jacobians = jac(input)
     expected_jacobians = {}
@@ -64,7 +65,7 @@ def test_empty_inputs_2(chunk_size: int | None):
     y = torch.stack([y1, y2])
     input = Jacobians({y: torch.eye(2)})
 
-    jac = Jac(outputs=[y], inputs=[], chunk_size=chunk_size)
+    jac = Jac(outputs=OrderedSet([y]), inputs=OrderedSet([]), chunk_size=chunk_size)
 
     jacobians = jac(input)
     expected_jacobians = {}
@@ -83,7 +84,7 @@ def test_empty_outputs(chunk_size: int | None):
     a2 = torch.tensor([1.0, 2.0], requires_grad=True)
     input = Jacobians({})
 
-    jac = Jac(outputs=[], inputs=[a1, a2], chunk_size=chunk_size)
+    jac = Jac(outputs=OrderedSet([]), inputs=OrderedSet([a1, a2]), chunk_size=chunk_size)
 
     jacobians = jac(input)
     expected_jacobians = {
@@ -105,8 +106,12 @@ def test_retain_graph():
     y = torch.stack([y1, y2])
     input = Jacobians({y: torch.eye(2)})
 
-    jac_retain_graph = Jac(outputs=[y], inputs=[a1, a2], chunk_size=None, retain_graph=True)
-    jac_discard_graph = Jac(outputs=[y], inputs=[a1, a2], chunk_size=None, retain_graph=False)
+    jac_retain_graph = Jac(
+        outputs=OrderedSet([y]), inputs=OrderedSet([a1, a2]), chunk_size=None, retain_graph=True
+    )
+    jac_discard_graph = Jac(
+        outputs=OrderedSet([y]), inputs=OrderedSet([a1, a2]), chunk_size=None, retain_graph=False
+    )
 
     jac_retain_graph(input)
     jac_retain_graph(input)
@@ -135,10 +140,14 @@ def test_two_levels():
     z = y * x2
     input = Jacobians({z: torch.eye(2)})
 
-    outer_jac = Jac(outputs=[y], inputs=[a1, a2], chunk_size=None, retain_graph=True)
-    inner_jac = Jac(outputs=[z], inputs=[y], chunk_size=None, retain_graph=True)
+    outer_jac = Jac(
+        outputs=OrderedSet([y]), inputs=OrderedSet([a1, a2]), chunk_size=None, retain_graph=True
+    )
+    inner_jac = Jac(
+        outputs=OrderedSet([z]), inputs=OrderedSet([y]), chunk_size=None, retain_graph=True
+    )
     composed_jac = outer_jac << inner_jac
-    jac = Jac(outputs=[z], inputs=[a1, a2], chunk_size=None)
+    jac = Jac(outputs=OrderedSet([z]), inputs=OrderedSet([a1, a2]), chunk_size=None)
 
     jacobians = composed_jac(input)
     expected_jacobians = jac(input)
@@ -168,7 +177,7 @@ def test_multiple_outputs_1(chunk_size: int | None):
     jac_output3 = torch.cat([zeros_2x2, zeros_2x2, identity_2x2])
     input = Jacobians({y1: jac_output1, y2: jac_output2, y3: jac_output3})
 
-    jac = Jac(outputs=[y1, y2, y3], inputs=[a1, a2], chunk_size=chunk_size)
+    jac = Jac(outputs=OrderedSet([y1, y2, y3]), inputs=OrderedSet([a1, a2]), chunk_size=chunk_size)
 
     jacobians = jac(input)
     zero_scalar = torch.tensor(0.0)
@@ -201,7 +210,7 @@ def test_multiple_outputs_2(chunk_size: int | None):
     jac_output3 = torch.stack([zeros_2, zeros_2, ones_2])
     input = Jacobians({y1: jac_output1, y2: jac_output2, y3: jac_output3})
 
-    jac = Jac(outputs=[y1, y2, y3], inputs=[a1, a2], chunk_size=chunk_size)
+    jac = Jac(outputs=OrderedSet([y1, y2, y3]), inputs=OrderedSet([a1, a2]), chunk_size=chunk_size)
 
     jacobians = jac(input)
     expected_jacobians = {
@@ -227,10 +236,17 @@ def test_composition_of_jacs_is_jac():
     z2 = y2 + x1
     input = Jacobians({z1: torch.tensor([1.0, 0.0]), z2: torch.tensor([0.0, 1.0])})
 
-    outer_jac = Jac(outputs=[y1, y2], inputs=[a], chunk_size=None, retain_graph=True)
-    inner_jac = Jac(outputs=[z1, z2], inputs=[y1, y2], chunk_size=None, retain_graph=True)
+    outer_jac = Jac(
+        outputs=OrderedSet([y1, y2]), inputs=OrderedSet([a]), chunk_size=None, retain_graph=True
+    )
+    inner_jac = Jac(
+        outputs=OrderedSet([z1, z2]),
+        inputs=OrderedSet([y1, y2]),
+        chunk_size=None,
+        retain_graph=True,
+    )
     composed_jac = outer_jac << inner_jac
-    jac = Jac(outputs=[z1, z2], inputs=[a], chunk_size=None)
+    jac = Jac(outputs=OrderedSet([z1, z2]), inputs=OrderedSet([a]), chunk_size=None)
 
     jacobians = composed_jac(input)
     expected_jacobians = jac(input)
@@ -253,10 +269,10 @@ def test_conjunction_of_jacs_is_jac():
     y = torch.stack([y1, y2])
     input = Jacobians({y: torch.eye(len(y))})
 
-    jac1 = Jac(outputs=[y], inputs=[a1], chunk_size=None, retain_graph=True)
-    jac2 = Jac(outputs=[y], inputs=[a2], chunk_size=None, retain_graph=True)
+    jac1 = Jac(outputs=OrderedSet([y]), inputs=OrderedSet([a1]), chunk_size=None, retain_graph=True)
+    jac2 = Jac(outputs=OrderedSet([y]), inputs=OrderedSet([a2]), chunk_size=None, retain_graph=True)
     conjunction_of_jacs = jac1 | jac2
-    jac = Jac(outputs=[y], inputs=[a1, a2], chunk_size=None)
+    jac = Jac(outputs=OrderedSet([y]), inputs=OrderedSet([a1, a2]), chunk_size=None)
 
     jacobians = conjunction_of_jacs(input)
     expected_jacobians = jac(input)
@@ -275,7 +291,9 @@ def test_create_graph():
     y = torch.stack([y1, y2])
     input = Jacobians({y: torch.eye(2)})
 
-    jac = Jac(outputs=[y], inputs=[a1, a2], chunk_size=None, create_graph=True)
+    jac = Jac(
+        outputs=OrderedSet([y]), inputs=OrderedSet([a1, a2]), chunk_size=None, create_graph=True
+    )
 
     jacobians = jac(input)
 
@@ -294,7 +312,7 @@ def test_check_keys():
     a2 = torch.tensor(3.0, requires_grad=True)
     y = torch.stack([a1 * x, a2 * x])
 
-    jac = Jac(outputs=[y], inputs=[a1, a2], chunk_size=None)
+    jac = Jac(outputs=OrderedSet([y]), inputs=OrderedSet([a1, a2]), chunk_size=None)
 
     output_keys = jac.check_keys({y})
     assert output_keys == {a1, a2}

--- a/tests/unit/autojac/_transform/test_select.py
+++ b/tests/unit/autojac/_transform/test_select.py
@@ -20,8 +20,8 @@ def test_partition():
     value3 = torch.ones_like(key3)
     input = TensorDict({key1: value1, key2: value2, key3: value3})
 
-    select1 = Select([key1, key2])
-    select2 = Select([key3])
+    select1 = Select({key1, key2})
+    select2 = Select({key3})
 
     output1 = select1(input)
     expected_output1 = {key1: value1, key2: value2}
@@ -45,10 +45,10 @@ def test_conjunction_of_selects_is_select():
     x3 = torch.tensor(7.0)
     input = TensorDict({x1: torch.ones_like(x1), x2: torch.ones_like(x2), x3: torch.ones_like(x3)})
 
-    select1 = Select([x1])
-    select2 = Select([x2])
+    select1 = Select({x1})
+    select2 = Select({x2})
     conjunction_of_selects = select1 | select2
-    select = Select([x1, x2])
+    select = Select({x1, x2})
 
     output = conjunction_of_selects(input)
     expected_output = select(input)
@@ -66,8 +66,8 @@ def test_check_keys():
     key2 = torch.tensor([2.0])
     key3 = torch.tensor([3.0])
 
-    output_keys = Select([key1, key2]).check_keys({key1, key2, key3})
+    output_keys = Select({key1, key2}).check_keys({key1, key2, key3})
     assert output_keys == {key1, key2}
 
     with raises(RequirementError):
-        Select([key1, key2]).check_keys({key1})
+        Select({key1, key2}).check_keys({key1})

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -19,7 +19,7 @@ def test_check_create_transform():
     y2 = (a1**2).sum() + a2.norm()
 
     transform = _create_transform(
-        tensors=[y1, y2],
+        tensors=OrderedSet([y1, y2]),
         aggregator=Mean(),
         inputs=OrderedSet([a1, a2]),
         retain_graph=False,

--- a/tests/unit/autojac/test_backward.py
+++ b/tests/unit/autojac/test_backward.py
@@ -242,9 +242,11 @@ def test_tensor_used_multiple_times(chunk_size: int | None):
 
 def test_repeated_tensors():
     """
-    Tests that backward correctly works when some tensors are repeated. In this case, since
-    torch.autograd.backward would sum the gradients of the repeated tensors, it is natural for
-    autojac to compute a Jacobian with one row per repeated tensor, and to aggregate it.
+    Tests that backward does not allow repeating tensors.
+
+    This behavior is different from torch.autograd.backward which would sum the gradients of the
+    repeated tensors, but it simplifies a lot the implementation of autojac and there are
+    alternative ways of producing Jacobians with repeated rows anyway.
     """
 
     a1 = torch.tensor([1.0, 2.0], requires_grad=True)
@@ -253,13 +255,8 @@ def test_repeated_tensors():
     y1 = torch.tensor([-1.0, 1.0]) @ a1 + a2.sum()
     y2 = (a1**2).sum() + (a2**2).sum()
 
-    expected_grad_wrt_a1 = grad([y1, y1, y2], a1, retain_graph=True)[0]
-    expected_grad_wrt_a2 = grad([y1, y1, y2], a2, retain_graph=True)[0]
-
-    backward([y1, y1, y2], Sum())
-
-    assert_close(a1.grad, expected_grad_wrt_a1)
-    assert_close(a2.grad, expected_grad_wrt_a2)
+    with raises(ValueError):
+        backward([y1, y1, y2], Sum())
 
 
 def test_repeated_inputs():

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -22,8 +22,8 @@ def test_check_create_transform():
     y2 = f1 * p2[0] + f2 * p2[1]
 
     transform = _create_transform(
-        losses=[y1, y2],
-        features=[f1, f2],
+        losses=OrderedSet([y1, y2]),
+        features=OrderedSet([f1, f2]),
         aggregator=Mean(),
         tasks_params=[OrderedSet([p1]), OrderedSet([p2])],
         shared_params=OrderedSet([p0]),

--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -590,10 +590,11 @@ def test_default_shared_params_overlapping_with_default_tasks_params_fails():
 
 def test_repeated_losses():
     """
-    Tests that mtl_backward correctly works when some losses are repeated. In this case, since
-    torch.autograd.backward would sum the gradients of the repeated losses, it is natural for
-    autojac to sum the task-specific gradients, and to compute and aggregate a Jacobian with one row
-    per repeated tensor, for shared gradients.
+    Tests that mtl_backward does not allow repeating losses.
+
+    This behavior is different from torch.autograd.backward which would sum the gradients of the
+    repeated losses, but it simplifies a lot the implementation of autojac and there are alternative
+    ways of producing Jacobians with repeated rows anyway.
     """
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True)
@@ -605,24 +606,18 @@ def test_repeated_losses():
     y1 = f1 * p1[0] + f2 * p1[1]
     y2 = f1 * p2[0] + f2 * p2[1]
 
-    expected_grad_wrt_p0 = grad([y1, y1, y2], [p0], retain_graph=True)[0]
-    expected_grad_wrt_p1 = grad([y1, y1], [p1], retain_graph=True)[0]
-    expected_grad_wrt_p2 = grad([y2], [p2], retain_graph=True)[0]
-
-    losses = [y1, y1, y2]
-    mtl_backward(losses=losses, features=[f1, f2], aggregator=Sum(), retain_graph=True)
-
-    assert_close(p0.grad, expected_grad_wrt_p0)
-    assert_close(p1.grad, expected_grad_wrt_p1)
-    assert_close(p2.grad, expected_grad_wrt_p2)
+    with raises(ValueError):
+        losses = [y1, y1, y2]
+        mtl_backward(losses=losses, features=[f1, f2], aggregator=Sum(), retain_graph=True)
 
 
 def test_repeated_features():
     """
-    Tests that mtl_backward correctly works when some features are repeated. Repeated features are
-    a bit more tricky, because we differentiate with respect to them (in which case it shouldn't
-    matter that they are repeated) and we also differentiate them (in which case it should lead to
-    extra rows in the Jacobian).
+    Tests that mtl_backward does not allow repeating features.
+
+    Repeated features are a bit more tricky, because we differentiate with respect to them (in which
+    case it shouldn't matter that they are repeated) and we also differentiate them (in which case
+    repetition would be very confusing and should thus be forbidden).
     """
 
     p0 = torch.tensor([1.0, 2.0], requires_grad=True)
@@ -634,17 +629,9 @@ def test_repeated_features():
     y1 = f1 * p1[0] + f2 * p1[1]
     y2 = f1 * p2[0] + f2 * p2[1]
 
-    grad_outputs = grad([y1, y2], [f1, f1, f2], retain_graph=True)
-    expected_grad_wrt_p0 = grad([f1, f1, f2], [p0], grad_outputs, retain_graph=True)[0]
-    expected_grad_wrt_p1 = grad([y1], [p1], retain_graph=True)[0]
-    expected_grad_wrt_p2 = grad([y2], [p2], retain_graph=True)[0]
-
-    features = [f1, f1, f2]
-    mtl_backward(losses=[y1, y2], features=features, aggregator=Sum())
-
-    assert_close(p0.grad, expected_grad_wrt_p0)
-    assert_close(p1.grad, expected_grad_wrt_p1)
-    assert_close(p2.grad, expected_grad_wrt_p2)
+    with raises(ValueError):
+        features = [f1, f1, f2]
+        mtl_backward(losses=[y1, y2], features=features, aggregator=Sum())
 
 
 def test_repeated_shared_params():


### PR DESCRIPTION
* Make OrderedSet inherit from collections.abc.Set
* Make Init take Set[Tensor] keys
* Make Select take Set[Tensor] keys
* Make Differentiate, Jac and Grad take OrderedSet[Tensor] outputs and inputs
* Move the cast to list of outputs and inputs from Jac._differentiate and Grad._differentiate to Differentiate.__init__
* Change as_tensor_list to as_checked_ordered_set and make it check that the provided tensors are unique
* Stop allowing repeated tensors to differentiate in backward and mtl_backward
* Remove changelog entry saying that we allow repeated outputs
* Change the implementation backward and mtl_backward to reduce the number of casts and use only OrderedSets
* Add changelog entry saying that we refactored internal types and that this should improve performance
