### PR TITLE
Fix type of _check_losses_are_scalar

### DIFF
--- a/src/torchjd/_autojac/_mtl_backward.py
+++ b/src/torchjd/_autojac/_mtl_backward.py
@@ -190,7 +190,7 @@ def _create_task_transform(
     return backward_task
 
 
-def _check_losses_are_scalar(losses: Sequence[Tensor]) -> None:
+def _check_losses_are_scalar(losses: Iterable[Tensor]) -> None:
     for loss in losses:
         if loss.ndim > 0:
             raise ValueError("`losses` should contain only scalars.")


### PR DESCRIPTION
It seems that the type of the `losses` parameter of ` _check_losses_are_scalar` was wrong. The reason is that the `losses` parameter that we're supposed to provide it with is an `OrderedSet[Tensor]`, which is not a `Sequence`. Also, we only iterate over these losses, so I think the desired type is `Iterable[Tensor]`. This is also consistent with the parameter types of `_check_no_overlap`.

This fixes the issue reported by mypy.
