### PR TITLE
Fix `_least_common_ancestor`

### DIFF
--- a/src/torchjd/_autojac/_transform/_tensor_dict.py
+++ b/src/torchjd/_autojac/_transform/_tensor_dict.py
@@ -127,7 +127,7 @@ class EmptyTensorDict(
 
 
 def _least_common_ancestor(first: type[TensorDict], second: type[TensorDict]) -> type[TensorDict]:
-    first_mro = first.mro()[:-1]  # removes `object` from `mro`.
+    first_mro = first.mro()
     output = TensorDict
     for candidate_type in first_mro:
         if issubclass(second, candidate_type):


### PR DESCRIPTION
As an example, if `first` is `EmptyTensorDict`, `first.mro()` is the following: 
```python
[<class 'torchjd._autojac._transform._tensor_dict.EmptyTensorDict'>,
<class 'torchjd._autojac._transform._tensor_dict.Gradients'>,
<class 'torchjd._autojac._transform._tensor_dict.Jacobians'>,
<class 'torchjd._autojac._transform._tensor_dict.GradientVectors'>,
<class 'torchjd._autojac._transform._tensor_dict.JacobianMatrices'>,
<class 'torchjd._autojac._transform._tensor_dict.TensorDict'>,
<class 'dict'>,
<class 'object'>]
```

We can see that the two last classes are `dict` and `object`. This will always be the case when `first` is a subtype of `TensorDict` (which it should be).

Since `second` is also always gonna be a subtype of `TensorDict`, we know that a common ancestor will be found before we reach `dict` or `object`.

So, removing `object` from the list has no effect. Removing both `dict` and `object` (which would probably make a bit more sense) would also have no effect. So my solution is to simply stop doing that.
