### PR TITLE
Fix genericity of Transforms

### DIFF
--- a/src/torchjd/_autojac/_transform/_base.py
+++ b/src/torchjd/_autojac/_transform/_base.py
@@ -51,7 +51,7 @@ class Transform(Generic[_B, _C], ABC):
     __or__ = conjunct
 
 
-class Composition(Transform[_A, _C]):
+class Composition(Transform[_B, _C]):
     """
     Transform corresponding to the composition of two transforms inner and outer.
 
@@ -59,14 +59,14 @@ class Composition(Transform[_A, _C]):
     :param outer: The transform to apply second, to the result of ``inner``.
     """
 
-    def __init__(self, outer: Transform[_B, _C], inner: Transform[_A, _B]):
+    def __init__(self, outer: Transform[_A, _C], inner: Transform[_B, _A]):
         self.outer = outer
         self.inner = inner
 
     def __str__(self) -> str:
         return str(self.outer) + " ∘ " + str(self.inner)
 
-    def __call__(self, input: _A) -> _C:
+    def __call__(self, input: _B) -> _C:
         intermediate = self.inner(input)
         return self.outer(intermediate)
 
@@ -76,7 +76,7 @@ class Composition(Transform[_A, _C]):
         return output_keys
 
 
-class Conjunction(Transform[_A, _B]):
+class Conjunction(Transform[_B, _C]):
     """
     Transform applying several transforms to the same input, and combining the results (by union)
     into a single TensorDict.
@@ -84,7 +84,7 @@ class Conjunction(Transform[_A, _B]):
     :param transforms: The transforms to apply. Their outputs should have disjoint sets of keys.
     """
 
-    def __init__(self, transforms: Sequence[Transform[_A, _B]]):
+    def __init__(self, transforms: Sequence[Transform[_B, _C]]):
         self.transforms = transforms
 
     def __str__(self) -> str:
@@ -97,10 +97,10 @@ class Conjunction(Transform[_A, _B]):
                 strings.append(s)
         return "(" + " | ".join(strings) + ")"
 
-    def __call__(self, tensor_dict: _A) -> _B:
+    def __call__(self, tensor_dict: _B) -> _C:
         tensor_dicts = [transform(tensor_dict) for transform in self.transforms]
-        output_type: type[_A] = EmptyTensorDict
-        output: _A = EmptyTensorDict()
+        output_type: type[_B] = EmptyTensorDict
+        output: _B = EmptyTensorDict()
         for tensor_dict in tensor_dicts:
             output_type = _least_common_ancestor(output_type, type(tensor_dict))
             output |= tensor_dict

--- a/src/torchjd/_autojac/_transform/_stack.py
+++ b/src/torchjd/_autojac/_transform/_stack.py
@@ -5,10 +5,10 @@ from torch import Tensor
 
 from ._base import Transform
 from ._materialize import materialize
-from ._tensor_dict import _A, Gradients, Jacobians
+from ._tensor_dict import _B, Gradients, Jacobians
 
 
-class Stack(Transform[_A, Jacobians]):
+class Stack(Transform[_B, Jacobians]):
     """
     Transform applying several transforms to the same input, and combining the results (by stacking)
     into a single TensorDict.
@@ -20,10 +20,10 @@ class Stack(Transform[_A, Jacobians]):
         at the positions corresponding to those dicts.
     """
 
-    def __init__(self, transforms: Sequence[Transform[_A, Gradients]]):
+    def __init__(self, transforms: Sequence[Transform[_B, Gradients]]):
         self.transforms = transforms
 
-    def __call__(self, input: _A) -> Jacobians:
+    def __call__(self, input: _B) -> Jacobians:
         results = [transform(input) for transform in self.transforms]
         result = _stack(results)
         return result

--- a/src/torchjd/_autojac/_transform/_tensor_dict.py
+++ b/src/torchjd/_autojac/_transform/_tensor_dict.py
@@ -182,5 +182,5 @@ def _check_corresponding_numel(key: Tensor, value: Tensor, dim: int) -> None:
 
 
 _A = TypeVar("_A", bound=TensorDict)
-_B = TypeVar("_B", bound=TensorDict)
-_C = TypeVar("_C", bound=TensorDict)
+_B = TypeVar("_B", bound=TensorDict, contravariant=True)
+_C = TypeVar("_C", bound=TensorDict, covariant=True)


### PR DESCRIPTION
A Transform (like any callable with immutable params) is supposed to be contravariant in its input type and covariant in its output type. This PR makes `_B` contravariant and `_C` covariant. Note that these `covariant` and `contravariant` fields are only used when parametrizing a new class, i.e. in the following lines:
```python
class Transform(Generic[_B, _C], ABC):
class Composition(Transform[_B, _C]):
class Conjunction(Transform[_B, _C]):
class Stack(Transform[_B, Jacobians]):
class Differentiate(Transform[_A, _A], ABC):
class Select(Transform[_A, _A]):
```
Therefore, **a Transform, a Composition and a Conjunction all become contravariant in their input and covariant in their output**.

Similarly, **a Stack becomes contravariant on its input** (and it is not generic in its output).

**Differentiate and Select remain invariant**, because their genericity is overridden with TypeVar `_A` that is invariant. This is normal, a Differentiate[Gradients] is not a Differentiate[TensorDict] (as it doesn't work on all possible TensorDicts) and a Differentiate[TensorDict] is not a Differentiate[Gradients] (as it doesn't necessarily produce Gradients).
The same thing can be said about the Select transform. Although it may seem like a Select[Gradients] could work when a Select[TensorDict] is expected, if such a select was provided with a (base) TensorDict, the `type(tensor_dict)(output)` would NOT call the constructor of Gradients (but instead, that of TensorDict), so this transform would not actually product Gradients, which breaks its contract. So it would work, but in a confusing (and non-safe) way.

---

* Make _B contravariant and _C covariant
* Make Composition, Conjunction and Stack use _B as the TypeVar for their input, and make Composition and Conjunction use _C as the TypeVar for their output.
