### PR TITLE
Fix installation of optional dependencies

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Install dependencies (default & doc)
-        run: pdm install --group doc --frozen-lockfile
+      - name: Install dependencies (default with full options & doc)
+        run: pdm install --group full --group doc --frozen-lockfile
 
       - name: Determine deployment folder
         id: deploy_folder

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         uses: pdm-project/setup-pdm@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install default and test dependencies
+      - name: Install default (with full options) and test dependencies
         run: pdm install --group full --group test --frozen-lockfile
       - name: Run unit and doc tests with coverage report
         run: pdm run pytest tests/unit tests/doc --cov=src --cov-report=xml
@@ -42,8 +42,8 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Install dependencies (default & doc)
-        run: pdm install --group doc --frozen-lockfile
+      - name: Install dependencies (default with full options & doc)
+        run: pdm install --group full --group doc --frozen-lockfile
 
       - name: Build Documentation
         working-directory: docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ with maintainers before implementing major changes.
    ```bash
    pdm venv create 3.13.1  # Requires Python 3.13.1 to be installed
    pdm use -i .venv/bin/python
-   pdm install --frozen-lockfile
+   pdm install --group full --frozen-lockfile
    pdm run pre-commit install
    ```
 


### PR DESCRIPTION
* Change the installation step to include the full group in documentation building job of tests.yml and in build-deploy-docs.yml
* Change the suggested installation of CONTRIBUTING.md to include the full group

Due to making cvxpy optional, we get a warning in the documentation building step of the CI:

 ```
WARNING: autodoc: failed to import module 'aggregation.aligned_mtl' from module 'torchjd'; the following exception was raised: No module named 'cvxpy'
```
and the built pages are thus empty for most aggregators.

We thus need to always install the full dependencies when installing torchjd.

This changes the installation step in both doc CI and in CONTRIBUTING.md to also add the full optional dependencies.

@PierreQuinton FYI