### PR TITLE
chore: Change imports of collections from typing to collections.abc

### DIFF
--- a/src/torchjd/_autojac/_backward.py
+++ b/src/torchjd/_autojac/_backward.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Sequence
+from collections.abc import Iterable, Sequence
 
 from torch import Tensor
 

--- a/src/torchjd/_autojac/_mtl_backward.py
+++ b/src/torchjd/_autojac/_mtl_backward.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Sequence
+from collections.abc import Iterable, Sequence
 
 from torch import Tensor
 

--- a/src/torchjd/_autojac/_transform/_aggregate.py
+++ b/src/torchjd/_autojac/_transform/_aggregate.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
-from typing import Hashable, TypeVar
+from collections.abc import Hashable
+from typing import TypeVar
 
 import torch
 from torch import Tensor

--- a/src/torchjd/_autojac/_transform/_base.py
+++ b/src/torchjd/_autojac/_transform/_base.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Generic, Sequence
+from collections.abc import Sequence
+from typing import Generic
 
 from torch import Tensor
 

--- a/src/torchjd/_autojac/_transform/_differentiate.py
+++ b/src/torchjd/_autojac/_transform/_differentiate.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Sequence
+from collections.abc import Sequence
 
 from torch import Tensor
 

--- a/src/torchjd/_autojac/_transform/_grad.py
+++ b/src/torchjd/_autojac/_transform/_grad.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 import torch
 from torch import Tensor

--- a/src/torchjd/_autojac/_transform/_jac.py
+++ b/src/torchjd/_autojac/_transform/_jac.py
@@ -1,7 +1,8 @@
 import math
+from collections.abc import Sequence
 from functools import partial
 from itertools import accumulate
-from typing import Callable, Sequence
+from typing import Callable
 
 import torch
 from torch import Size, Tensor

--- a/src/torchjd/_autojac/_transform/_materialize.py
+++ b/src/torchjd/_autojac/_transform/_materialize.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 import torch
 from torch import Tensor

--- a/src/torchjd/_autojac/_transform/_ordered_set.py
+++ b/src/torchjd/_autojac/_transform/_ordered_set.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
-from collections.abc import Set
-from typing import Hashable, Iterable, TypeVar
+from collections.abc import Hashable, Iterable, Set
+from typing import TypeVar
 
 _KeyType = TypeVar("_KeyType", bound=Hashable)
 

--- a/src/torchjd/_autojac/_transform/_stack.py
+++ b/src/torchjd/_autojac/_transform/_stack.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 import torch
 from torch import Tensor

--- a/src/torchjd/_autojac/_utils.py
+++ b/src/torchjd/_autojac/_utils.py
@@ -1,5 +1,5 @@
 from collections import deque
-from typing import Iterable, Sequence
+from collections.abc import Iterable, Sequence
 
 from torch import Tensor
 from torch.autograd.graph import Node

--- a/tests/unit/aggregation/test_aggregator_bases.py
+++ b/tests/unit/aggregation/test_aggregator_bases.py
@@ -1,5 +1,5 @@
+from collections.abc import Sequence
 from contextlib import nullcontext as does_not_raise
-from typing import Sequence
 
 import torch
 from pytest import mark, raises


### PR DESCRIPTION
Importing Collections from `typing` is deprecated since Python 3.9.