### PR TITLE
Remove warning filtering from `test_cagrad`

### DIFF
--- a/tests/doc/test_aggregation.py
+++ b/tests/doc/test_aggregation.py
@@ -21,12 +21,6 @@ def test_aligned_mtl():
 
 
 def test_cagrad():
-    # Extra ----------------------------------------------------------------------------------------
-    import warnings
-
-    warnings.filterwarnings("ignore")
-    # ----------------------------------------------------------------------------------------------
-
     from torch import tensor
 
     from torchjd.aggregation import CAGrad


### PR DESCRIPTION
* It seems like it is not needed anymore, probably due to an update in cvxpy or in its CLARABEL solver
* This warning filtering was partially removed in #214 (56f319f6b84727bf3aaf98fbb0be06948d54c718) but not from the doc tests apparently
