### PR TITLE
Add canonical link to html pages

### DIFF
--- a/docs/source/_templates/page.html
+++ b/docs/source/_templates/page.html
@@ -1,0 +1,18 @@
+<!--
+Adds a canonical link to the stable version of the documentation to each built hmtl page.
+The reason to do that is that search engines require it:
+https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls
+
+This template overrides the page.html furo template
+(https://github.com/pradyunsg/furo/blob/main/src/furo/theme/furo/page.html) by adding an extra line
+to its <head> section, with the appropriate canonical link. Note that there is no guarantee that the
+furo theme keeps using a file named page.html, so this could silently break with future updates of
+furo. See https://pradyunsg.me/furo/customisation/injecting/ and
+https://github.com/pradyunsg/furo/discussions/248 for more information.
+-->
+
+{% extends "!page.html" %}
+
+{% block extrahead %}
+    <link rel="canonical" href="https://torchjd.org/stable/{{ pagename }}.html">
+{% endblock %}

--- a/docs/source/_templates/page.html
+++ b/docs/source/_templates/page.html
@@ -1,18 +1,16 @@
-<!--
-Adds a canonical link to the stable version of the documentation to each built hmtl page.
-The reason to do that is that search engines require it:
-https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls
+{#
+    Adds a canonical link to the stable version of the documentation to each built hmtl page.
+    The reason to do that is that search engines require it:
+    https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls
 
-This template overrides the page.html furo template
-(https://github.com/pradyunsg/furo/blob/main/src/furo/theme/furo/page.html) by adding an extra line
-to its <head> section, with the appropriate canonical link. Note that there is no guarantee that the
-furo theme keeps using a file named page.html, so this could silently break with future updates of
-furo. See https://pradyunsg.me/furo/customisation/injecting/ and
-https://github.com/pradyunsg/furo/discussions/248 for more information.
--->
-
+    This template overrides the page.html furo template
+    (https://github.com/pradyunsg/furo/blob/main/src/furo/theme/furo/page.html) by adding an extra
+    line to its <head> section, with the appropriate canonical link. Note that there is no guarantee
+    that the furo theme keeps using a file named page.html, so this could silently break with future
+    updates of furo. See https://pradyunsg.me/furo/customisation/injecting/ and
+    https://github.com/pradyunsg/furo/discussions/248 for more information.
+#}
 {% extends "!page.html" %}
-
 {% block extrahead %}
     <link rel="canonical" href="https://torchjd.org/stable/{{ pagename }}.html">
 {% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,7 @@ extensions = [
 
 html_theme = "furo"
 html_static_path = ["_static"]
+templates_path = ["_templates"]
 
 autodoc_member_order = "bysource"
 intersphinx_mapping = {


### PR DESCRIPTION
Everything is explained in the comment of the added file.
A few notes:
- Having a link to itself does not seem to be a problem according to the specification of the canonical links: https://datatracker.ietf.org/doc/html/rfc6596.html#section-3
- The solution proposed in this PR could break silently with furo updates. If furo decide to stop using page.html to make their pages, but e.g. something.html, sphinx will not even raise an error and the link will not be added. I think that in this case (that will probably never happen), Google should warn us soon after about duplicate pages without any canonical indicated. So I don't think it's too bad.
- The comment that I have written in `_templates/page.html` is not visible in the built html pages.