### PR TITLE
Revamp `Conjunction`

### DIFF
--- a/src/torchjd/_autojac/_transform/_tensor_dict.py
+++ b/src/torchjd/_autojac/_transform/_tensor_dict.py
@@ -35,6 +35,7 @@ class TensorDict(dict[Tensor, Tensor]):
     def _raise_immutable_error(self, *args, **kwargs) -> None:
         raise TypeError(f"{self.__class__.__name__} is immutable.")
 
+    __ior__ = _raise_immutable_error
     __setitem__ = _raise_immutable_error
     __delitem__ = _raise_immutable_error
     clear = _raise_immutable_error

--- a/src/torchjd/_autojac/_transform/_tensor_dict.py
+++ b/src/torchjd/_autojac/_transform/_tensor_dict.py
@@ -126,16 +126,6 @@ class EmptyTensorDict(
         super().__init__({})
 
 
-def _least_common_ancestor(first: type[TensorDict], second: type[TensorDict]) -> type[TensorDict]:
-    first_mro = first.mro()[:-1]  # removes `object` from `mro`.
-    output = TensorDict
-    for candidate_type in first_mro:
-        if issubclass(second, candidate_type):
-            output = candidate_type
-            break
-    return output
-
-
 def _check_values_have_unique_first_dim(tensor_dict: dict[Tensor, Tensor]) -> None:
     first_dims = [value.shape[0] for value in tensor_dict.values()]
     if len(set(first_dims)) > 1:

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -4,8 +4,8 @@ import torch
 from pytest import raises
 from torch import Tensor
 
-from torchjd._autojac._transform._base import Conjunction, RequirementError, Transform
-from torchjd._autojac._transform._tensor_dict import _B, _C, TensorDict
+from torchjd._autojac._transform._base import RequirementError, Transform
+from torchjd._autojac._transform._tensor_dict import _B, _C
 
 
 class FakeTransform(Transform[_B, _C]):
@@ -100,17 +100,6 @@ def test_conjunct_check_keys_2():
 
     with raises(RequirementError):
         (t1 | t2 | t3).check_keys(set())
-
-
-def test_empty_conjunction():
-    """
-    Tests that it is possible to take the conjunction of no transform. This should return an empty
-    dictionary.
-    """
-
-    conjunction = Conjunction([])
-
-    assert len(conjunction(TensorDict({}))) == 0
 
 
 def test_str():

--- a/tests/unit/autojac/_transform/test_tensor_dict.py
+++ b/tests/unit/autojac/_transform/test_tensor_dict.py
@@ -13,7 +13,6 @@ from torchjd._autojac._transform import (
     Jacobians,
     TensorDict,
 )
-from torchjd._autojac._transform._tensor_dict import _least_common_ancestor
 
 _key_shapes = [[], [1], [2, 3]]
 
@@ -78,25 +77,6 @@ def test_jacobian_matrices(value_shapes: list[list[int]], expectation: Exception
     """Tests that the JacobianMatrices class checks properly its inputs."""
 
     _assert_class_checks_properly(JacobianMatrices, value_shapes, expectation)
-
-
-@mark.parametrize(
-    ["first", "second", "result"],
-    [
-        (EmptyTensorDict, EmptyTensorDict, EmptyTensorDict),
-        (EmptyTensorDict, Jacobians, Jacobians),
-        (Jacobians, EmptyTensorDict, Jacobians),
-        (Jacobians, Jacobians, Jacobians),
-        (EmptyTensorDict, Gradients, Gradients),
-        (EmptyTensorDict, GradientVectors, GradientVectors),
-        (EmptyTensorDict, JacobianMatrices, JacobianMatrices),
-        (GradientVectors, JacobianMatrices, TensorDict),
-    ],
-)
-def test_least_common_ancestor(
-    first: type[TensorDict], second: type[TensorDict], result: type[TensorDict]
-):
-    assert _least_common_ancestor(first, second) == result
 
 
 def _assert_class_checks_properly(


### PR DESCRIPTION
This PR completely reimplements `Conjunction` to make it much more efficient.

First, we can notice that all transforms that the `Conjunction` holds map to the same output type (`_B`). We thus don't have to do several costly calls to `_least_common_ancestor`! We can simply call `type(self.transforms[0](tensor_dict))` to get the class of TensorDict that we want the final output to be.

This, however, would require having at least one transform. Until now, we also allowed empty conjunctions. We have two choices:
- Make the `output_type` be `EmptyTensorDict` when the `Conjunction` is empty. This is a bit confusing for the type checker, because when the `Conjunction` is empty, `_B` is not very well-defined (in this case, it is, in fact, `EmtpyTensorDict`, but mypy doesn't seem to infer this).
- Stop allowing empty `Conjunctions`. We do not allow `mtl_backward` with no loss anyway, so there's no way for a user to ever need an empty `Conjunction` at the moment.

I selected the second choice, because it's much simpler to implement. If we ever really need empty `Conjunctions` (which I doubt we will, because we can always replace them with a trivial transform returning the `EmptyTensorDict`), we can always go back on this choice.

Another implementation would have been:
```python
tensor_dicts = [transform(tensor_dict) for transform in self.transforms]
union: dict[Tensor, Tensor] = {}
for td in tensor_dicts:
    union |= td
return type(tensor_dicts[0])(union)
```
This is shorter, but I'm scared it could use a bit more memory (in fact, since only references should be stored, this is probably not significant at all, so we could arguably use this implementation instead).

Lastly, this fixes another issue that we had in the previous implementation: `TensorDict`s are supposed to be immutable, but we called `|=` (the `__ior__` method) on `EmptyTensorDict`. Now, we only call `|=` on `union`, which is **not** a `TensorDict`. The instantiation of the `TensorDict` is done only at the end, with `return output_type(union)`.

This allows us to assign `_raise_immutable_error` to `TensorDict.__ior__`, as we should already have done.

* Revamp Conjunction.__call__
* Remove _least_common_ancestor
* Disable __ior__ in TensorDict (for immutability)
