### PR TITLE
Add step to kill ssh-agent in build-deploy-docs.yml

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -50,6 +50,10 @@ jobs:
           external_repository: TorchJD/documentation
           publish_branch: main
 
+      - name: Kill ssh-agent
+        # See: https://github.com/peaceiris/actions-gh-pages/issues/909
+        run: killall ssh-agent
+
       - name: Deploy to stable of TorchJD/documentation
         if: startsWith(github.ref, 'refs/tags/')
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
Apparently, there is a bug with peaceiris/actions-gh-pages when two deployments are made from the same action: see https://github.com/peaceiris/actions-gh-pages/issues/909. It seems that a fix is to kill the ssh agent. This PR adds a step to do this in-between the two deployments, following https://github.com/filmil/bazel-ebook/commit/a3d465087bc9362ac1fdae00657711946bdbb802.