### PR TITLE
fix(aggregation): Delete _OptionalDepsNotInstalledError from scope

### DIFF
--- a/src/torchjd/aggregation/__init__.py
+++ b/src/torchjd/aggregation/__init__.py
@@ -26,3 +26,5 @@ try:
     from ._nash_mtl import NashMTL
 except _OptionalDepsNotInstalledError:  # The required dependencies are not installed
     pass
+
+del _OptionalDepsNotInstalledError


### PR DESCRIPTION
If we now do `from torchjd.aggregation import *`, we do not import `_OptionalDepsNotInstalledError`