### PR TITLE
Move tensor dict checks out of constructor

### DIFF
--- a/src/torchjd/_autojac/_backward.py
+++ b/src/torchjd/_autojac/_backward.py
@@ -95,7 +95,7 @@ def backward(
         parallel_chunk_size=parallel_chunk_size,
     )
 
-    backward_transform(EmptyTensorDict())
+    backward_transform(EmptyTensorDict({}))
 
 
 def _create_transform(

--- a/src/torchjd/_autojac/_mtl_backward.py
+++ b/src/torchjd/_autojac/_mtl_backward.py
@@ -114,7 +114,7 @@ def mtl_backward(
         parallel_chunk_size=parallel_chunk_size,
     )
 
-    backward_transform(EmptyTensorDict())
+    backward_transform(EmptyTensorDict({}))
 
 
 def _create_transform(

--- a/src/torchjd/_autojac/_transform/_accumulate.py
+++ b/src/torchjd/_autojac/_transform/_accumulate.py
@@ -19,7 +19,7 @@ class Accumulate(Transform[Gradients, EmptyTensorDict]):
                 # (in case it was obtained via create_graph=True and a differentiable aggregator).
                 key.grad = gradients[key].clone()
 
-        return EmptyTensorDict()
+        return EmptyTensorDict({})
 
     def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
         return set()

--- a/src/torchjd/_autojac/_transform/_aggregate.py
+++ b/src/torchjd/_autojac/_transform/_aggregate.py
@@ -100,7 +100,7 @@ class _AggregateMatrices(Transform[JacobianMatrices, GradientVectors]):
         """
 
         if len(jacobian_matrices) == 0:
-            return EmptyTensorDict()
+            return EmptyTensorDict({})
 
         united_jacobian_matrix = _AggregateMatrices._unite(jacobian_matrices)
         united_gradient_vector = aggregator(united_jacobian_matrix)

--- a/src/torchjd/_autojac/_transform/_base.py
+++ b/src/torchjd/_autojac/_transform/_base.py
@@ -100,7 +100,7 @@ class Conjunction(Transform[_A, _B]):
     def __call__(self, tensor_dict: _A) -> _B:
         tensor_dicts = [transform(tensor_dict) for transform in self.transforms]
         output_type: type[_A] = EmptyTensorDict
-        output: _A = EmptyTensorDict()
+        output: _A = EmptyTensorDict({})
         for tensor_dict in tensor_dicts:
             output_type = _least_common_ancestor(output_type, type(tensor_dict))
             output |= tensor_dict

--- a/src/torchjd/_autojac/_transform/_tensor_dict.py
+++ b/src/torchjd/_autojac/_transform/_tensor_dict.py
@@ -118,10 +118,16 @@ class EmptyTensorDict(
     explicitly checking them.
     """
 
-    def __init__(self, tensor_dict: dict[Tensor, Tensor] | None = None):
-        if tensor_dict is not None and len(tensor_dict) != 0:
-            raise ValueError("Cannot build a non-empty `EmptyTensorDict`")
+    def __init__(self, _: dict[Tensor, Tensor] | None = None):
         super().__init__({})
+
+    @staticmethod
+    def _check_dict(tensor_dict: dict[Tensor, Tensor]) -> None:
+        if len(tensor_dict) != 0:
+            raise ValueError(
+                "Parameter `tensor_dict` should be empty. "
+                f"Found its length to be {len(tensor_dict)}."
+            )
 
 
 def _least_common_ancestor(first: type[TensorDict], second: type[TensorDict]) -> type[TensorDict]:

--- a/src/torchjd/_autojac/_transform/_tensor_dict.py
+++ b/src/torchjd/_autojac/_transform/_tensor_dict.py
@@ -118,9 +118,6 @@ class EmptyTensorDict(
     explicitly checking them.
     """
 
-    def __init__(self, _: dict[Tensor, Tensor] | None = None):
-        super().__init__({})
-
     @staticmethod
     def _check_dict(tensor_dict: dict[Tensor, Tensor]) -> None:
         if len(tensor_dict) != 0:

--- a/src/torchjd/_autojac/_transform/_tensor_dict.py
+++ b/src/torchjd/_autojac/_transform/_tensor_dict.py
@@ -14,14 +14,16 @@ class TensorDict(dict[Tensor, Tensor]):
     def __init__(self, tensor_dict: dict[Tensor, Tensor]):
         super().__init__(tensor_dict)
 
-    @staticmethod
-    def _check_dict(tensor_dict: dict[Tensor, Tensor]) -> None:
+    def check(self) -> None:
+        self._check_dict()
+        self._check_all_pairs()
+
+    def _check_dict(self) -> None:
         pass
 
-    @classmethod
-    def _check_all_pairs(cls, tensor_dict: dict[Tensor, Tensor]) -> None:
-        for key, value in tensor_dict.items():
-            cls._check_key_value_pair(key, value)
+    def _check_all_pairs(self) -> None:
+        for key, value in self.items():
+            self._check_key_value_pair(key, value)
 
     @staticmethod
     def _check_key_value_pair(key: Tensor, value: Tensor) -> None:
@@ -64,9 +66,8 @@ class Jacobians(TensorDict):
     - The rest of the shape of each value must be the same as the shape of its corresponding key.
     """
 
-    @staticmethod
-    def _check_dict(tensor_dict: dict[Tensor, Tensor]) -> None:
-        _check_values_have_unique_first_dim(tensor_dict)
+    def _check_dict(self) -> None:
+        _check_values_have_unique_first_dim(self)
 
     @staticmethod
     def _check_key_value_pair(key: Tensor, value: Tensor) -> None:
@@ -96,9 +97,8 @@ class JacobianMatrices(TensorDict):
       the number of elements of their corresponding key.
     """
 
-    @staticmethod
-    def _check_dict(tensor_dict: dict[Tensor, Tensor]) -> None:
-        _check_values_have_unique_first_dim(tensor_dict)
+    def _check_dict(self) -> None:
+        _check_values_have_unique_first_dim(self)
 
     @staticmethod
     def _check_key_value_pair(key: Tensor, value: Tensor) -> None:
@@ -118,12 +118,10 @@ class EmptyTensorDict(
     explicitly checking them.
     """
 
-    @staticmethod
-    def _check_dict(tensor_dict: dict[Tensor, Tensor]) -> None:
-        if len(tensor_dict) != 0:
+    def _check_dict(self) -> None:
+        if len(self) != 0:
             raise ValueError(
-                "Parameter `tensor_dict` should be empty. "
-                f"Found its length to be {len(tensor_dict)}."
+                f"Parameter `tensor_dict` should be empty. Found its length to be {len(self)}."
             )
 
 

--- a/src/torchjd/_autojac/_transform/_tensor_dict.py
+++ b/src/torchjd/_autojac/_transform/_tensor_dict.py
@@ -12,8 +12,6 @@ class TensorDict(dict[Tensor, Tensor]):
     """
 
     def __init__(self, tensor_dict: dict[Tensor, Tensor]):
-        self._check_dict(tensor_dict)
-        self._check_all_pairs(tensor_dict)
         super().__init__(tensor_dict)
 
     @staticmethod

--- a/tests/unit/autojac/_transform/_dict_assertions.py
+++ b/tests/unit/autojac/_transform/_dict_assertions.py
@@ -1,12 +1,23 @@
 from torch import Tensor
 from torch.testing import assert_close
 
+from torchjd._autojac._transform import TensorDict
+
 
 def assert_tensor_dicts_are_close(d1: dict[Tensor, Tensor], d2: dict[Tensor, Tensor]) -> None:
     """
     Check that two dictionaries of tensors are close enough. Note that this does not require the
     keys to have the same ordering.
+
+    Additionally, if the parameters are TensorDicts, this checks that their content respects their
+    supposed type.
     """
+
+    if isinstance(d1, TensorDict):
+        d1.check()
+
+    if isinstance(d2, TensorDict):
+        d2.check()
 
     assert d1.keys() == d2.keys()
 

--- a/tests/unit/autojac/_transform/test_init.py
+++ b/tests/unit/autojac/_transform/test_init.py
@@ -13,7 +13,7 @@ def test_single_input():
     """
 
     key = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-    input = EmptyTensorDict()
+    input = EmptyTensorDict({})
 
     init = Init({key})
 
@@ -31,7 +31,7 @@ def test_multiple_inputs():
 
     key1 = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     key2 = torch.tensor([1.0, 3.0, 5.0])
-    input = EmptyTensorDict()
+    input = EmptyTensorDict({})
 
     init = Init({key1, key2})
 
@@ -51,7 +51,7 @@ def test_conjunction_of_inits_is_init():
 
     x1 = torch.tensor(5.0)
     x2 = torch.tensor(6.0)
-    input = EmptyTensorDict()
+    input = EmptyTensorDict({})
 
     init1 = Init({x1})
     init2 = Init({x2})

--- a/tests/unit/autojac/_transform/test_interactions.py
+++ b/tests/unit/autojac/_transform/test_interactions.py
@@ -64,7 +64,7 @@ def test_single_differentiation():
 
     a = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
     y = a * 2.0
-    input = EmptyTensorDict()
+    input = EmptyTensorDict({})
 
     init = Init({y})
     grad = Grad(OrderedSet([y]), OrderedSet([a]))
@@ -86,7 +86,7 @@ def test_multiple_differentiations():
     a2 = torch.tensor([1.0, 3.0, 5.0], requires_grad=True)
     y1 = a1 * 2.0
     y2 = a2 * 3.0
-    input = EmptyTensorDict()
+    input = EmptyTensorDict({})
 
     grad1 = Grad(OrderedSet([y1]), OrderedSet([a1]))
     grad2 = Grad(OrderedSet([y2]), OrderedSet([a2]))

--- a/tests/unit/autojac/_transform/test_stack.py
+++ b/tests/unit/autojac/_transform/test_stack.py
@@ -28,7 +28,7 @@ def test_single_key():
     """
 
     key = torch.zeros([3, 4])
-    input = EmptyTensorDict()
+    input = EmptyTensorDict({})
 
     transform = FakeGradientsTransform([key])
     stack = Stack([transform, transform])
@@ -48,7 +48,7 @@ def test_disjoint_key_sets():
 
     key1 = torch.zeros([1, 2])
     key2 = torch.zeros([3])
-    input = EmptyTensorDict()
+    input = EmptyTensorDict({})
 
     transform1 = FakeGradientsTransform([key1])
     transform2 = FakeGradientsTransform([key2])
@@ -73,7 +73,7 @@ def test_overlapping_key_sets():
     key1 = torch.zeros([1, 2])
     key2 = torch.zeros([3])
     key3 = torch.zeros([4])
-    input = EmptyTensorDict()
+    input = EmptyTensorDict({})
 
     transform12 = FakeGradientsTransform([key1, key2])
     transform23 = FakeGradientsTransform([key2, key3])

--- a/tests/unit/autojac/_transform/test_tensor_dict.py
+++ b/tests/unit/autojac/_transform/test_tensor_dict.py
@@ -81,6 +81,22 @@ def test_jacobian_matrices(value_shapes: list[list[int]], expectation: Exception
 
 
 @mark.parametrize(
+    ["tensor_mapping", "expectation"],
+    [
+        ({}, does_not_raise()),
+        ({torch.ones(1): torch.ones(1)}, raises(ValueError)),  # Non-empty
+    ],
+)
+def test_empty_tensor_dict(
+    tensor_mapping: dict[Tensor, Tensor] | None, expectation: ExceptionContext
+):
+    """Tests that the JacobianMatrices class checks properly its inputs."""
+
+    with expectation:
+        EmptyTensorDict(tensor_mapping).check()
+
+
+@mark.parametrize(
     ["first", "second", "result"],
     [
         (EmptyTensorDict, EmptyTensorDict, EmptyTensorDict),
@@ -105,7 +121,7 @@ def _assert_class_checks_properly(
     tensor_mapping = _make_tensor_dict(value_shapes)
 
     with expectation:
-        class_(tensor_mapping)
+        class_(tensor_mapping).check()
 
 
 def _make_tensor_dict(value_shapes: list[list[int]]) -> dict[Tensor, Tensor]:
@@ -120,10 +136,3 @@ def test_immutability():
         t[torch.ones(1)] = torch.ones(1)
 
     assert t == Gradients({})
-
-
-def test_empty_tensor_dict():
-    """Tests that it's impossible to instantiate a non-empty EmptyTensorDict."""
-
-    with raises(ValueError):
-        _ = EmptyTensorDict({torch.ones(1): torch.ones(1)})

--- a/tests/unit/autojac/_transform/test_tensor_dict.py
+++ b/tests/unit/autojac/_transform/test_tensor_dict.py
@@ -28,7 +28,7 @@ _key_shapes = [[], [1], [2, 3]]
     ],
 )
 def test_gradients(value_shapes: list[list[int]], expectation: ExceptionContext):
-    """Tests that the Gradients class checks properly its inputs."""
+    """Tests Gradients.check."""
 
     _assert_class_checks_properly(Gradients, value_shapes, expectation)
 
@@ -44,7 +44,7 @@ def test_gradients(value_shapes: list[list[int]], expectation: ExceptionContext)
     ],
 )
 def test_jacobians(value_shapes: list[list[int]], expectation: ExceptionContext):
-    """Tests that the Jacobians class checks properly its inputs."""
+    """Tests Jacobians.check."""
 
     _assert_class_checks_properly(Jacobians, value_shapes, expectation)
 
@@ -59,7 +59,7 @@ def test_jacobians(value_shapes: list[list[int]], expectation: ExceptionContext)
     ],
 )
 def test_gradient_vectors(value_shapes: list[list[int]], expectation: ExceptionContext):
-    """Tests that the GradientVectors class checks properly its inputs."""
+    """Tests GradientVectors.check."""
 
     _assert_class_checks_properly(GradientVectors, value_shapes, expectation)
 
@@ -75,7 +75,7 @@ def test_gradient_vectors(value_shapes: list[list[int]], expectation: ExceptionC
     ],
 )
 def test_jacobian_matrices(value_shapes: list[list[int]], expectation: ExceptionContext):
-    """Tests that the JacobianMatrices class checks properly its inputs."""
+    """Tests JacobianMatrices.check."""
 
     _assert_class_checks_properly(JacobianMatrices, value_shapes, expectation)
 
@@ -90,7 +90,7 @@ def test_jacobian_matrices(value_shapes: list[list[int]], expectation: Exception
 def test_empty_tensor_dict(
     tensor_mapping: dict[Tensor, Tensor] | None, expectation: ExceptionContext
 ):
-    """Tests that the JacobianMatrices class checks properly its inputs."""
+    """Tests EmptyTensorDict.check."""
 
     with expectation:
         EmptyTensorDict(tensor_mapping).check()


### PR DESCRIPTION
Addresses #376 

This PR moves the checks done by TensorDicts out of the constructor, to the `check` method, so that these check are not used at runtime, but only during tests.
This also changes EmptyTensorDict to not allow taking a None as input (which doesn't really make sense now).

Lastly, since we don't run these checks at runtime anymore, it becomes interesting to run them in the tests. Note that I'm not talking about `test_tensor_dict.py` (those are meant to verify that the checks work correctly). I'm talking about testing that the TensorDicts returned by the transforms are actually correct (exactly like we test that the transforms returned by backward and mtl_backward have recursively correct keys). The easiest way to do that was simply to test the correctness of the tensor dicts in `assert_tensor_dicts_are_close` whenever the inputs are `TensorDict` (and not just `dict[Tensor, Tensor]`).

* Remove tensor dict checks at runtime
* Change EmptyTensorDict to make its check not run at instantiation
* Remove EmptyTensorDict special constructor
* Make check non static
* Update tensor dict tests
* Add check of structure in assert_tensor_dicts_are_close
