### PR TITLE
Migrate from `pdm` to `uv`

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -17,13 +17,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup PDM
-        uses: pdm-project/setup-pdm@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.13'
 
       - name: Install dependencies (default with full options & doc)
-        run: pdm install --group full --group doc --frozen-lockfile
+        run: uv pip install '.[full]' --group doc
 
       - name: Determine deployment folder
         id: deploy_folder
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build Documentation
         working-directory: docs
-        run: pdm run make dirhtml
+        run: uv run make dirhtml
         env:
           TORCHJD_VERSION: ${{ steps.deploy_folder.outputs.TORCHJD_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,16 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: pdm-project/setup-pdm@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.13'
+
+      - name: Build
+        run: uv build
+
       - name: Publish package distributions to PyPI
-        run: pdm publish
+        run: uv publish -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 name: Release
 
-# Adapted from https://pdm-project.org/latest/usage/publish/
 on:
   release:
     types: [published]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,14 +18,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up PDM
-        uses: pdm-project/setup-pdm@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install default (with full options) and test dependencies
-        run: pdm install --group full --group test --frozen-lockfile
+        run: uv pip install '.[full]' --group test
       - name: Run unit and doc tests with coverage report
-        run: pdm run pytest tests/unit tests/doc --cov=src --cov-report=xml
+        run: uv run pytest tests/unit tests/doc --cov=src --cov-report=xml
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v4
         with:
@@ -36,15 +36,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up PDM
-        uses: pdm-project/setup-pdm@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.13'
       - name: Install default (without any option) and test dependencies
-        run: pdm install --group test --frozen-lockfile
+        run: uv pip install . --group test
       - name: Run unit and doc tests with coverage report
         run: |
-          pdm run pytest tests/unit tests/doc \
+          uv run pytest tests/unit tests/doc \
           --ignore tests/unit/aggregation/test_cagrad.py \
           --ignore tests/unit/aggregation/test_nash_mtl.py \
           --ignore tests/doc/test_aggregation.py \
@@ -61,14 +61,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup PDM
-        uses: pdm-project/setup-pdm@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.13'
 
       - name: Install dependencies (default with full options & doc)
-        run: pdm install --group full --group doc --frozen-lockfile
+        run: uv pip install '.[full]' --group doc
 
       - name: Build Documentation
         working-directory: docs
-        run: pdm run make dirhtml
+        run: uv run make dirhtml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,8 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - name: Install default (with full options) and test dependencies
         run: uv pip install '.[full]' --group test
       - name: Run unit and doc tests with coverage report
@@ -40,6 +42,8 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.13'
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - name: Install default (without any option) and test dependencies
         run: uv pip install . --group test
       - name: Run unit and doc tests with coverage report
@@ -65,6 +69,8 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.13'
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies (default with full options & doc)
         run: uv pip install '.[full]' --group doc

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,6 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
       - name: Install default (with full options) and test dependencies
         run: uv pip install '.[full]' --group test
       - name: Run unit and doc tests with coverage report
@@ -42,8 +40,6 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.13'
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
       - name: Install default (without any option) and test dependencies
         run: uv pip install . --group test
       - name: Run unit and doc tests with coverage report
@@ -69,8 +65,6 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.13'
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies (default with full options & doc)
         run: uv pip install '.[full]' --group doc

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # pdm
 .pdm-python
 
+# uv
+uv.lock
+
 # PyCharm
 .idea/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# pdm
-.pdm-python
-
 # uv
 uv.lock
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ with maintainers before implementing major changes.
 ## Installation
 
 To work with TorchJD, we suggest you to use [uv](https://docs.astral.sh/uv/). While this is not
-mandatory, we only provide installation steps this tool. You can install it by following their
+mandatory, we only provide installation steps with this tool. You can install it by following their
 [installation documentation](https://docs.astral.sh/uv/getting-started/installation/).
 
 1) Pre-requisites: Use `uv` to install a Python version compatible with TorchJD and to pin it to the
@@ -15,15 +15,11 @@ mandatory, we only provide installation steps this tool. You can install it by f
    uv python install 3.13.3
    uv python pin 3.13.3
    ```
-   You should also make sure that `gcc` is installed on your machine. Some unmaintained optional
-   dependencies of `torchjd` (such as `ecos`) may have not released compiled packages for newer
-   Python version, and `uv` will thus try to compile them itself using your system's compiler.
 
 2) Create a virtual environment and install the project in it. From the root of `torchjd`, run:
    ```bash
    uv venv
-   export CC=gcc
-   uv pip install '.[full]' --group check --group doc --group test --group plot
+   CC=gcc uv pip install '.[full]' --group check --group doc --group test --group plot
    uv run pre-commit install
    ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,58 +5,75 @@ with maintainers before implementing major changes.
 
 ## Installation
 
-1) Pre-requisites: To work with TorchJD, you need Python to be installed. In the following, we
-   suggest to use Python 3.13.1, but you can work with any python version supported by `torchjd`. We
-   use [pyenv](https://github.com/pyenv/pyenv) to install Python and
-   [pdm](https://pdm-project.org/en/latest/) to manage dependencies. While the desired Python
-   version can also be installed without pyenv, the installation of `torchjd` for development
-   purposes requires `pdm`. To install it, follow their
-   [installation steps](https://pdm-project.org/en/latest/#installation).
+To work with TorchJD, we suggest you to use [uv](https://docs.astral.sh/uv/). While this is not
+mandatory, we only provide installation steps this tool. You can install it by following their
+[installation documentation](https://docs.astral.sh/uv/getting-started/installation/).
+
+1) Pre-requisites: Use `uv` to install a Python version compatible with TorchJD and to pin it to the
+  `torchjd` folder. From the root of the `torchjd` repo, run:
+   ```bash
+   uv python install 3.13.3
+   uv python pin 3.13.3
+   ```
+   You should also make sure that `gcc` is installed on your machine. Some unmaintained optional
+   dependencies of `torchjd` (such as `ecos`) may have not released compiled packages for newer
+   Python version, and `uv` will thus try to compile them itself using your system's compiler.
 
 2) Create a virtual environment and install the project in it. From the root of `torchjd`, run:
    ```bash
-   pdm venv create 3.13.1  # Requires Python 3.13.1 to be installed
-   pdm use -i .venv/bin/python
-   pdm install --group full --frozen-lockfile
-   pdm run pre-commit install
+   uv venv
+   export CC=gcc
+   uv pip install '.[full]' --group check --group doc --group test --group plot
+   uv run pre-commit install
    ```
+
+> [!TIP]
+> If you're running into issues when `uv` tries to compile `ecos`, make sure that `gcc` is
+> installed. Alternatively, you can try to install `clang` or try to use some older Python version
+> (3.12) for which `ecos` has provided compiled packages (the list is accessible
+> [here](https://pypi.org/project/ecos/#files)).
 
 > [!TIP]
 > The Python version that you should specify in your IDE is `<path-to-torchjd>/.venv/bin/python`.
 
+> [!TIP]
+> In the following commands, you can get rid of the `uv run` prefix if you activate the `venv`
+> created by `uv`, using `source .venv/bin/activate` from the root of `torchjd`. This will, however,
+> only work in the current terminal until it is closed.
+
 ## Running tests
    - To verify that your installation was successful, and that all unit tests pass, run:
      ```bash
-     pdm run pytest tests/unit
+     uv run pytest tests/unit
      ```
 
    - If you have access to a cuda-enabled GPU, you should also check that the unit tests pass on it:
      ```bash
-     CUBLAS_WORKSPACE_CONFIG=:4096:8 PYTEST_TORCH_DEVICE=cuda:0 pdm run pytest tests/unit
+     CUBLAS_WORKSPACE_CONFIG=:4096:8 PYTEST_TORCH_DEVICE=cuda:0 uv run pytest tests/unit
      ```
 
    - To check that the usage examples from docstrings and `.rst` files are correct, we test their
    behavior in `tests/doc`. To run these tests, do:
      ```bash
-     pdm run pytest tests/doc
+     uv run pytest tests/doc
      ```
 
   - To compute the code coverage locally, you should run the unit tests and the doc tests together,
   with the `--cov` flag:
     ```bash
-    pdm run pytest tests/unit tests/doc --cov=src
+    uv run pytest tests/unit tests/doc --cov=src
     ```
 
 ## Building the documentation locally
    - From the `docs` folder, run:
      ```bash
-     pdm run make html
+     uv run make html
      ```
    - You can then open `docs/build/html/index.html` with a web browser.
    - Sometimes, you need to manually delete the built documentation before generating it. To do
    this, from the `docs` folder, run:
      ```bash
-     pdm run make clean
+     uv run make clean
      ```
 
 ## Development guidelines

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["pdm-backend"]
-build-backend = "pdm.backend"
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchjd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
@@ -33,6 +32,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
+license = "MIT"
 
 [project.urls]
 Homepage = "https://torchjd.org/"


### PR DESCRIPTION
* Add uv.lock to .gitignore and remove .pdm-python from it 
* Change pdm to uv in CONTRIBUTING.md
* Change pdm to uv in tests.yml, build-deploy-docs.yml and release.yml
* Change build-system to setuptools
* Change license classifier to a license field in pyproject.toml

Theoretically, this should only affect contributors and CI. 

The main goal is to reduce the duration of the CI checks. They now seem much shorter, (< 80 sec for the slowest I think instead of about 240 seconds with pdm). This could probably be reduced even further by using caching, to maybe < 40 sec (which would be really nice).

TODO:
- [x] Change release.yml. I think we need to build + publish with uv in two different commands, but it should be similar
- [x] Do we pin uv version? According to their documentation "It is considered best practice to pin to a specific uv version" => They dont seem confident about not making breaking changes. But at the same time, if they make breaking changes, I'm fine with having tests fail and fixing the CI asap to always be using the newest uv version. If it's once per year it's perfectly fine, if it's once per month it's boring. => I would go against pinnning uv version for now, and maybe do it if it causes problems too often. The reason is that we don't really pin anything in torchjd, even the versions of the pre-commit hooks are updated via pre-commit ci pull requests, so this would be the only thing that would need to be manually updated from time to time. I don't really like that.

Maybe in future PR:
- [x] Try out uv caching with dependency on `uv.lock` => It would require to have a uv.lock file tracked by git and updated by the CI, which will be more time consumed than saved IMO.

