### PR TITLE
Add `mypy`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,3 +72,21 @@ jobs:
       - name: Build Documentation
         working-directory: docs
         run: uv run make dirhtml
+
+  mypy:
+    name: Run mypy
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        python-version: '3.13'
+
+    - name: Install dependencies (default with full options & check)
+      run: uv pip install '.[full]' --group check
+
+    - name: Run mypy
+      run: uv run mypy src/torchjd --follow-untyped-imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ Changelog = "https://github.com/TorchJD/torchjd/blob/main/CHANGELOG.md"
 
 [dependency-groups]
 check = [
-    "pre-commit>=2.9.2"  # isort doesn't work before 2.9.2
+    "mypy>=1.16.0",
+    "pre-commit>=2.9.2",  # isort doesn't work before 2.9.2
 ]
 
 doc = [

--- a/src/torchjd/_autojac/_backward.py
+++ b/src/torchjd/_autojac/_backward.py
@@ -77,20 +77,20 @@ def backward(
     """
     check_optional_positive_chunk_size(parallel_chunk_size)
 
-    tensors = as_checked_ordered_set(tensors, "tensors")
+    tensors_ = as_checked_ordered_set(tensors, "tensors")
 
-    if len(tensors) == 0:
+    if len(tensors_) == 0:
         raise ValueError("`tensors` cannot be empty")
 
     if inputs is None:
-        inputs = get_leaf_tensors(tensors=tensors, excluded=set())
+        inputs_ = get_leaf_tensors(tensors=tensors_, excluded=set())
     else:
-        inputs = OrderedSet(inputs)
+        inputs_ = OrderedSet(inputs)
 
     backward_transform = _create_transform(
-        tensors=tensors,
+        tensors=tensors_,
         aggregator=aggregator,
-        inputs=inputs,
+        inputs=inputs_,
         retain_graph=retain_graph,
         parallel_chunk_size=parallel_chunk_size,
     )

--- a/src/torchjd/_autojac/_mtl_backward.py
+++ b/src/torchjd/_autojac/_mtl_backward.py
@@ -190,7 +190,7 @@ def _create_task_transform(
     return backward_task
 
 
-def _check_losses_are_scalar(losses: Sequence[Tensor]) -> None:
+def _check_losses_are_scalar(losses: Iterable[Tensor]) -> None:
     for loss in losses:
         if loss.ndim > 0:
             raise ValueError("`losses` should contain only scalars.")

--- a/src/torchjd/_autojac/_mtl_backward.py
+++ b/src/torchjd/_autojac/_mtl_backward.py
@@ -179,10 +179,10 @@ def _create_task_transform(
 
     # Transform that accumulates the gradients w.r.t. the task-specific parameters into their
     # .grad fields.
-    accumulate = Accumulate() << Select(task_params)
+    accumulate = Accumulate() << Select[Gradients](task_params)
 
     # Transform that backpropagates the gradients of the losses w.r.t. the features.
-    backpropagate = Select(features)
+    backpropagate = Select[Gradients](features)
 
     # Transform that accumulates the gradient of the losses w.r.t. the task-specific parameters into
     # their .grad fields and backpropagates the gradient of the losses w.r.t. to the features.

--- a/src/torchjd/_autojac/_mtl_backward.py
+++ b/src/torchjd/_autojac/_mtl_backward.py
@@ -81,35 +81,35 @@ def mtl_backward(
 
     check_optional_positive_chunk_size(parallel_chunk_size)
 
-    losses = as_checked_ordered_set(losses, "losses")
-    features = as_checked_ordered_set(features, "features")
+    losses_ = as_checked_ordered_set(losses, "losses")
+    features_ = as_checked_ordered_set(features, "features")
 
     if shared_params is None:
-        shared_params = get_leaf_tensors(tensors=features, excluded=[])
+        shared_params_ = get_leaf_tensors(tensors=features_, excluded=[])
     else:
-        shared_params = OrderedSet(shared_params)
+        shared_params_ = OrderedSet(shared_params)
     if tasks_params is None:
-        tasks_params = [get_leaf_tensors(tensors=[loss], excluded=features) for loss in losses]
+        tasks_params_ = [get_leaf_tensors(tensors=[loss], excluded=features_) for loss in losses_]
     else:
-        tasks_params = [OrderedSet(task_params) for task_params in tasks_params]
+        tasks_params_ = [OrderedSet(task_params) for task_params in tasks_params]
 
-    if len(features) == 0:
+    if len(features_) == 0:
         raise ValueError("`features` cannot be empty.")
 
-    _check_no_overlap(shared_params, tasks_params)
-    _check_losses_are_scalar(losses)
+    _check_no_overlap(shared_params_, tasks_params_)
+    _check_losses_are_scalar(losses_)
 
-    if len(losses) == 0:
+    if len(losses_) == 0:
         raise ValueError("`losses` cannot be empty")
-    if len(losses) != len(tasks_params):
+    if len(losses_) != len(tasks_params_):
         raise ValueError("`losses` and `tasks_params` should have the same size.")
 
     backward_transform = _create_transform(
-        losses=losses,
-        features=features,
+        losses=losses_,
+        features=features_,
         aggregator=aggregator,
-        tasks_params=tasks_params,
-        shared_params=shared_params,
+        tasks_params=tasks_params_,
+        shared_params=shared_params_,
         retain_graph=retain_graph,
         parallel_chunk_size=parallel_chunk_size,
     )

--- a/src/torchjd/_autojac/_transform/_base.py
+++ b/src/torchjd/_autojac/_transform/_base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Generic
+from typing import Generic, cast
 
 from torch import Tensor
 
@@ -99,12 +99,14 @@ class Conjunction(Transform[_B, _C]):
 
     def __call__(self, tensor_dict: _B) -> _C:
         tensor_dicts = [transform(tensor_dict) for transform in self.transforms]
-        output_type: type[_B] = EmptyTensorDict
-        output: _B = EmptyTensorDict()
-        for tensor_dict in tensor_dicts:
-            output_type = _least_common_ancestor(output_type, type(tensor_dict))
-            output |= tensor_dict
-        return output_type(output)
+        union: dict[Tensor, Tensor] = {}
+        for d in tensor_dicts:
+            union |= d
+
+        output_type = cast(type[_C], EmptyTensorDict)
+        for td in tensor_dicts:
+            output_type = cast(type[_C], _least_common_ancestor(output_type, type(td)))
+        return output_type(union)
 
     def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
         output_keys_list = [key for t in self.transforms for key in t.check_keys(input_keys)]

--- a/src/torchjd/_autojac/_transform/_base.py
+++ b/src/torchjd/_autojac/_transform/_base.py
@@ -51,7 +51,7 @@ class Transform(Generic[_B, _C], ABC):
     __or__ = conjunct
 
 
-class Composition(Transform[_A, _C]):
+class Composition(Transform[_B, _C]):
     """
     Transform corresponding to the composition of two transforms inner and outer.
 
@@ -59,14 +59,14 @@ class Composition(Transform[_A, _C]):
     :param outer: The transform to apply second, to the result of ``inner``.
     """
 
-    def __init__(self, outer: Transform[_B, _C], inner: Transform[_A, _B]):
+    def __init__(self, outer: Transform[_A, _C], inner: Transform[_B, _A]):
         self.outer = outer
         self.inner = inner
 
     def __str__(self) -> str:
         return str(self.outer) + " ∘ " + str(self.inner)
 
-    def __call__(self, input: _A) -> _C:
+    def __call__(self, input: _B) -> _C:
         intermediate = self.inner(input)
         return self.outer(intermediate)
 
@@ -76,7 +76,7 @@ class Composition(Transform[_A, _C]):
         return output_keys
 
 
-class Conjunction(Transform[_A, _B]):
+class Conjunction(Transform[_B, _C]):
     """
     Transform applying several transforms to the same input, and combining the results (by union)
     into a single TensorDict.
@@ -84,7 +84,7 @@ class Conjunction(Transform[_A, _B]):
     :param transforms: The transforms to apply. Their outputs should have disjoint sets of keys.
     """
 
-    def __init__(self, transforms: Sequence[Transform[_A, _B]]):
+    def __init__(self, transforms: Sequence[Transform[_B, _C]]):
         self.transforms = transforms
 
     def __str__(self) -> str:
@@ -97,10 +97,10 @@ class Conjunction(Transform[_A, _B]):
                 strings.append(s)
         return "(" + " | ".join(strings) + ")"
 
-    def __call__(self, tensor_dict: _A) -> _B:
+    def __call__(self, tensor_dict: _B) -> _C:
         tensor_dicts = [transform(tensor_dict) for transform in self.transforms]
-        output_type: type[_A] = EmptyTensorDict
-        output: _A = EmptyTensorDict()
+        output_type: type[_B] = EmptyTensorDict
+        output: _B = EmptyTensorDict()
         for tensor_dict in tensor_dicts:
             output_type = _least_common_ancestor(output_type, type(tensor_dict))
             output |= tensor_dict

--- a/src/torchjd/_autojac/_transform/_ordered_set.py
+++ b/src/torchjd/_autojac/_transform/_ordered_set.py
@@ -2,31 +2,41 @@ from collections import OrderedDict
 from collections.abc import Hashable, Iterable, MutableSet
 from typing import TypeVar
 
-_KeyType = TypeVar("_KeyType", bound=Hashable)
+_T = TypeVar("_T", bound=Hashable)
 
 
-class OrderedSet(OrderedDict[_KeyType, None], MutableSet[_KeyType]):
+class OrderedSet(MutableSet[_T]):
     """Ordered collection of distinct elements."""
 
-    def __init__(self, elements: Iterable[_KeyType]):
-        super().__init__([(element, None) for element in elements])
+    def __init__(self, elements: Iterable[_T]):
+        super().__init__()
+        self.ordered_dict = OrderedDict[_T, None]([(element, None) for element in elements])
 
-    def difference_update(self, elements: set[_KeyType]) -> None:
+    def difference_update(self, elements: set[_T]) -> None:
         """Removes all specified elements from the OrderedSet."""
 
         for element in elements:
             self.discard(element)
 
-    def add(self, element: _KeyType) -> None:
+    def add(self, element: _T) -> None:
         """Adds the specified element to the OrderedSet."""
 
-        self[element] = None
+        self.ordered_dict[element] = None
 
-    def __add__(self, other: "OrderedSet[_KeyType]") -> "OrderedSet[_KeyType]":
+    def __add__(self, other: "OrderedSet[_T]") -> "OrderedSet[_T]":
         """Creates a new OrderedSet with the elements of self followed by the elements of other."""
 
         return OrderedSet([*self, *other])
 
-    def discard(self, value: _KeyType) -> None:
+    def discard(self, value: _T) -> None:
         if value in self:
-            del self[value]
+            del self.ordered_dict[value]
+
+    def __iter__(self):
+        return self.ordered_dict.__iter__()
+
+    def __len__(self):
+        return len(self.ordered_dict)
+
+    def __contains__(self, element: object):
+        return element in self.ordered_dict

--- a/src/torchjd/_autojac/_transform/_stack.py
+++ b/src/torchjd/_autojac/_transform/_stack.py
@@ -5,10 +5,10 @@ from torch import Tensor
 
 from ._base import Transform
 from ._materialize import materialize
-from ._tensor_dict import _A, Gradients, Jacobians
+from ._tensor_dict import _B, Gradients, Jacobians
 
 
-class Stack(Transform[_A, Jacobians]):
+class Stack(Transform[_B, Jacobians]):
     """
     Transform applying several transforms to the same input, and combining the results (by stacking)
     into a single TensorDict.
@@ -20,10 +20,10 @@ class Stack(Transform[_A, Jacobians]):
         at the positions corresponding to those dicts.
     """
 
-    def __init__(self, transforms: Sequence[Transform[_A, Gradients]]):
+    def __init__(self, transforms: Sequence[Transform[_B, Gradients]]):
         self.transforms = transforms
 
-    def __call__(self, input: _A) -> Jacobians:
+    def __call__(self, input: _B) -> Jacobians:
         results = [transform(input) for transform in self.transforms]
         result = _stack(results)
         return result

--- a/src/torchjd/_autojac/_transform/_stack.py
+++ b/src/torchjd/_autojac/_transform/_stack.py
@@ -36,7 +36,7 @@ def _stack(gradient_dicts: list[Gradients]) -> Jacobians:
     # It is important to first remove duplicate keys before computing their associated
     # stacked tensor. Otherwise, some computations would be duplicated. Therefore, we first compute
     # unique_keys, and only then, we compute the stacked tensors.
-    union = {}
+    union: dict[Tensor, Tensor] = {}
     for d in gradient_dicts:
         union |= d
     unique_keys = union.keys()

--- a/src/torchjd/_autojac/_transform/_tensor_dict.py
+++ b/src/torchjd/_autojac/_transform/_tensor_dict.py
@@ -1,4 +1,4 @@
-from typing import TypeVar
+from typing import TypeVar, cast
 
 from torch import Tensor
 
@@ -131,7 +131,7 @@ def _least_common_ancestor(first: type[TensorDict], second: type[TensorDict]) ->
     output = TensorDict
     for candidate_type in first_mro:
         if issubclass(second, candidate_type):
-            output = candidate_type
+            output = cast(type[TensorDict], candidate_type)
             break
     return output
 

--- a/src/torchjd/_autojac/_transform/_tensor_dict.py
+++ b/src/torchjd/_autojac/_transform/_tensor_dict.py
@@ -32,16 +32,18 @@ class TensorDict(dict[Tensor, Tensor]):
     # Make TensorDict immutable, following answer in
     # https://stackoverflow.com/questions/11014262/how-to-create-an-immutable-dictionary-in-python
     # coming from https://peps.python.org/pep-0351/
+    # Note that this is not a perfect solution, because it breaks Liskov Substitution Principle, but
+    # it works.
     def _raise_immutable_error(self, *args, **kwargs) -> None:
         raise TypeError(f"{self.__class__.__name__} is immutable.")
 
     __setitem__ = _raise_immutable_error
     __delitem__ = _raise_immutable_error
     clear = _raise_immutable_error
-    update = _raise_immutable_error
-    setdefault = _raise_immutable_error
-    pop = _raise_immutable_error
-    popitem = _raise_immutable_error
+    update = _raise_immutable_error  # type: ignore[assignment]
+    setdefault = _raise_immutable_error  # type: ignore[assignment]
+    pop = _raise_immutable_error  # type: ignore[assignment]
+    popitem = _raise_immutable_error  # type: ignore[assignment]
 
 
 class Gradients(TensorDict):

--- a/src/torchjd/_autojac/_transform/_tensor_dict.py
+++ b/src/torchjd/_autojac/_transform/_tensor_dict.py
@@ -182,5 +182,5 @@ def _check_corresponding_numel(key: Tensor, value: Tensor, dim: int) -> None:
 
 
 _A = TypeVar("_A", bound=TensorDict)
-_B = TypeVar("_B", bound=TensorDict)
-_C = TypeVar("_C", bound=TensorDict)
+_B = TypeVar("_B", bound=TensorDict, contravariant=True)
+_C = TypeVar("_C", bound=TensorDict, covariant=True)

--- a/src/torchjd/_autojac/_utils.py
+++ b/src/torchjd/_autojac/_utils.py
@@ -67,7 +67,7 @@ def _get_descendant_accumulate_grads(
     """
 
     excluded_nodes = set(excluded_nodes)  # Re-instantiate set to avoid modifying input
-    result = OrderedSet([])
+    result: OrderedSet[Node] = OrderedSet([])
     roots.difference_update(excluded_nodes)
     nodes_to_traverse = deque(roots)
 

--- a/src/torchjd/_autojac/_utils.py
+++ b/src/torchjd/_autojac/_utils.py
@@ -1,5 +1,6 @@
 from collections import deque
 from collections.abc import Iterable, Sequence
+from typing import cast
 
 from torch import Tensor
 from torch.autograd.graph import Node
@@ -48,8 +49,8 @@ def get_leaf_tensors(tensors: Iterable[Tensor], excluded: Iterable[Tensor]) -> O
         raise ValueError("All `excluded` tensors should have a `grad_fn`.")
 
     accumulate_grads = _get_descendant_accumulate_grads(
-        roots=OrderedSet([tensor.grad_fn for tensor in tensors]),
-        excluded_nodes={tensor.grad_fn for tensor in excluded},
+        roots=cast(OrderedSet[Node], OrderedSet([tensor.grad_fn for tensor in tensors])),
+        excluded_nodes=cast(set[Node], {tensor.grad_fn for tensor in excluded}),
     )
     leaves = OrderedSet([g.variable for g in accumulate_grads])
 

--- a/src/torchjd/_autojac/_utils.py
+++ b/src/torchjd/_autojac/_utils.py
@@ -52,7 +52,10 @@ def get_leaf_tensors(tensors: Iterable[Tensor], excluded: Iterable[Tensor]) -> O
         roots=cast(OrderedSet[Node], OrderedSet([tensor.grad_fn for tensor in tensors])),
         excluded_nodes=cast(set[Node], {tensor.grad_fn for tensor in excluded}),
     )
-    leaves = OrderedSet([g.variable for g in accumulate_grads])
+
+    # accumulate_grads contains instances of AccumulateGrad, which contain a `variable` field.
+    # They cannot be typed as such because AccumulateGrad is not public.
+    leaves = OrderedSet([g.variable for g in accumulate_grads])  # type: ignore[attr-defined]
 
     return leaves
 

--- a/src/torchjd/aggregation/_cagrad.py
+++ b/src/torchjd/aggregation/_cagrad.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from ._utils.check_dependencies import check_dependencies_are_installed
 from ._weighting_bases import PSDMatrix, Weighting
 
@@ -101,7 +103,7 @@ class _CAGradWeighting(Weighting[PSDMatrix]):
         problem = cp.Problem(objective=cp.Minimize(cost), constraints=[w >= 0, cp.sum(w) == 1])
 
         problem.solve(cp.CLARABEL)
-        w_opt = w.value
+        w_opt = cast(np.ndarray, w.value)
 
         g_w_norm = np.linalg.norm(reduced_array.T @ w_opt, 2).item()
         if g_w_norm >= self.norm_eps:

--- a/src/torchjd/aggregation/_mgda.py
+++ b/src/torchjd/aggregation/_mgda.py
@@ -77,7 +77,7 @@ class _MGDAWeighting(Weighting[PSDMatrix]):
             elif b <= a:
                 gamma = 0.0
             else:
-                gamma = (b - a) / (b + c - 2 * a)
+                gamma = (b - a) / (b + c - 2 * a)  # type: ignore[assignment]
             alpha = (1 - gamma) * alpha + gamma * e_t
             if gamma < self.epsilon:
                 break

--- a/src/torchjd/aggregation/_nash_mtl.py
+++ b/src/torchjd/aggregation/_nash_mtl.py
@@ -23,6 +23,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# mypy: ignore-errors
+
 from ._utils.check_dependencies import check_dependencies_are_installed
 from ._weighting_bases import Matrix, Weighting
 


### PR DESCRIPTION
This PR is just to give an overview of the changes related to the addition of mypy. I will probably break this into smaller PRs when it's completed. To install mypy and run it locally, do:
```
uv pip install mypy
uv run mypy src/torchjd --follow-untyped-imports
```

#365: Add mypy action

#366: Fix type of _check_losses_are_scalar

#367:
* Add type hint to union in _stack
* Add type hint to result in _get_descendant_accumulate_grads
* Be more specific about the type of Select when instantiating it

#368: Use new variables in backward and mtl_backward when changing type

#369:
* Make _B contravariant and _C covariant
* Fix generic parametrization in Composition and Conjunction

#372:
* Add cast in get_leaf_tensors
* Add cast of w_opt to np.ndarray in _CAGradWeighting.forward
* Add cast to type[TensorDict] in _least_common_ancestor

#370:
* Add comment to ignore mypy errors in _nash_mtl.py
* Add comment to ignore type error in mgda
* Add type: ignore[assignment] when needed in TensorDict immutability tricks, and add a comment

#371: Ignore type error in get_leaf_tensors and add comment

#374: Update Conjunction.__call__ to make its typing correct

#375: Change OrderedSet to compose with OrderedDict instead of inheriting from it