### PR TITLE
Add missing type hints

### DIFF
--- a/src/torchjd/_autojac/_mtl_backward.py
+++ b/src/torchjd/_autojac/_mtl_backward.py
@@ -179,10 +179,10 @@ def _create_task_transform(
 
     # Transform that accumulates the gradients w.r.t. the task-specific parameters into their
     # .grad fields.
-    accumulate = Accumulate() << Select(task_params)
+    accumulate = Accumulate() << Select[Gradients](task_params)
 
     # Transform that backpropagates the gradients of the losses w.r.t. the features.
-    backpropagate = Select(features)
+    backpropagate = Select[Gradients](features)
 
     # Transform that accumulates the gradient of the losses w.r.t. the task-specific parameters into
     # their .grad fields and backpropagates the gradient of the losses w.r.t. to the features.

--- a/src/torchjd/_autojac/_transform/_stack.py
+++ b/src/torchjd/_autojac/_transform/_stack.py
@@ -36,7 +36,7 @@ def _stack(gradient_dicts: list[Gradients]) -> Jacobians:
     # It is important to first remove duplicate keys before computing their associated
     # stacked tensor. Otherwise, some computations would be duplicated. Therefore, we first compute
     # unique_keys, and only then, we compute the stacked tensors.
-    union = {}
+    union: dict[Tensor, Tensor] = {}
     for d in gradient_dicts:
         union |= d
     unique_keys = union.keys()

--- a/src/torchjd/_autojac/_utils.py
+++ b/src/torchjd/_autojac/_utils.py
@@ -67,7 +67,7 @@ def _get_descendant_accumulate_grads(
     """
 
     excluded_nodes = set(excluded_nodes)  # Re-instantiate set to avoid modifying input
-    result = OrderedSet([])
+    result: OrderedSet[Node] = OrderedSet([])
     roots.difference_update(excluded_nodes)
     nodes_to_traverse = deque(roots)
 


### PR DESCRIPTION
This PR adds type hint when it's not possible for mypy to infer them: when an empty structure is created before being filled (note that mypy is able to infer the type in this case but only when the structure is filled with simple .append calls - here we use dict union or our add function), and when a Select transform is created.

The thing is that when creating a Select transform, there is no way for mypy to know whether it's a selection of Gradients, of Jacobians, or of something else. Also, we can directly specify the type of the Select transform right after the class name when instantiating it, which is what I used there.

* Add type hint to union in _stack
* Add type hint to result in _get_descendant_accumulate_grads
* Be more specific about the type of Select when instantiating it

Note that this is required to avoid some mypy errors.
