### PR TITLE
Make non-differentiability explicit

### DIFF
--- a/src/torchjd/aggregation/_non_differentiable.py
+++ b/src/torchjd/aggregation/_non_differentiable.py
@@ -1,0 +1,10 @@
+from torch import Tensor, nn
+
+
+class NonDifferentiableError(RuntimeError):
+    def __init__(self, module: nn.Module):
+        super().__init__(f"Trying to differentiate through {module}, which is not differentiable.")
+
+
+def raise_non_differentiable_error(module: nn.Module, _: tuple[Tensor, ...]) -> None:
+    raise NonDifferentiableError(module)

--- a/src/torchjd/aggregation/cagrad.py
+++ b/src/torchjd/aggregation/cagrad.py
@@ -8,6 +8,7 @@ import torch
 from torch import Tensor
 
 from ._gramian_utils import compute_gramian, normalize
+from ._non_differentiable import raise_non_differentiable_error
 from .bases import _WeightedAggregator, _Weighting
 
 
@@ -43,6 +44,9 @@ class CAGrad(_WeightedAggregator):
 
     def __init__(self, c: float, norm_eps: float = 0.0001):
         super().__init__(weighting=_CAGradWeighting(c=c, norm_eps=norm_eps))
+
+        # This prevents considering the computed weights as constant w.r.t. the matrix.
+        self.register_full_backward_pre_hook(raise_non_differentiable_error)
 
     def __repr__(self) -> str:
         return (

--- a/src/torchjd/aggregation/config.py
+++ b/src/torchjd/aggregation/config.py
@@ -28,6 +28,7 @@
 import torch
 from torch import Tensor
 
+from ._non_differentiable import raise_non_differentiable_error
 from ._pref_vector_utils import pref_vector_to_str_suffix, pref_vector_to_weighting
 from .bases import Aggregator
 from .sum import _SumWeighting
@@ -64,6 +65,9 @@ class ConFIG(Aggregator):
         super().__init__()
         self.weighting = pref_vector_to_weighting(pref_vector, default=_SumWeighting())
         self._pref_vector = pref_vector
+
+        # This prevents computing gradients that can be very wrong.
+        self.register_full_backward_pre_hook(raise_non_differentiable_error)
 
     def forward(self, matrix: Tensor) -> Tensor:
         weights = self.weighting(matrix)

--- a/src/torchjd/aggregation/dualproj.py
+++ b/src/torchjd/aggregation/dualproj.py
@@ -4,6 +4,7 @@ from torch import Tensor
 
 from ._dual_cone_utils import project_weights
 from ._gramian_utils import compute_gramian, normalize, regularize
+from ._non_differentiable import raise_non_differentiable_error
 from ._pref_vector_utils import pref_vector_to_str_suffix, pref_vector_to_weighting
 from .bases import _WeightedAggregator, _Weighting
 from .mean import _MeanWeighting
@@ -55,6 +56,9 @@ class DualProj(_WeightedAggregator):
                 weighting=weighting, norm_eps=norm_eps, reg_eps=reg_eps, solver=solver
             )
         )
+
+        # This prevents considering the computed weights as constant w.r.t. the matrix.
+        self.register_full_backward_pre_hook(raise_non_differentiable_error)
 
     def __repr__(self) -> str:
         return (

--- a/src/torchjd/aggregation/graddrop.py
+++ b/src/torchjd/aggregation/graddrop.py
@@ -3,6 +3,7 @@ from typing import Callable
 import torch
 from torch import Tensor
 
+from ._non_differentiable import raise_non_differentiable_error
 from .bases import Aggregator
 
 
@@ -46,6 +47,9 @@ class GradDrop(Aggregator):
         super().__init__()
         self.f = f
         self.leak = leak
+
+        # This prevents computing gradients that can be very wrong.
+        self.register_full_backward_pre_hook(raise_non_differentiable_error)
 
     def forward(self, matrix: Tensor) -> Tensor:
         self._check_is_matrix(matrix)

--- a/src/torchjd/aggregation/imtl_g.py
+++ b/src/torchjd/aggregation/imtl_g.py
@@ -2,6 +2,7 @@ import torch
 from torch import Tensor
 
 from ._gramian_utils import compute_gramian
+from ._non_differentiable import raise_non_differentiable_error
 from .bases import _WeightedAggregator, _Weighting
 
 
@@ -29,6 +30,9 @@ class IMTLG(_WeightedAggregator):
 
     def __init__(self):
         super().__init__(weighting=_IMTLGWeighting())
+
+        # This prevents computing gradients that can be very wrong.
+        self.register_full_backward_pre_hook(raise_non_differentiable_error)
 
 
 class _IMTLGWeighting(_Weighting):

--- a/src/torchjd/aggregation/nash_mtl.py
+++ b/src/torchjd/aggregation/nash_mtl.py
@@ -33,6 +33,7 @@ import torch
 from cvxpy import Expression
 from torch import Tensor
 
+from ._non_differentiable import raise_non_differentiable_error
 from .bases import _WeightedAggregator, _Weighting
 
 
@@ -94,6 +95,9 @@ class NashMTL(_WeightedAggregator):
                 optim_niter=optim_niter,
             )
         )
+
+        # This prevents considering the computed weights as constant w.r.t. the matrix.
+        self.register_full_backward_pre_hook(raise_non_differentiable_error)
 
     def reset(self) -> None:
         """Resets the internal state of the algorithm."""

--- a/src/torchjd/aggregation/pcgrad.py
+++ b/src/torchjd/aggregation/pcgrad.py
@@ -2,6 +2,7 @@ import torch
 from torch import Tensor
 
 from ._gramian_utils import compute_gramian
+from ._non_differentiable import raise_non_differentiable_error
 from .bases import _WeightedAggregator, _Weighting
 
 
@@ -27,6 +28,9 @@ class PCGrad(_WeightedAggregator):
 
     def __init__(self):
         super().__init__(weighting=_PCGradWeighting())
+
+        # This prevents running into a RuntimeError due to modifying stored tensors in place.
+        self.register_full_backward_pre_hook(raise_non_differentiable_error)
 
 
 class _PCGradWeighting(_Weighting):

--- a/src/torchjd/aggregation/upgrad.py
+++ b/src/torchjd/aggregation/upgrad.py
@@ -5,6 +5,7 @@ from torch import Tensor
 
 from ._dual_cone_utils import project_weights
 from ._gramian_utils import compute_gramian, normalize, regularize
+from ._non_differentiable import raise_non_differentiable_error
 from ._pref_vector_utils import pref_vector_to_str_suffix, pref_vector_to_weighting
 from .bases import _WeightedAggregator, _Weighting
 from .mean import _MeanWeighting
@@ -55,6 +56,9 @@ class UPGrad(_WeightedAggregator):
                 weighting=weighting, norm_eps=norm_eps, reg_eps=reg_eps, solver=solver
             )
         )
+
+        # This prevents considering the computed weights as constant w.r.t. the matrix.
+        self.register_full_backward_pre_hook(raise_non_differentiable_error)
 
     def __repr__(self) -> str:
         return (

--- a/tests/unit/aggregation/test_cagrad.py
+++ b/tests/unit/aggregation/test_cagrad.py
@@ -5,11 +5,15 @@ from unit._utils import ExceptionContext
 
 from torchjd.aggregation import CAGrad
 
-from ._property_testers import ExpectedStructureProperty, NonConflictingProperty
+from ._property_testers import (
+    ExpectedStructureProperty,
+    NonConflictingProperty,
+    NonDifferentiableProperty,
+)
 
 
 @mark.parametrize("aggregator", [CAGrad(c=0.5)])
-class TestCAGrad(ExpectedStructureProperty):
+class TestCAGrad(ExpectedStructureProperty, NonDifferentiableProperty):
     pass
 
 

--- a/tests/unit/aggregation/test_config.py
+++ b/tests/unit/aggregation/test_config.py
@@ -3,13 +3,17 @@ from pytest import mark
 
 from torchjd.aggregation import ConFIG
 
-from ._property_testers import ExpectedStructureProperty, LinearUnderScalingProperty
+from ._property_testers import (
+    ExpectedStructureProperty,
+    LinearUnderScalingProperty,
+    NonDifferentiableProperty,
+)
 
 
 # For some reason, some permutation-invariance property tests fail with the pinv-based
 # implementation.
 @mark.parametrize("aggregator", [ConFIG()])
-class TestConfig(ExpectedStructureProperty, LinearUnderScalingProperty):
+class TestConfig(ExpectedStructureProperty, LinearUnderScalingProperty, NonDifferentiableProperty):
     pass
 
 

--- a/tests/unit/aggregation/test_dualproj.py
+++ b/tests/unit/aggregation/test_dualproj.py
@@ -6,6 +6,7 @@ from torchjd.aggregation import DualProj
 from ._property_testers import (
     ExpectedStructureProperty,
     NonConflictingProperty,
+    NonDifferentiableProperty,
     PermutationInvarianceProperty,
     StrongStationarityProperty,
 )
@@ -17,6 +18,7 @@ class TestDualProj(
     NonConflictingProperty,
     PermutationInvarianceProperty,
     StrongStationarityProperty,
+    NonDifferentiableProperty,
 ):
     pass
 

--- a/tests/unit/aggregation/test_graddrop.py
+++ b/tests/unit/aggregation/test_graddrop.py
@@ -6,11 +6,11 @@ from unit._utils import ExceptionContext
 
 from torchjd.aggregation import GradDrop
 
-from ._property_testers import ExpectedStructureProperty
+from ._property_testers import ExpectedStructureProperty, NonDifferentiableProperty
 
 
 @mark.parametrize("aggregator", [GradDrop()])
-class TestGradDrop(ExpectedStructureProperty):
+class TestGradDrop(ExpectedStructureProperty, NonDifferentiableProperty):
     pass
 
 

--- a/tests/unit/aggregation/test_imtl_g.py
+++ b/tests/unit/aggregation/test_imtl_g.py
@@ -4,12 +4,12 @@ from torch.testing import assert_close
 
 from torchjd.aggregation import IMTLG
 
-from ._property_testers import ExpectedStructureProperty
+from ._property_testers import ExpectedStructureProperty, NonDifferentiableProperty
 
 
 # For some reason, a permutation-invariance property test fails on GPU
 @mark.parametrize("aggregator", [IMTLG()])
-class TestIMTLG(ExpectedStructureProperty):
+class TestIMTLG(ExpectedStructureProperty, NonDifferentiableProperty):
     pass
 
 

--- a/tests/unit/aggregation/test_nash_mtl.py
+++ b/tests/unit/aggregation/test_nash_mtl.py
@@ -6,7 +6,7 @@ from torch.testing import assert_close
 from torchjd.aggregation import NashMTL
 
 from ._inputs import nash_mtl_matrices
-from ._property_testers import ExpectedStructureProperty
+from ._property_testers import ExpectedStructureProperty, NonDifferentiableProperty
 
 
 def _make_aggregator(matrix: Tensor) -> NashMTL:
@@ -20,7 +20,7 @@ _aggregators = [_make_aggregator(matrix) for matrix in nash_mtl_matrices]
     "ignore:Solution may be inaccurate.",
     "ignore:You are solving a parameterized problem that is not DPP.",
 )
-class TestNashMTL(ExpectedStructureProperty):
+class TestNashMTL(ExpectedStructureProperty, NonDifferentiableProperty):
     # Override the parametrization of `test_expected_structure_property` to make the test use the
     # right aggregator with each matrix.
 
@@ -29,6 +29,13 @@ class TestNashMTL(ExpectedStructureProperty):
     @classmethod
     @mark.parametrize(["aggregator", "matrix"], zip(_aggregators, nash_mtl_matrices))
     def test_expected_structure_property(cls, aggregator: NashMTL, matrix: Tensor):
+        cls._assert_expected_structure_property(aggregator, matrix)
+
+    @classmethod
+    @mark.parametrize(
+        ["aggregator", "matrix"], [(NashMTL(n_tasks=3), torch.ones(3, 5, requires_grad=True))]
+    )
+    def test_non_differentiable_property(cls, aggregator: NashMTL, matrix: Tensor):
         cls._assert_expected_structure_property(aggregator, matrix)
 
 

--- a/tests/unit/aggregation/test_pcgrad.py
+++ b/tests/unit/aggregation/test_pcgrad.py
@@ -7,11 +7,11 @@ from torchjd.aggregation.pcgrad import _PCGradWeighting
 from torchjd.aggregation.sum import _SumWeighting
 from torchjd.aggregation.upgrad import _UPGradWrapper
 
-from ._property_testers import ExpectedStructureProperty
+from ._property_testers import ExpectedStructureProperty, NonDifferentiableProperty
 
 
 @mark.parametrize("aggregator", [PCGrad()])
-class TestPCGrad(ExpectedStructureProperty):
+class TestPCGrad(ExpectedStructureProperty, NonDifferentiableProperty):
     pass
 
 

--- a/tests/unit/aggregation/test_upgrad.py
+++ b/tests/unit/aggregation/test_upgrad.py
@@ -7,6 +7,7 @@ from ._property_testers import (
     ExpectedStructureProperty,
     LinearUnderScalingProperty,
     NonConflictingProperty,
+    NonDifferentiableProperty,
     PermutationInvarianceProperty,
     StrongStationarityProperty,
 )
@@ -19,6 +20,7 @@ class TestUPGrad(
     PermutationInvarianceProperty,
     LinearUnderScalingProperty,
     StrongStationarityProperty,
+    NonDifferentiableProperty,
 ):
     pass
 


### PR DESCRIPTION
- **Add _non_differentiable.py with NonDifferentiableError and raise_non_differentiable_error**
- **Register raise_non_differentiable_error as a full_backward_pre_hook of CAGrad, ConFIG, DualProj, GradDrop, IMTLG, NashMTL, PCGrad and UPGrad**
- **Add NonDifferentiableProperty**
- **Give NonDifferentiableProperty to CAGrad, ConFIG, DualProj, GradDrop, IMTLG, NashMTL, PCGrad and UPGrad**
