### PR TITLE
Fix raise_non_differentiable_error type

### DIFF
--- a/src/torchjd/aggregation/_utils/non_differentiable.py
+++ b/src/torchjd/aggregation/_utils/non_differentiable.py
@@ -6,5 +6,5 @@ class NonDifferentiableError(RuntimeError):
         super().__init__(f"Trying to differentiate through {module}, which is not differentiable.")
 
 
-def raise_non_differentiable_error(module: nn.Module, _: tuple[Tensor, ...]) -> None:
+def raise_non_differentiable_error(module: nn.Module, _: tuple[Tensor, ...] | Tensor) -> None:
     raise NonDifferentiableError(module)


### PR DESCRIPTION
By contravariance, the type of the _ parameter must be a supertype of the type of the expected parameter for a backward hook, which is `tuple[Tensor, ...] | Tensor`. Indeed, this hook is supposed to work even if a single Tensor is passed to it.

This was highlighted by MyPy.