### PR TITLE
Add version-selector in page.html template

### DIFF
--- a/docs/source/_templates/page.html
+++ b/docs/source/_templates/page.html
@@ -13,4 +13,6 @@
 {% extends "!page.html" %}
 {% block extrahead %}
     <link rel="canonical" href="https://torchjd.org/stable/{{ pagename }}.html">
+    <script src="/version-selector.js"></script>
+    <link rel="stylesheet" href="/version-selector.css">
 {% endblock %}


### PR DESCRIPTION
This will add a call to the version-selector.js (available [here](https://github.com/TorchJD/documentation/blob/main/version-selector.js)) in all built html pages.

Note that whenever we merge this, an action will deploy the built documentation to `latest`, so the version selector should already appear in the `latest` part of the doc (with "stable" and "latest" as choices). We'll have to manually update the `stable` part (or wait for v0.6.0) to make this link appear in `stable` as well).