### PR TITLE
Revamp `OrderedSet`

### DIFF
--- a/src/torchjd/_autojac/_transform/_ordered_set.py
+++ b/src/torchjd/_autojac/_transform/_ordered_set.py
@@ -2,31 +2,41 @@ from collections import OrderedDict
 from collections.abc import Hashable, Iterable, MutableSet
 from typing import TypeVar
 
-_KeyType = TypeVar("_KeyType", bound=Hashable)
+_T = TypeVar("_T", bound=Hashable)
 
 
-class OrderedSet(OrderedDict[_KeyType, None], MutableSet[_KeyType]):
+class OrderedSet(MutableSet[_T]):
     """Ordered collection of distinct elements."""
 
-    def __init__(self, elements: Iterable[_KeyType]):
-        super().__init__([(element, None) for element in elements])
+    def __init__(self, elements: Iterable[_T]):
+        super().__init__()
+        self.ordered_dict = OrderedDict[_T, None]([(element, None) for element in elements])
 
-    def difference_update(self, elements: set[_KeyType]) -> None:
+    def difference_update(self, elements: set[_T]) -> None:
         """Removes all specified elements from the OrderedSet."""
 
         for element in elements:
             self.discard(element)
 
-    def add(self, element: _KeyType) -> None:
+    def add(self, element: _T) -> None:
         """Adds the specified element to the OrderedSet."""
 
-        self[element] = None
+        self.ordered_dict[element] = None
 
-    def __add__(self, other: "OrderedSet[_KeyType]") -> "OrderedSet[_KeyType]":
+    def __add__(self, other: "OrderedSet[_T]") -> "OrderedSet[_T]":
         """Creates a new OrderedSet with the elements of self followed by the elements of other."""
 
         return OrderedSet([*self, *other])
 
-    def discard(self, value: _KeyType) -> None:
+    def discard(self, value: _T) -> None:
         if value in self:
-            del self[value]
+            del self.ordered_dict[value]
+
+    def __iter__(self):
+        return self.ordered_dict.__iter__()
+
+    def __len__(self):
+        return len(self.ordered_dict)
+
+    def __contains__(self, element: object):
+        return element in self.ordered_dict


### PR DESCRIPTION
Change OrderedSet to compose with OrderedDict instead of inheritting from it. I think this is much more correct.

This requires defining the `__iter__`, `__len__` and `__contains__` method, which are abstract in `MutableSet`.

Note that we do not need extra tests for those methods, as they are used in `backward` and `mtl_backward`, and they are thus covered.
