### PR TITLE
Ignore some type errors

### DIFF
--- a/src/torchjd/_autojac/_transform/_tensor_dict.py
+++ b/src/torchjd/_autojac/_transform/_tensor_dict.py
@@ -32,16 +32,18 @@ class TensorDict(dict[Tensor, Tensor]):
     # Make TensorDict immutable, following answer in
     # https://stackoverflow.com/questions/11014262/how-to-create-an-immutable-dictionary-in-python
     # coming from https://peps.python.org/pep-0351/
+    # Note that this is not a perfect solution, because it breaks Liskov Substitution Principle, but
+    # it works.
     def _raise_immutable_error(self, *args, **kwargs) -> None:
         raise TypeError(f"{self.__class__.__name__} is immutable.")
 
     __setitem__ = _raise_immutable_error
     __delitem__ = _raise_immutable_error
     clear = _raise_immutable_error
-    update = _raise_immutable_error
-    setdefault = _raise_immutable_error
-    pop = _raise_immutable_error
-    popitem = _raise_immutable_error
+    update = _raise_immutable_error  # type: ignore[assignment]
+    setdefault = _raise_immutable_error  # type: ignore[assignment]
+    pop = _raise_immutable_error  # type: ignore[assignment]
+    popitem = _raise_immutable_error  # type: ignore[assignment]
 
 
 class Gradients(TensorDict):

--- a/src/torchjd/aggregation/_mgda.py
+++ b/src/torchjd/aggregation/_mgda.py
@@ -77,7 +77,7 @@ class _MGDAWeighting(Weighting[PSDMatrix]):
             elif b <= a:
                 gamma = 0.0
             else:
-                gamma = (b - a) / (b + c - 2 * a)
+                gamma = (b - a) / (b + c - 2 * a)  # type: ignore[assignment]
             alpha = (1 - gamma) * alpha + gamma * e_t
             if gamma < self.epsilon:
                 break

--- a/src/torchjd/aggregation/_nash_mtl.py
+++ b/src/torchjd/aggregation/_nash_mtl.py
@@ -23,6 +23,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# mypy: ignore-errors
+
 from ._utils.check_dependencies import check_dependencies_are_installed
 from ._weighting_bases import Matrix, Weighting
 


### PR DESCRIPTION
Some type errors are simply not worth the time to fix. This includes:
- NashMTL (there are way too errors, and they would be hard to fix)
- Assignment to `gamma` in MGDA (it's supposed to be a float but we assign a Tensor (containing a single float) to it). We will solve that if we ever re-implement MGDA anyway.
- TensorDict immutability tricks: these tricks break the Liskov Substition Principle anyway, so there's no way to fix the core issue without completely changing TensorDicts. The current solution works though, and alternatives seem really bad or slow, so I really don't think it's worth changing anything. I still added a comment to be clear about the fact this trick breaks LSP.

---

* Add comment to ignore mypy errors in _nash_mtl.py
* Add comment to ignore type error in mgda
* Add type: ignore[assignment] when needed in TensorDict immutability tricks, and add a comment
