### PR TITLE
Fix `TensorDict` immutability

### DIFF
--- a/src/torchjd/_autojac/_transform/_tensor_dict.py
+++ b/src/torchjd/_autojac/_transform/_tensor_dict.py
@@ -35,6 +35,7 @@ class TensorDict(dict[Tensor, Tensor]):
     def _raise_immutable_error(self, *args, **kwargs) -> None:
         raise TypeError(f"{self.__class__.__name__} is immutable.")
 
+    __ior__ = _raise_immutable_error
     __setitem__ = _raise_immutable_error
     __delitem__ = _raise_immutable_error
     clear = _raise_immutable_error


### PR DESCRIPTION
In the original stackoverflow answer from which the immutability trick was taken, the `__ior__` method (e.g. a |= b) was forgotten (because this method was added in Python 3.9).
This PR assigns the `_raise_immutable_error` to `__ior__`, similarly to other mutation methods.
