### PR TITLE
feat(aggregation): Implement custom QP solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ changes that do not affect the user.
 ### Changed
 
 - **BREAKING**: Implemented a custom QP solver for projections onto the dual cone of a matrix. This results in:
-  - Great speedups when computing `UPGrad` and `DualProj`. This enables computing those aggregators on large matrices.
+  - Great speedups when computing `UPGrad` and `DualProj`. This enables computing those aggregators on tall matrices.
   - No more dependence on the packages `qpsolvers`, `quadprog`.
   - Change of interface for `UPGrad` and `DUalProj` to parametrize our solver. The call with the default values is not
     impacted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@ changes that do not affect the user.
 
 ### Changed
 
+- **BREAKING**: Implemented a custom QP solver for projections onto the dual cone of a matrix. This results in:
+  - Great speedups when computing `UPGrad` and `DualProj`. This enables computing those aggregators on large matrices.
+  - No more dependence on the packages `qpsolvers`, `quadprog`.
+  - Change of interface for `UPGrad` and `DUalProj` to parametrize our solver. The call with the default values is not
+    impacted.
 - **BREAKING**: Changed the dependencies of `CAGrad` and `NashMTL` to be optional when installing
   TorchJD. Users of these aggregators will have to use `pip install torchjd[cagrad]`, `pip install
   torchjd[nash_mtl]` or `pip install torchjd[full]` to install TorchJD alongside those dependencies.
-  This should make TorchJD more lightweight.
+  This should make TorchJD more lightweight: the basic installation now only depends on `torch`.
 
 ## [0.6.0] - 2025-04-19
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ mandatory, we only provide installation steps with this tool. You can install it
 2) Create a virtual environment and install the project in it. From the root of `torchjd`, run:
    ```bash
    uv venv
-   CC=gcc uv pip install '.[full]' --group check --group doc --group test --group plot
+   CC=gcc uv pip install -e '.[full]' --group check --group doc --group test --group plot
    uv run pre-commit install
    ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ authors = [
 requires-python = ">=3.10"
 dependencies = [
     "torch>=2.0.0",
-    "numpy>=1.21.0",  # Does not work before 1.21
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -59,6 +58,7 @@ test = [
 ]
 
 plot = [
+    "numpy>=1.21.0",  # Does not work before 1.21
     "plotly>=5.19.0",  # Recent version to avoid problems, could be relaxed
     "dash>=2.16.0",  # Recent version to avoid problems, could be relaxed
     "kaleido==0.2.1",  # Only works with locked version
@@ -66,13 +66,16 @@ plot = [
 
 [project.optional-dependencies]
 nash_mtl = [
+    "numpy>=1.21.0",  # Does not work before 1.21
     "cvxpy>=1.3.0",  # Could be relaxed
     "ecos>=2.0.14",  # Does not work before 2.0.14
 ]
 cagrad = [
+    "numpy>=1.21.0",  # Does not work before 1.21
     "cvxpy>=1.3.0",  # No Clarabel solver before 1.3.0
 ]
 full = [
+    "numpy>=1.21.0",  # Does not work before 1.21
     "cvxpy>=1.3.0",  # No Clarabel solver before 1.3.0
     "ecos>=2.0.14",  # Does not work before 2.0.14
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,7 @@ authors = [
 requires-python = ">=3.10"
 dependencies = [
     "torch>=2.0.0",
-    "quadprog>=0.1.9, != 0.1.10",  # Doesn't work before 0.1.9, 0.1.10 is yanked
     "numpy>=1.21.0",  # Does not work before 1.21
-    "qpsolvers>=1.0.1",  # Does not work before 1.0.1
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -2,7 +2,7 @@ import torch
 from torch import Tensor
 
 
-def project_weights(U: Tensor, G: Tensor, max_iter: int, eps: float) -> Tensor:
+def project_weights(U: Tensor, G: Tensor, max_iter: int, eps: float, lr: float = 1.9) -> Tensor:
     """
     Computes the tensor of weights corresponding to the projection of the vectors in `U` onto the
     rows of a matrix whose Gramian is provided.
@@ -21,12 +21,12 @@ def project_weights(U: Tensor, G: Tensor, max_iter: int, eps: float) -> Tensor:
     m = shape[-1]
     U_matrix = U.reshape([-1, m]).T
 
-    V = _project_weight_matrix(U_matrix, G, max_iter, eps)
+    V = _project_weight_matrix(U_matrix, G, max_iter, eps, lr)
 
     return V.T.reshape(shape)
 
 
-def _project_weight_matrix(U: Tensor, G: Tensor, max_iter: int, eps: float) -> Tensor:
+def _project_weight_matrix(U: Tensor, G: Tensor, max_iter: int, eps: float, lr: float) -> Tensor:
     r"""
     Computes the tensor of weights corresponding to the projection of the columns in `U` onto the
     rows of a matrix whose Gramian is provided.
@@ -66,7 +66,7 @@ def _project_weight_matrix(U: Tensor, G: Tensor, max_iter: int, eps: float) -> T
     if lambda_max < 1e-10:
         return U
 
-    step_size = 1.9 / lambda_max
+    step_size = lr / lambda_max
 
     V = U.clone()
     for t in range(1, max_iter + 1):

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -66,11 +66,11 @@ def _project_weight_matrix(U: Tensor, G: Tensor, max_iter: int, eps: float, lr: 
     if lambda_max < 1e-10:
         return U
 
-    step_size = lr / lambda_max
+    neg_step_size = (-lr / lambda_max).item()
 
     V = U.clone()
     for t in range(1, max_iter + 1):
-        V_new = torch.maximum(V - step_size * (G @ V), U)
+        V_new = torch.maximum(torch.addmm(V, G, V, alpha=neg_step_size), U)
         if (V - V_new).norm() < eps:
             break
         V = V_new

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -1,60 +1,45 @@
-from typing import Literal
-
-import numpy as np
 import torch
-from qpsolvers import solve_qp
 from torch import Tensor
 
 
-def project_weights(U: Tensor, G: Tensor, solver: Literal["quadprog"]) -> Tensor:
-    """
+def project_weights(U: Tensor, G: Tensor, max_iter: int = 200, eps: float = 1e-07) -> Tensor:
+    r"""
     Computes the tensor of weights corresponding to the projection of the vectors in `U` onto the
     rows of a matrix whose Gramian is provided.
 
-    :param U: The tensor of weights corresponding to the vectors to project, of shape `[..., m]`.
-    :param G: The Gramian matrix of shape `[m, m]`. It must be symmetric and positive definite.
-    :param solver: The quadratic programming solver to use.
-    :return: A tensor of projection weights with the same shape as `U`.
-    """
-
-    G_ = _to_array(G)
-    U_ = _to_array(U)
-
-    W = np.apply_along_axis(lambda u: _project_weight_vector(u, G_, solver), axis=-1, arr=U_)
-
-    return torch.as_tensor(W, device=G.device, dtype=G.dtype)
-
-
-def _project_weight_vector(u: np.ndarray, G: np.ndarray, solver: Literal["quadprog"]) -> np.ndarray:
-    r"""
-    Computes the weights `w` of the projection of `J^T u` onto the dual cone of the rows of `J`,
-    given `G = J J^T` and `u`. In other words, this computes the `w` that satisfies
-    `\pi_J(J^T u) = J^T w`, with `\pi_J` defined in Equation 3 of [1].
 
     By Proposition 1 of [1], this is equivalent to solving for `v` the following quadratic program:
+
     minimize        v^T G v
     subject to      u \preceq v
+
+    for each u in U.
+
+    This is done by projected gradient descent.
 
     Reference:
     [1] `Jacobian Descent For Multi-Objective Optimization <https://arxiv.org/pdf/2406.16232>`_.
 
-    :param u: The vector of weights `u` of shape `[m]` corresponding to the vector `J^T u` to
-        project.
-    :param G: The Gramian matrix of `J`, equal to `J J^T`, and of shape `[m, m]`. It must be
-        symmetric and positive definite.
-    :param solver: The quadratic programming solver to use.
+    :param U: The tensor of weights corresponding to the vectors to project, of shape `[..., m]`.
+    :param G: The Gramian matrix of shape `[m, m]`. It must be symmetric and positive definite.
+    :param max_iter: The maximum number of step of projected gradient descent.
+    :param eps: Tolerance precision threshold to stop optimizing.
+    :return: A tensor of projection weights with the same shape as `U`.
     """
 
-    m = G.shape[0]
-    w = solve_qp(G, np.zeros(m), -np.eye(m), -u, solver=solver)
+    shape = U.shape
+    m = shape[-1]
+    U_matrix = U.reshape([-1, m]).T
+    V = U_matrix.clone()
 
-    if w is None:  # This may happen when G has large values.
-        raise ValueError("Failed to solve the quadratic programming problem.")
-
-    return w
-
-
-def _to_array(tensor: Tensor) -> np.ndarray:
-    """Transforms a tensor into a numpy array with float64 dtype."""
-
-    return tensor.cpu().detach().numpy().astype(np.float64)
+    # torch.linalg.eigvals synchronizes G on the CPU.
+    lambda_max = torch.max(torch.linalg.eigvals(G).real).item()
+    for t in range(1, max_iter + 1):
+        sigma = 1.0 / t**0.5
+        step_size = 2.0 / (lambda_max + sigma)
+        V_new = torch.maximum(V - step_size * (G @ V), U_matrix)
+        gap = (V - V_new).norm()
+        if gap < eps:
+            break
+        V = V_new
+    return V.T.reshape(shape)

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -3,7 +3,7 @@ from torch import Tensor
 
 
 def project_weights(U: Tensor, G: Tensor, max_iter: int, eps: float) -> Tensor:
-    r"""
+    """
     Computes the tensor of weights corresponding to the projection of the vectors in `U` onto the
     rows of a matrix whose Gramian is provided.
 
@@ -11,8 +11,9 @@ def project_weights(U: Tensor, G: Tensor, max_iter: int, eps: float) -> Tensor:
 
     :param U: The tensor of weights corresponding to the vectors to project, of shape `[..., m]`.
     :param G: The Gramian matrix of shape `[m, m]`. It must be symmetric and positive definite.
-    :param max_iter: The maximum number of step of projected gradient descent.
-    :param eps: Tolerance precision threshold to stop optimizing.
+    :param max_iter: The maximum number of steps of projected gradient descent.
+    :param eps: Tolerance precision threshold to stop optimizing. A lower value leads to a higher
+        precision but a potentially larger number of iterations.
     :return: A tensor of projection weights with the same shape as `U`.
     """
 
@@ -55,8 +56,9 @@ def _project_weight_matrix(U: Tensor, G: Tensor, max_iter: int, eps: float) -> T
     :param U: The matrix of weight vectors corresponding to the vectors to project, of shape
         `[m, k]`.
     :param G: The Gramian matrix of shape `[m, m]`. It must be symmetric and positive definite.
-    :param max_iter: The maximum number of step of projected gradient descent.
-    :param eps: Tolerance precision threshold to stop optimizing.
+    :param max_iter: The maximal number of iterations of the solver.
+    :param eps: Tolerance precision threshold to stop optimizing. A lower value leads to a higher
+        precision but a potentially larger number of iterations.
     :return: A tensor of projection weights with the same shape as `U`.
     """
     driver = "gesvdj" if G.device.type == "cuda" else None
@@ -67,7 +69,6 @@ def _project_weight_matrix(U: Tensor, G: Tensor, max_iter: int, eps: float) -> T
     step_size = 1.9 / lambda_max
 
     V = U.clone()
-
     for t in range(1, max_iter + 1):
         V_new = torch.maximum(V - step_size * (G @ V), U)
         if (V - V_new).norm() < eps:

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -36,12 +36,14 @@ def project_weights(U: Tensor, G: Tensor, max_iter: int, eps: float) -> Tensor:
     lambda_max = torch.linalg.svd(G, driver=driver)[1][0]
     if lambda_max < 1e-10:
         return U
+
+    # The typical stepsize should be in [1/lambda_max, 2/lambda_max[. We pick an aggressive step
+    # size as it works well in practice.
+    step_size = 1.9 / lambda_max
+
     for t in range(1, max_iter + 1):
-        sigma = 1.0 / t**0.5
-        step_size = 2.0 / (lambda_max * (1 + sigma))
         V_new = torch.maximum(V - step_size * (G @ V), U_matrix)
-        gap = (V - V_new).norm()
-        if gap < eps:
+        if (V - V_new).norm() < eps:
             break
         V = V_new
     return V.T.reshape(shape)

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -2,7 +2,7 @@ import torch
 from torch import Tensor
 
 
-def project_weights(U: Tensor, G: Tensor, max_iter: int = 200, eps: float = 1e-07) -> Tensor:
+def project_weights(U: Tensor, G: Tensor, max_iter: int, eps: float) -> Tensor:
     r"""
     Computes the tensor of weights corresponding to the projection of the vectors in `U` onto the
     rows of a matrix whose Gramian is provided.

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -32,10 +32,7 @@ def project_weights(U: Tensor, G: Tensor, max_iter: int, eps: float) -> Tensor:
     U_matrix = U.reshape([-1, m]).T
     V = U_matrix.clone()
 
-    if G.device.type == "cuda":
-        driver = "gesvdj"
-    else:
-        driver = None
+    driver = "gesvdj" if G.device.type == "cuda" else None
     lambda_max = torch.linalg.svd(G, driver=driver)[1][0]
     if lambda_max < 1e-10:
         return U

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -7,13 +7,36 @@ def project_weights(U: Tensor, G: Tensor, max_iter: int, eps: float) -> Tensor:
     Computes the tensor of weights corresponding to the projection of the vectors in `U` onto the
     rows of a matrix whose Gramian is provided.
 
+    This is a tensorization of _project_weight_matrix
+
+    :param U: The tensor of weights corresponding to the vectors to project, of shape `[..., m]`.
+    :param G: The Gramian matrix of shape `[m, m]`. It must be symmetric and positive definite.
+    :param max_iter: The maximum number of step of projected gradient descent.
+    :param eps: Tolerance precision threshold to stop optimizing.
+    :return: A tensor of projection weights with the same shape as `U`.
+    """
+
+    shape = U.shape
+    m = shape[-1]
+    U_matrix = U.reshape([-1, m]).T
+
+    V = _project_weight_matrix(U_matrix, G, max_iter, eps)
+
+    return V.T.reshape(shape)
+
+
+def _project_weight_matrix(U: Tensor, G: Tensor, max_iter: int, eps: float) -> Tensor:
+    r"""
+    Computes the tensor of weights corresponding to the projection of the columns in `U` onto the
+    rows of a matrix whose Gramian is provided.
+
 
     By Proposition 1 of [1], this is equivalent to solving for `v` the following quadratic program:
 
     minimize        f(v)=\frac{1}{2} v^T G v
     subject to      u \preceq v
 
-    for each u in U.
+    for each column u in U.
 
     This is done by projected gradient descent:
     - Initialize at $v_0=u$.
@@ -29,18 +52,13 @@ def project_weights(U: Tensor, G: Tensor, max_iter: int, eps: float) -> Tensor:
     Reference:
     [1] `Jacobian Descent For Multi-Objective Optimization <https://arxiv.org/pdf/2406.16232>`_.
 
-    :param U: The tensor of weights corresponding to the vectors to project, of shape `[..., m]`.
+    :param U: The matrix of weight vectors corresponding to the vectors to project, of shape
+        `[m, k]`.
     :param G: The Gramian matrix of shape `[m, m]`. It must be symmetric and positive definite.
     :param max_iter: The maximum number of step of projected gradient descent.
     :param eps: Tolerance precision threshold to stop optimizing.
     :return: A tensor of projection weights with the same shape as `U`.
     """
-
-    shape = U.shape
-    m = shape[-1]
-    U_matrix = U.reshape([-1, m]).T
-    V = U_matrix.clone()
-
     driver = "gesvdj" if G.device.type == "cuda" else None
     lambda_max = torch.linalg.svd(G, driver=driver)[1][0]
     if lambda_max < 1e-10:
@@ -48,9 +66,11 @@ def project_weights(U: Tensor, G: Tensor, max_iter: int, eps: float) -> Tensor:
 
     step_size = 1.9 / lambda_max
 
+    V = U.clone()
+
     for t in range(1, max_iter + 1):
-        V_new = torch.maximum(V - step_size * (G @ V), U_matrix)
+        V_new = torch.maximum(V - step_size * (G @ V), U)
         if (V - V_new).norm() < eps:
             break
         V = V_new
-    return V.T.reshape(shape)
+    return V

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -32,8 +32,11 @@ def project_weights(U: Tensor, G: Tensor, max_iter: int, eps: float) -> Tensor:
     U_matrix = U.reshape([-1, m]).T
     V = U_matrix.clone()
 
-    # torch.linalg.eigvals synchronizes G on the CPU.
-    lambda_max = torch.max(torch.linalg.eigvals(G).real).item()
+    if G.device.type == "cuda":
+        driver = "gesvdj"
+    else:
+        driver = None
+    lambda_max = torch.linalg.svd(G, driver=driver)[1][0]
     if lambda_max < 1e-10:
         return U
     for t in range(1, max_iter + 1):

--- a/src/torchjd/aggregation/_dual_cone_utils.py
+++ b/src/torchjd/aggregation/_dual_cone_utils.py
@@ -34,9 +34,11 @@ def project_weights(U: Tensor, G: Tensor, max_iter: int, eps: float) -> Tensor:
 
     # torch.linalg.eigvals synchronizes G on the CPU.
     lambda_max = torch.max(torch.linalg.eigvals(G).real).item()
+    if lambda_max < 1e-10:
+        return U
     for t in range(1, max_iter + 1):
         sigma = 1.0 / t**0.5
-        step_size = 2.0 / (lambda_max + sigma)
+        step_size = 2.0 / (lambda_max * (1 + sigma))
         V_new = torch.maximum(V - step_size * (G @ V), U_matrix)
         gap = (V - V_new).norm()
         if gap < eps:

--- a/src/torchjd/aggregation/_gramian_utils.py
+++ b/src/torchjd/aggregation/_gramian_utils.py
@@ -23,18 +23,3 @@ def normalize(gramian: Tensor, eps: float) -> Tensor:
         return torch.zeros_like(gramian)
     else:
         return gramian / squared_frobenius_norm
-
-
-def regularize(gramian: Tensor, eps: float) -> Tensor:
-    """
-    Adds a regularization term to the gramian to enforce positive definiteness.
-
-    Because of numerical errors, `gramian` might have slightly negative eigenvalue(s). Adding a
-    regularization term which is a small proportion of the identity matrix ensures that the gramian
-    is positive definite.
-    """
-
-    regularization_matrix = eps * torch.eye(
-        gramian.shape[0], dtype=gramian.dtype, device=gramian.device
-    )
-    return gramian + regularization_matrix

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -17,8 +17,9 @@ class DualProj(_WeightedAggregator):
 
     :param pref_vector: The preference vector used to combine the rows. If not provided, defaults to
         the simple averaging.
-    :param max_iter: The maximal number of iteration of the solver.
-    :param eps: The convergence threshold of the solver.
+    :param max_iter: The maximal number of iterations of the solver.
+    :param eps: The convergence threshold of the solver. A lower value leads to a higher precision
+        but a potentially larger number of iterations.
 
     .. admonition::
         Example

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -34,18 +34,11 @@ class DualProj(_WeightedAggregator):
         tensor([0.5556, 1.1111, 1.1111])
     """
 
-    def __init__(
-        self,
-        pref_vector: Tensor | None = None,
-        max_iter: int = 200,
-        eps: float = 1e-07,
-    ):
+    def __init__(self, pref_vector: Tensor | None = None, max_iter: int = 200, eps: float = 1e-07):
         weighting = pref_vector_to_weighting(pref_vector, default=_MeanWeighting())
         self._pref_vector = pref_vector
 
-        super().__init__(
-            weighting=_DualProjWrapper(weighting=weighting, max_iter=max_iter, eps=eps)
-        )
+        super().__init__(weighting=_DualProjWrapper(weighting, max_iter, eps))
 
     def __repr__(self) -> str:
         return (
@@ -71,12 +64,7 @@ class _DualProjWrapper(_Weighting):
     :param eps: The convergence threshold of the solver.
     """
 
-    def __init__(
-        self,
-        weighting: _Weighting,
-        max_iter: int,
-        eps: float,
-    ):
+    def __init__(self, weighting: _Weighting, max_iter: int, eps: float):
         super().__init__()
         self.weighting = weighting
         self.max_iter = max_iter

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -34,7 +34,7 @@ class DualProj(_WeightedAggregator):
         tensor([0.5556, 1.1111, 1.1111])
     """
 
-    def __init__(self, pref_vector: Tensor | None = None, max_iter: int = 200, eps: float = 1e-07):
+    def __init__(self, pref_vector: Tensor | None = None, max_iter: int = 100, eps: float = 1e-05):
         weighting = pref_vector_to_weighting(pref_vector, default=_MeanWeighting())
         self._pref_vector = pref_vector
 

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -30,7 +30,7 @@ class DualProj(_WeightedAggregator):
         >>> J = tensor([[-4., 1., 1.], [6., 1., 1.]])
         >>>
         >>> A(J)
-        tensor([0.5563, 1.1109, 1.1109])
+        tensor([0.5556, 1.1111, 1.1111])
     """
 
     def __init__(

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -17,7 +17,6 @@ class DualProj(_WeightedAggregator):
     :param pref_vector: The preference vector used to combine the rows. If not provided, defaults to
         the simple averaging.
     :param norm_eps: A small value to avoid division by zero when normalizing.
-    :param solver: The solver used to optimize the underlying optimization problem.
 
     .. admonition::
         Example
@@ -65,7 +64,6 @@ class _DualProjWrapper(_Weighting):
     :param weighting: The wrapped :class:`~torchjd.aggregation.bases._Weighting`
         responsible for extracting weight vectors from the input matrices.
     :param norm_eps: A small value to avoid division by zero when normalizing.
-    :param solver: The solver used to optimize the underlying optimization problem.
     """
 
     def __init__(

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -1,5 +1,3 @@
-from typing import Literal
-
 from torch import Tensor
 
 from ._dual_cone_utils import project_weights
@@ -45,22 +43,18 @@ class DualProj(_WeightedAggregator):
         pref_vector: Tensor | None = None,
         norm_eps: float = 0.0001,
         reg_eps: float = 0.0001,
-        solver: Literal["quadprog"] = "quadprog",
     ):
         weighting = pref_vector_to_weighting(pref_vector, default=_MeanWeighting())
         self._pref_vector = pref_vector
 
         super().__init__(
-            weighting=_DualProjWrapper(
-                weighting=weighting, norm_eps=norm_eps, reg_eps=reg_eps, solver=solver
-            )
+            weighting=_DualProjWrapper(weighting=weighting, norm_eps=norm_eps, reg_eps=reg_eps)
         )
 
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(pref_vector={repr(self._pref_vector)}, norm_eps="
-            f"{self.weighting.norm_eps}, reg_eps={self.weighting.reg_eps}, "
-            f"solver={repr(self.weighting.solver)})"
+            f"{self.weighting.norm_eps}, reg_eps={self.weighting.reg_eps})"
         )
 
     def __str__(self) -> str:
@@ -90,13 +84,11 @@ class _DualProjWrapper(_Weighting):
         weighting: _Weighting,
         norm_eps: float,
         reg_eps: float,
-        solver: Literal["quadprog"],
     ):
         super().__init__()
         self.weighting = weighting
         self.norm_eps = norm_eps
         self.reg_eps = reg_eps
-        self.solver = solver
 
     def forward(self, matrix: Tensor) -> Tensor:
         u = self.weighting(matrix)

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -1,7 +1,7 @@
 from torch import Tensor
 
 from ._dual_cone_utils import project_weights
-from ._gramian_utils import compute_gramian, normalize
+from ._gramian_utils import compute_gramian
 from ._pref_vector_utils import pref_vector_to_str_suffix, pref_vector_to_weighting
 from .bases import _WeightedAggregator, _Weighting
 from .mean import _MeanWeighting
@@ -92,6 +92,6 @@ class _DualProjWrapper(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         u = self.weighting(matrix)
-        G = normalize(compute_gramian(matrix), self.norm_eps)
+        G = compute_gramian(matrix)
         w = project_weights(u, G)
         return w

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -17,10 +17,6 @@ class DualProj(_WeightedAggregator):
     :param pref_vector: The preference vector used to combine the rows. If not provided, defaults to
         the simple averaging.
     :param norm_eps: A small value to avoid division by zero when normalizing.
-    :param reg_eps: A small value to add to the diagonal of the gramian of the matrix. Due to
-        numerical errors when computing the gramian, it might not exactly be positive definite.
-        This issue can make the optimization fail. Adding ``reg_eps`` to the diagonal of the gramian
-        ensures that it is positive definite.
     :param solver: The solver used to optimize the underlying optimization problem.
 
     .. admonition::
@@ -42,19 +38,16 @@ class DualProj(_WeightedAggregator):
         self,
         pref_vector: Tensor | None = None,
         norm_eps: float = 0.0001,
-        reg_eps: float = 0.0001,
     ):
         weighting = pref_vector_to_weighting(pref_vector, default=_MeanWeighting())
         self._pref_vector = pref_vector
 
-        super().__init__(
-            weighting=_DualProjWrapper(weighting=weighting, norm_eps=norm_eps, reg_eps=reg_eps)
-        )
+        super().__init__(weighting=_DualProjWrapper(weighting=weighting, norm_eps=norm_eps))
 
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(pref_vector={repr(self._pref_vector)}, norm_eps="
-            f"{self.weighting.norm_eps}, reg_eps={self.weighting.reg_eps})"
+            f"{self.weighting.norm_eps})"
         )
 
     def __str__(self) -> str:
@@ -72,10 +65,6 @@ class _DualProjWrapper(_Weighting):
     :param weighting: The wrapped :class:`~torchjd.aggregation.bases._Weighting`
         responsible for extracting weight vectors from the input matrices.
     :param norm_eps: A small value to avoid division by zero when normalizing.
-    :param reg_eps: A small value to add to the diagonal of the gramian of the matrix. Due to
-        numerical errors when computing the gramian, it might not exactly be positive definite.
-        This issue can make the optimization fail. Adding ``reg_eps`` to the diagonal of the gramian
-        ensures that it is positive definite.
     :param solver: The solver used to optimize the underlying optimization problem.
     """
 
@@ -83,12 +72,10 @@ class _DualProjWrapper(_Weighting):
         self,
         weighting: _Weighting,
         norm_eps: float,
-        reg_eps: float,
     ):
         super().__init__()
         self.weighting = weighting
         self.norm_eps = norm_eps
-        self.reg_eps = reg_eps
 
     def forward(self, matrix: Tensor) -> Tensor:
         u = self.weighting(matrix)

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -2,7 +2,6 @@ from torch import Tensor
 
 from ._dual_cone_utils import project_weights
 from ._gramian_utils import compute_gramian
-from ._gramian_utils import compute_gramian
 from ._non_differentiable import raise_non_differentiable_error
 from ._pref_vector_utils import pref_vector_to_str_suffix, pref_vector_to_weighting
 from .bases import _WeightedAggregator, _Weighting

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -3,7 +3,7 @@ from typing import Literal
 from torch import Tensor
 
 from ._dual_cone_utils import project_weights
-from ._gramian_utils import compute_gramian, normalize, regularize
+from ._gramian_utils import compute_gramian, normalize
 from ._pref_vector_utils import pref_vector_to_str_suffix, pref_vector_to_weighting
 from .bases import _WeightedAggregator, _Weighting
 from .mean import _MeanWeighting
@@ -100,6 +100,6 @@ class _DualProjWrapper(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         u = self.weighting(matrix)
-        G = regularize(normalize(compute_gramian(matrix), self.norm_eps), self.reg_eps)
-        w = project_weights(u, G, self.solver)
+        G = normalize(compute_gramian(matrix), self.norm_eps)
+        w = project_weights(u, G)
         return w

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -30,7 +30,7 @@ class UPGrad(_WeightedAggregator):
         >>> J = tensor([[-4., 1., 1.], [6., 1., 1.]])
         >>>
         >>> A(J)
-        tensor([0.2929, 1.9004, 1.9004])
+        tensor([0.2924, 1.9006, 1.9006])
     """
 
     def __init__(

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -17,10 +17,6 @@ class UPGrad(_WeightedAggregator):
     :param pref_vector: The preference vector used to combine the projected rows. If not provided,
         defaults to the simple averaging of the projected rows.
     :param norm_eps: A small value to avoid division by zero when normalizing.
-    :param reg_eps: A small value to add to the diagonal of the gramian of the matrix. Due to
-        numerical errors when computing the gramian, it might not exactly be positive definite.
-        This issue can make the optimization fail. Adding ``reg_eps`` to the diagonal of the gramian
-        ensures that it is positive definite.
     :param solver: The solver used to optimize the underlying optimization problem.
 
     .. admonition::
@@ -42,19 +38,16 @@ class UPGrad(_WeightedAggregator):
         self,
         pref_vector: Tensor | None = None,
         norm_eps: float = 0.0001,
-        reg_eps: float = 0.0001,
     ):
         weighting = pref_vector_to_weighting(pref_vector, default=_MeanWeighting())
         self._pref_vector = pref_vector
 
-        super().__init__(
-            weighting=_UPGradWrapper(weighting=weighting, norm_eps=norm_eps, reg_eps=reg_eps)
-        )
+        super().__init__(weighting=_UPGradWrapper(weighting=weighting, norm_eps=norm_eps))
 
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(pref_vector={repr(self._pref_vector)}, norm_eps="
-            f"{self.weighting.norm_eps}, reg_eps={self.weighting.reg_eps})"
+            f"{self.weighting.norm_eps})"
         )
 
     def __str__(self) -> str:
@@ -68,10 +61,6 @@ class _UPGradWrapper(_Weighting):
 
     :param weighting: The wrapped weighting.
     :param norm_eps: A small value to avoid division by zero when normalizing.
-    :param reg_eps: A small value to add to the diagonal of the gramian of the matrix. Due to
-        numerical errors when computing the gramian, it might not exactly be positive definite.
-        This issue can make the optimization fail. Adding ``reg_eps`` to the diagonal of the gramian
-        ensures that it is positive definite.
     :param solver: The solver used to optimize the underlying optimization problem.
     """
 
@@ -79,12 +68,10 @@ class _UPGradWrapper(_Weighting):
         self,
         weighting: _Weighting,
         norm_eps: float,
-        reg_eps: float,
     ):
         super().__init__()
         self.weighting = weighting
         self.norm_eps = norm_eps
-        self.reg_eps = reg_eps
 
     def forward(self, matrix: Tensor) -> Tensor:
         U = torch.diag(self.weighting(matrix))

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -2,7 +2,7 @@ import torch
 from torch import Tensor
 
 from ._dual_cone_utils import project_weights
-from ._gramian_utils import compute_gramian, normalize
+from ._gramian_utils import compute_gramian
 from ._pref_vector_utils import pref_vector_to_str_suffix, pref_vector_to_weighting
 from .bases import _WeightedAggregator, _Weighting
 from .mean import _MeanWeighting
@@ -88,6 +88,6 @@ class _UPGradWrapper(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         U = torch.diag(self.weighting(matrix))
-        G = normalize(compute_gramian(matrix), self.norm_eps)
+        G = compute_gramian(matrix)
         W = project_weights(U, G)
         return torch.sum(W, dim=0)

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -34,7 +34,7 @@ class UPGrad(_WeightedAggregator):
         tensor([0.2924, 1.9006, 1.9006])
     """
 
-    def __init__(self, pref_vector: Tensor | None = None, max_iter: int = 200, eps: float = 1e-07):
+    def __init__(self, pref_vector: Tensor | None = None, max_iter: int = 100, eps: float = 1e-05):
         weighting = pref_vector_to_weighting(pref_vector, default=_MeanWeighting())
         self._pref_vector = pref_vector
 

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -4,7 +4,7 @@ import torch
 from torch import Tensor
 
 from ._dual_cone_utils import project_weights
-from ._gramian_utils import compute_gramian, normalize, regularize
+from ._gramian_utils import compute_gramian, normalize
 from ._pref_vector_utils import pref_vector_to_str_suffix, pref_vector_to_weighting
 from .bases import _WeightedAggregator, _Weighting
 from .mean import _MeanWeighting
@@ -96,6 +96,6 @@ class _UPGradWrapper(_Weighting):
 
     def forward(self, matrix: Tensor) -> Tensor:
         U = torch.diag(self.weighting(matrix))
-        G = regularize(normalize(compute_gramian(matrix), self.norm_eps), self.reg_eps)
-        W = project_weights(U, G, self.solver)
+        G = normalize(compute_gramian(matrix), self.norm_eps)
+        W = project_weights(U, G)
         return torch.sum(W, dim=0)

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -16,7 +16,8 @@ class UPGrad(_WeightedAggregator):
 
     :param pref_vector: The preference vector used to combine the projected rows. If not provided,
         defaults to the simple averaging of the projected rows.
-    :param norm_eps: A small value to avoid division by zero when normalizing.
+    :param max_iter: The maximal number of iteration of the solver.
+    :param eps: The convergence threshold of the solver.
 
     .. admonition::
         Example
@@ -36,17 +37,18 @@ class UPGrad(_WeightedAggregator):
     def __init__(
         self,
         pref_vector: Tensor | None = None,
-        norm_eps: float = 0.0001,
+        max_iter: int = 200,
+        eps: float = 1e-07,
     ):
         weighting = pref_vector_to_weighting(pref_vector, default=_MeanWeighting())
         self._pref_vector = pref_vector
 
-        super().__init__(weighting=_UPGradWrapper(weighting=weighting, norm_eps=norm_eps))
+        super().__init__(weighting=_UPGradWrapper(weighting=weighting, max_iter=max_iter, eps=eps))
 
     def __repr__(self) -> str:
         return (
-            f"{self.__class__.__name__}(pref_vector={repr(self._pref_vector)}, norm_eps="
-            f"{self.weighting.norm_eps})"
+            f"{self.__class__.__name__}(pref_vector={repr(self._pref_vector)}, max_iter="
+            f"{self.weighting.max_iter}, eps={self.weighting.eps})"
         )
 
     def __str__(self) -> str:
@@ -59,20 +61,23 @@ class _UPGradWrapper(_Weighting):
     that each weighted row is projected onto the dual cone of all rows.
 
     :param weighting: The wrapped weighting.
-    :param norm_eps: A small value to avoid division by zero when normalizing.
+    :param max_iter: The maximal number of iteration of the solver.
+    :param eps: The convergence threshold of the solver.
     """
 
     def __init__(
         self,
         weighting: _Weighting,
-        norm_eps: float,
+        max_iter: int,
+        eps: float,
     ):
         super().__init__()
         self.weighting = weighting
-        self.norm_eps = norm_eps
+        self.max_iter = max_iter
+        self.eps = eps
 
     def forward(self, matrix: Tensor) -> Tensor:
         U = torch.diag(self.weighting(matrix))
         G = compute_gramian(matrix)
-        W = project_weights(U, G)
+        W = project_weights(U, G, self.max_iter, self.eps)
         return torch.sum(W, dim=0)

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -17,7 +17,6 @@ class UPGrad(_WeightedAggregator):
     :param pref_vector: The preference vector used to combine the projected rows. If not provided,
         defaults to the simple averaging of the projected rows.
     :param norm_eps: A small value to avoid division by zero when normalizing.
-    :param solver: The solver used to optimize the underlying optimization problem.
 
     .. admonition::
         Example
@@ -61,7 +60,6 @@ class _UPGradWrapper(_Weighting):
 
     :param weighting: The wrapped weighting.
     :param norm_eps: A small value to avoid division by zero when normalizing.
-    :param solver: The solver used to optimize the underlying optimization problem.
     """
 
     def __init__(

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -1,5 +1,3 @@
-from typing import Literal
-
 import torch
 from torch import Tensor
 
@@ -45,22 +43,18 @@ class UPGrad(_WeightedAggregator):
         pref_vector: Tensor | None = None,
         norm_eps: float = 0.0001,
         reg_eps: float = 0.0001,
-        solver: Literal["quadprog"] = "quadprog",
     ):
         weighting = pref_vector_to_weighting(pref_vector, default=_MeanWeighting())
         self._pref_vector = pref_vector
 
         super().__init__(
-            weighting=_UPGradWrapper(
-                weighting=weighting, norm_eps=norm_eps, reg_eps=reg_eps, solver=solver
-            )
+            weighting=_UPGradWrapper(weighting=weighting, norm_eps=norm_eps, reg_eps=reg_eps)
         )
 
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(pref_vector={repr(self._pref_vector)}, norm_eps="
-            f"{self.weighting.norm_eps}, reg_eps={self.weighting.reg_eps}, "
-            f"solver={repr(self.weighting.solver)})"
+            f"{self.weighting.norm_eps}, reg_eps={self.weighting.reg_eps})"
         )
 
     def __str__(self) -> str:
@@ -86,13 +80,11 @@ class _UPGradWrapper(_Weighting):
         weighting: _Weighting,
         norm_eps: float,
         reg_eps: float,
-        solver: Literal["quadprog"],
     ):
         super().__init__()
         self.weighting = weighting
         self.norm_eps = norm_eps
         self.reg_eps = reg_eps
-        self.solver = solver
 
     def forward(self, matrix: Tensor) -> Tensor:
         U = torch.diag(self.weighting(matrix))

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -34,16 +34,11 @@ class UPGrad(_WeightedAggregator):
         tensor([0.2924, 1.9006, 1.9006])
     """
 
-    def __init__(
-        self,
-        pref_vector: Tensor | None = None,
-        max_iter: int = 200,
-        eps: float = 1e-07,
-    ):
+    def __init__(self, pref_vector: Tensor | None = None, max_iter: int = 200, eps: float = 1e-07):
         weighting = pref_vector_to_weighting(pref_vector, default=_MeanWeighting())
         self._pref_vector = pref_vector
 
-        super().__init__(weighting=_UPGradWrapper(weighting=weighting, max_iter=max_iter, eps=eps))
+        super().__init__(weighting=_UPGradWrapper(weighting, max_iter, eps))
 
     def __repr__(self) -> str:
         return (
@@ -65,12 +60,7 @@ class _UPGradWrapper(_Weighting):
     :param eps: The convergence threshold of the solver.
     """
 
-    def __init__(
-        self,
-        weighting: _Weighting,
-        max_iter: int,
-        eps: float,
-    ):
+    def __init__(self, weighting: _Weighting, max_iter: int, eps: float):
         super().__init__()
         self.weighting = weighting
         self.max_iter = max_iter

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -17,8 +17,9 @@ class UPGrad(_WeightedAggregator):
 
     :param pref_vector: The preference vector used to combine the projected rows. If not provided,
         defaults to the simple averaging of the projected rows.
-    :param max_iter: The maximal number of iteration of the solver.
-    :param eps: The convergence threshold of the solver.
+    :param max_iter: The maximal number of iterations of the solver.
+    :param eps: The convergence threshold of the solver. A lower value leads to a higher precision
+        but a potentially larger number of iterations.
 
     .. admonition::
         Example

--- a/tests/doc/test_aggregation.py
+++ b/tests/doc/test_aggregation.py
@@ -61,7 +61,7 @@ def test_dualproj():
     A = DualProj()
     J = tensor([[-4.0, 1.0, 1.0], [6.0, 1.0, 1.0]])
 
-    assert_close(A(J), tensor([0.5563, 1.1109, 1.1109]), rtol=0, atol=1e-4)
+    assert_close(A(J), tensor([0.5556, 1.1111, 1.1111]), rtol=0, atol=1e-4)
 
 
 def test_graddrop():
@@ -210,4 +210,4 @@ def test_upgrad():
     A = UPGrad()
     J = tensor([[-4.0, 1.0, 1.0], [6.0, 1.0, 1.0]])
 
-    assert_close(A(J), tensor([0.2929, 1.9004, 1.9004]), rtol=0, atol=1e-4)
+    assert_close(A(J), tensor([0.2924, 1.9006, 1.9006]), rtol=0, atol=1e-4)

--- a/tests/unit/aggregation/_property_testers.py
+++ b/tests/unit/aggregation/_property_testers.py
@@ -43,7 +43,7 @@ class NonConflictingProperty:
         vector = aggregator(matrix)
         output_direction = matrix @ vector
         positive_directions = output_direction[output_direction >= 0]
-        assert_close(positive_directions.norm(), output_direction.norm(), atol=4e-04, rtol=0)
+        assert_close(positive_directions.norm(), output_direction.norm(), atol=7e-04, rtol=0)
 
 
 class PermutationInvarianceProperty:

--- a/tests/unit/aggregation/_property_testers.py
+++ b/tests/unit/aggregation/_property_testers.py
@@ -44,7 +44,7 @@ class NonConflictingProperty:
         vector = aggregator(matrix)
         output_direction = matrix @ vector
         positive_directions = output_direction[output_direction >= 0]
-        assert_close(positive_directions.norm(), output_direction.norm(), atol=7e-04, rtol=0)
+        assert_close(positive_directions.norm(), output_direction.norm(), atol=9e-04, rtol=0)
 
 
 class PermutationInvarianceProperty:

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -5,7 +5,7 @@ from torch.testing import assert_close
 from torchjd.aggregation._dual_cone_utils import project_weights
 
 
-@mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100)])
+@mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100), (400, 1000)])
 def test_solution_weights(shape: tuple[int, int]):
     r"""
     Tests that `_project_weights` returns valid weights corresponding to the projection onto the
@@ -43,11 +43,11 @@ def test_solution_weights(shape: tuple[int, int]):
 
     # Primal feasibility
     primal_gap_positive_part = primal_gap[primal_gap >= 0]
-    assert_close(primal_gap_positive_part.norm(), primal_gap.norm(), atol=1e-04, rtol=0)
+    assert_close(primal_gap_positive_part.norm(), primal_gap.norm(), atol=1e-03, rtol=0)
 
     # Complementary slackness
     slackness = dual_gap @ primal_gap
-    assert_close(slackness, torch.zeros_like(slackness), atol=2e-05, rtol=0)
+    assert_close(slackness, torch.zeros_like(slackness), atol=1e-04, rtol=0)
 
 
 @mark.parametrize("shape", [(5, 7), (9, 37), (32, 114)])

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -1,5 +1,5 @@
 import torch
-from pytest import mark, raises
+from pytest import mark
 from torch.testing import assert_close
 
 from torchjd.aggregation._dual_cone_utils import project_weights
@@ -84,12 +84,3 @@ def test_tensorization_shape(shape: tuple[int, ...]):
     W_matrix = project_weights(U_matrix, G)
 
     assert_close(W_matrix.reshape(shape), W_tensor)
-
-
-def test_project_weight_failure():
-    """Tests that `project_weight` raises an error when the input G has too large values."""
-
-    large_J = torch.randn(10, 100) * 1e5
-    large_G = large_J @ large_J.T
-    with raises(ValueError):
-        project_weights(torch.ones(10), large_G)

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -47,7 +47,7 @@ def test_solution_weights(shape: tuple[int, int]):
 
     # Complementary slackness
     slackness = dual_gap @ primal_gap
-    assert_close(slackness, torch.zeros_like(slackness), atol=3e-03, rtol=0)
+    assert_close(slackness, torch.zeros_like(slackness), atol=1e-05, rtol=0)
 
 
 @mark.parametrize("shape", [(5, 7), (9, 37), (32, 114)])

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -32,7 +32,7 @@ def test_solution_weights(shape: tuple[int, int]):
     G = J @ J.T
     u = torch.rand(shape[0])
 
-    w = project_weights(u, G)
+    w = project_weights(u, G, 200, 1e-07)
     dual_gap = w - u
 
     # Dual feasibility
@@ -61,8 +61,8 @@ def test_scale_invariant(shape: tuple[int, int], scaling: float):
     G = J @ J.T
     u = torch.rand(shape[0])
 
-    w = project_weights(u, G)
-    w_scaled = project_weights(u, scaling * G)
+    w = project_weights(u, G, 200, 1e-07)
+    w_scaled = project_weights(u, scaling * G, 200, 1e-07)
 
     assert_close(w_scaled, w)
 
@@ -80,7 +80,7 @@ def test_tensorization_shape(shape: tuple[int, ...]):
 
     G = matrix @ matrix.T
 
-    W_tensor = project_weights(U_tensor, G)
-    W_matrix = project_weights(U_matrix, G)
+    W_tensor = project_weights(U_tensor, G, 200, 1e-07)
+    W_matrix = project_weights(U_matrix, G, 200, 1e-07)
 
     assert_close(W_matrix.reshape(shape), W_tensor)

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -5,7 +5,7 @@ from torch.testing import assert_close
 from torchjd.aggregation._dual_cone_utils import project_weights
 
 
-@mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100), (400, 1000)])
+@mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100)])
 def test_solution_weights(shape: tuple[int, int]):
     r"""
     Tests that `_project_weights` returns valid weights corresponding to the projection onto the
@@ -43,11 +43,11 @@ def test_solution_weights(shape: tuple[int, int]):
 
     # Primal feasibility
     primal_gap_positive_part = primal_gap[primal_gap >= 0]
-    assert_close(primal_gap_positive_part.norm(), primal_gap.norm(), atol=1e-03, rtol=0)
+    assert_close(primal_gap_positive_part.norm(), primal_gap.norm(), atol=1e-04, rtol=0)
 
     # Complementary slackness
     slackness = dual_gap @ primal_gap
-    assert_close(slackness, torch.zeros_like(slackness), atol=1e-04, rtol=0)
+    assert_close(slackness, torch.zeros_like(slackness), atol=2e-05, rtol=0)
 
 
 @mark.parametrize("shape", [(5, 7), (9, 37), (32, 114)])

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -1,9 +1,8 @@
-import numpy as np
 import torch
 from pytest import mark, raises
 from torch.testing import assert_close
 
-from torchjd.aggregation._dual_cone_utils import _project_weight_vector, project_weights
+from torchjd.aggregation._dual_cone_utils import project_weights
 
 
 @mark.parametrize("shape", [(5, 7), (9, 37), (2, 14), (32, 114), (50, 100)])
@@ -33,7 +32,7 @@ def test_solution_weights(shape: tuple[int, int]):
     G = J @ J.T
     u = torch.rand(shape[0])
 
-    w = project_weights(u, G, "quadprog")
+    w = project_weights(u, G)
     dual_gap = w - u
 
     # Dual feasibility
@@ -62,8 +61,8 @@ def test_scale_invariant(shape: tuple[int, int], scaling: float):
     G = J @ J.T
     u = torch.rand(shape[0])
 
-    w = project_weights(u, G, "quadprog")
-    w_scaled = project_weights(u, scaling * G, "quadprog")
+    w = project_weights(u, G)
+    w_scaled = project_weights(u, scaling * G)
 
     assert_close(w_scaled, w)
 
@@ -81,16 +80,16 @@ def test_tensorization_shape(shape: tuple[int, ...]):
 
     G = matrix @ matrix.T
 
-    W_tensor = project_weights(U_tensor, G, "quadprog")
-    W_matrix = project_weights(U_matrix, G, "quadprog")
+    W_tensor = project_weights(U_tensor, G)
+    W_matrix = project_weights(U_matrix, G)
 
     assert_close(W_matrix.reshape(shape), W_tensor)
 
 
-def test_project_weight_vector_failure():
-    """Tests that `_project_weight_vector` raises an error when the input G has too large values."""
+def test_project_weight_failure():
+    """Tests that `project_weight` raises an error when the input G has too large values."""
 
-    large_J = np.random.randn(10, 100) * 1e5
+    large_J = torch.randn(10, 100) * 1e5
     large_G = large_J @ large_J.T
     with raises(ValueError):
-        _project_weight_vector(np.ones(10), large_G, "quadprog")
+        project_weights(torch.ones(10), large_G)

--- a/tests/unit/aggregation/test_dual_cone_utils.py
+++ b/tests/unit/aggregation/test_dual_cone_utils.py
@@ -47,7 +47,7 @@ def test_solution_weights(shape: tuple[int, int]):
 
     # Complementary slackness
     slackness = dual_gap @ primal_gap
-    assert_close(slackness, torch.zeros_like(slackness), atol=1e-05, rtol=0)
+    assert_close(slackness, torch.zeros_like(slackness), atol=2e-05, rtol=0)
 
 
 @mark.parametrize("shape", [(5, 7), (9, 37), (32, 114)])

--- a/tests/unit/aggregation/test_dualproj.py
+++ b/tests/unit/aggregation/test_dualproj.py
@@ -22,12 +22,10 @@ class TestDualProj(
 
 
 def test_representations():
-    A = DualProj(pref_vector=None, norm_eps=0.0001, reg_eps=0.0001)
-    assert repr(A) == "DualProj(pref_vector=None, norm_eps=0.0001, reg_eps=0.0001)"
+    A = DualProj(pref_vector=None, norm_eps=0.0001)
+    assert repr(A) == "DualProj(pref_vector=None, norm_eps=0.0001)"
     assert str(A) == "DualProj"
 
-    A = DualProj(
-        pref_vector=torch.tensor([1.0, 2.0, 3.0], device="cpu"), norm_eps=0.0001, reg_eps=0.0001
-    )
-    assert repr(A) == "DualProj(pref_vector=tensor([1., 2., 3.]), norm_eps=0.0001, reg_eps=0.0001)"
+    A = DualProj(pref_vector=torch.tensor([1.0, 2.0, 3.0], device="cpu"), norm_eps=0.0001)
+    assert repr(A) == "DualProj(pref_vector=tensor([1., 2., 3.]), norm_eps=0.0001)"
     assert str(A) == "DualProj([1., 2., 3.])"

--- a/tests/unit/aggregation/test_dualproj.py
+++ b/tests/unit/aggregation/test_dualproj.py
@@ -22,10 +22,10 @@ class TestDualProj(
 
 
 def test_representations():
-    A = DualProj(pref_vector=None, norm_eps=0.0001)
-    assert repr(A) == "DualProj(pref_vector=None, norm_eps=0.0001)"
+    A = DualProj(pref_vector=None, max_iter=100, eps=0.0001)
+    assert repr(A) == "DualProj(pref_vector=None, max_iter=100, eps=0.0001)"
     assert str(A) == "DualProj"
 
-    A = DualProj(pref_vector=torch.tensor([1.0, 2.0, 3.0], device="cpu"), norm_eps=0.0001)
-    assert repr(A) == "DualProj(pref_vector=tensor([1., 2., 3.]), norm_eps=0.0001)"
+    A = DualProj(pref_vector=torch.tensor([1.0, 2.0, 3.0], device="cpu"), max_iter=100, eps=0.0001)
+    assert repr(A) == "DualProj(pref_vector=tensor([1., 2., 3.]), max_iter=100, eps=0.0001)"
     assert str(A) == "DualProj([1., 2., 3.])"

--- a/tests/unit/aggregation/test_dualproj.py
+++ b/tests/unit/aggregation/test_dualproj.py
@@ -22,20 +22,12 @@ class TestDualProj(
 
 
 def test_representations():
-    A = DualProj(pref_vector=None, norm_eps=0.0001, reg_eps=0.0001, solver="quadprog")
-    assert (
-        repr(A) == "DualProj(pref_vector=None, norm_eps=0.0001, reg_eps=0.0001, solver='quadprog')"
-    )
+    A = DualProj(pref_vector=None, norm_eps=0.0001, reg_eps=0.0001)
+    assert repr(A) == "DualProj(pref_vector=None, norm_eps=0.0001, reg_eps=0.0001)"
     assert str(A) == "DualProj"
 
     A = DualProj(
-        pref_vector=torch.tensor([1.0, 2.0, 3.0], device="cpu"),
-        norm_eps=0.0001,
-        reg_eps=0.0001,
-        solver="quadprog",
+        pref_vector=torch.tensor([1.0, 2.0, 3.0], device="cpu"), norm_eps=0.0001, reg_eps=0.0001
     )
-    assert (
-        repr(A) == "DualProj(pref_vector=tensor([1., 2., 3.]), norm_eps=0.0001, reg_eps=0.0001, "
-        "solver='quadprog')"
-    )
+    assert repr(A) == "DualProj(pref_vector=tensor([1., 2., 3.]), norm_eps=0.0001, reg_eps=0.0001)"
     assert str(A) == "DualProj([1., 2., 3.])"

--- a/tests/unit/aggregation/test_pcgrad.py
+++ b/tests/unit/aggregation/test_pcgrad.py
@@ -39,7 +39,7 @@ def test_equivalence_upgrad_sum_two_rows(shape: tuple[int, int]):
     matrix = torch.randn(shape)
 
     pc_grad_weighting = _PCGradWeighting()
-    upgrad_sum_weighting = _UPGradWrapper(_SumWeighting(), norm_eps=0.0)
+    upgrad_sum_weighting = _UPGradWrapper(_SumWeighting(), max_iter=200, eps=0.0)
 
     result = pc_grad_weighting(matrix)
     expected = upgrad_sum_weighting(matrix)

--- a/tests/unit/aggregation/test_pcgrad.py
+++ b/tests/unit/aggregation/test_pcgrad.py
@@ -39,7 +39,7 @@ def test_equivalence_upgrad_sum_two_rows(shape: tuple[int, int]):
     matrix = torch.randn(shape)
 
     pc_grad_weighting = _PCGradWeighting()
-    upgrad_sum_weighting = _UPGradWrapper(_SumWeighting(), norm_eps=0.0, reg_eps=0.0)
+    upgrad_sum_weighting = _UPGradWrapper(_SumWeighting(), norm_eps=0.0)
 
     result = pc_grad_weighting(matrix)
     expected = upgrad_sum_weighting(matrix)

--- a/tests/unit/aggregation/test_pcgrad.py
+++ b/tests/unit/aggregation/test_pcgrad.py
@@ -39,9 +39,7 @@ def test_equivalence_upgrad_sum_two_rows(shape: tuple[int, int]):
     matrix = torch.randn(shape)
 
     pc_grad_weighting = _PCGradWeighting()
-    upgrad_sum_weighting = _UPGradWrapper(
-        _SumWeighting(), norm_eps=0.0, reg_eps=0.0, solver="quadprog"
-    )
+    upgrad_sum_weighting = _UPGradWrapper(_SumWeighting(), norm_eps=0.0, reg_eps=0.0)
 
     result = pc_grad_weighting(matrix)
     expected = upgrad_sum_weighting(matrix)

--- a/tests/unit/aggregation/test_upgrad.py
+++ b/tests/unit/aggregation/test_upgrad.py
@@ -24,10 +24,10 @@ class TestUPGrad(
 
 
 def test_representations():
-    A = UPGrad(pref_vector=None, norm_eps=0.0001)
-    assert repr(A) == "UPGrad(pref_vector=None, norm_eps=0.0001)"
+    A = UPGrad(pref_vector=None, max_iter=100, eps=0.0001)
+    assert repr(A) == "UPGrad(pref_vector=None, max_iter=100, eps=0.0001)"
     assert str(A) == "UPGrad"
 
-    A = UPGrad(pref_vector=torch.tensor([1.0, 2.0, 3.0], device="cpu"), norm_eps=0.0001)
-    assert repr(A) == "UPGrad(pref_vector=tensor([1., 2., 3.]), norm_eps=0.0001)"
+    A = UPGrad(pref_vector=torch.tensor([1.0, 2.0, 3.0], device="cpu"), max_iter=100, eps=0.0001)
+    assert repr(A) == "UPGrad(pref_vector=tensor([1., 2., 3.]), max_iter=100, eps=0.0001)"
     assert str(A) == "UPGrad([1., 2., 3.])"

--- a/tests/unit/aggregation/test_upgrad.py
+++ b/tests/unit/aggregation/test_upgrad.py
@@ -24,18 +24,12 @@ class TestUPGrad(
 
 
 def test_representations():
-    A = UPGrad(pref_vector=None, norm_eps=0.0001, reg_eps=0.0001, solver="quadprog")
-    assert repr(A) == "UPGrad(pref_vector=None, norm_eps=0.0001, reg_eps=0.0001, solver='quadprog')"
+    A = UPGrad(pref_vector=None, norm_eps=0.0001, reg_eps=0.0001)
+    assert repr(A) == "UPGrad(pref_vector=None, norm_eps=0.0001, reg_eps=0.0001)"
     assert str(A) == "UPGrad"
 
     A = UPGrad(
-        pref_vector=torch.tensor([1.0, 2.0, 3.0], device="cpu"),
-        norm_eps=0.0001,
-        reg_eps=0.0001,
-        solver="quadprog",
+        pref_vector=torch.tensor([1.0, 2.0, 3.0], device="cpu"), norm_eps=0.0001, reg_eps=0.0001
     )
-    assert (
-        repr(A) == "UPGrad(pref_vector=tensor([1., 2., 3.]), norm_eps=0.0001, reg_eps=0.0001, "
-        "solver='quadprog')"
-    )
+    assert repr(A) == "UPGrad(pref_vector=tensor([1., 2., 3.]), norm_eps=0.0001, reg_eps=0.0001)"
     assert str(A) == "UPGrad([1., 2., 3.])"

--- a/tests/unit/aggregation/test_upgrad.py
+++ b/tests/unit/aggregation/test_upgrad.py
@@ -24,12 +24,10 @@ class TestUPGrad(
 
 
 def test_representations():
-    A = UPGrad(pref_vector=None, norm_eps=0.0001, reg_eps=0.0001)
-    assert repr(A) == "UPGrad(pref_vector=None, norm_eps=0.0001, reg_eps=0.0001)"
+    A = UPGrad(pref_vector=None, norm_eps=0.0001)
+    assert repr(A) == "UPGrad(pref_vector=None, norm_eps=0.0001)"
     assert str(A) == "UPGrad"
 
-    A = UPGrad(
-        pref_vector=torch.tensor([1.0, 2.0, 3.0], device="cpu"), norm_eps=0.0001, reg_eps=0.0001
-    )
-    assert repr(A) == "UPGrad(pref_vector=tensor([1., 2., 3.]), norm_eps=0.0001, reg_eps=0.0001)"
+    A = UPGrad(pref_vector=torch.tensor([1.0, 2.0, 3.0], device="cpu"), norm_eps=0.0001)
+    assert repr(A) == "UPGrad(pref_vector=tensor([1., 2., 3.]), norm_eps=0.0001)"
     assert str(A) == "UPGrad([1., 2., 3.])"


### PR DESCRIPTION
* Implement a torch based QP solver for dual cone projections
* Change the interface of UPGrad and DualProj to parametrize the solver
* Remove qpsolvers and quadprog from dependencies
* Move numpy dependency to optional dependencies cagrad, nash_mtl and full
* Remove regularization function for Gramians as not used
* Add changelog entry

TODO:
- [x] Remove quadprog and qpsolver dependencies entirely from pyproject.toml
- [x] Remove numpy from the main dependencies and add it as a cagrad, nash_mtl, full and plot dependency
- [x] Remove parameter solver to UPGrad and DualProj
- [x] Add parameters related to max_iter and norm_eps of solver to UPGrad and DualProj (don't forget representation)
- [x] Find out if there is a way to compute the largest eigen value of the gramian without synching the gramian with the CPU. If we must cast on CPU to compute the largest eigen value, should we cast back on GPU for the for loop?
- [x] Add a changelog entry