### PR TITLE
Fix typing in tests

### DIFF
--- a/tests/plots/_utils.py
+++ b/tests/plots/_utils.py
@@ -1,8 +1,7 @@
 import numpy as np
 import torch
-from dash.html import Figure
 from plotly import graph_objects as go
-from plotly.graph_objs import Scatter
+from plotly.graph_objs import Figure, Scatter
 
 from torchjd.aggregation import Aggregator
 

--- a/tests/plots/interactive_plotter.py
+++ b/tests/plots/interactive_plotter.py
@@ -6,7 +6,7 @@ from threading import Timer
 import numpy as np
 import torch
 from dash import Dash, Input, Output, callback, dcc, html
-from dash.html import Figure
+from plotly.graph_objs import Figure
 from plots._utils import Plotter, angle_to_coord, coord_to_angle
 
 from torchjd.aggregation import (

--- a/tests/plots/interactive_plotter.py
+++ b/tests/plots/interactive_plotter.py
@@ -121,11 +121,11 @@ def main() -> None:
         prevent_initial_call=True,
     )
     def update_gradient_coordinate(*values) -> Figure:
-        values = [float(value) for value in values]
+        values_ = [float(value) for value in values]
 
-        for j in range(len(values) // 2):
-            angle = values[2 * j]
-            r = values[2 * j + 1]
+        for j in range(len(values_) // 2):
+            angle = values_[2 * j]
+            r = values_[2 * j + 1]
             x, y = angle_to_coord(angle, r)
             plotter.matrix[j, 0] = x
             plotter.matrix[j, 1] = y


### PR DESCRIPTION
Up until now, I only ran mypy on `src/torchjd`. I thus tried to run it on `tests`, and got a few errors.

```
tests/unit/aggregation/_matrix_samplers.py:108: error: Slice index must be an integer, SupportsIndex or None  [misc]
tests/unit/aggregation/_matrix_samplers.py:110: error: Slice index must be an integer, SupportsIndex or None  [misc]
tests/plots/interactive_plotter.py:71: error: Argument "figure" to "Graph" has incompatible type "dash.html.Figure.Figure"; expected "plotly.graph_objs._figure.Figure | dict[Any, Any] | None"  [arg-type]
tests/unit/autojac/_transform/test_jac.py:48: error: Need type annotation for "expected_jacobians" (hint: "expected_jacobians: dict[<type>, <type>] = ...")  [var-annotated]
tests/unit/autojac/_transform/test_jac.py:70: error: Need type annotation for "expected_jacobians" (hint: "expected_jacobians: dict[<type>, <type>] = ...")  [var-annotated]
tests/unit/autojac/_transform/test_jac.py:84: error: Need type annotation for "input" (hint: "input: dict[<type>, <type>] = ...")  [var-annotated]
tests/unit/autojac/_transform/test_accumulate.py:63: error: Argument 1 to "assert_tensor_dicts_are_close" has incompatible type "dict[Tensor, Tensor | None]"; expected "dict[Tensor, Tensor]"  [arg-type]
tests/doc/test_rst.py:161: error: Item "list[LightningOptimizer]" of "LightningOptimizer | list[LightningOptimizer]" has no attribute "zero_grad"  [union-attr]
tests/doc/test_rst.py:163: error: Item "list[LightningOptimizer]" of "LightningOptimizer | list[LightningOptimizer]" has no attribute "step"  [union-attr]
Found 11 errors in 6 files (checked 50 source files)
```
=> All of these would be fixed simply by casting or adding an extra type hint, which we don't want to do because it makes the code less readable. => IMO it's better to leave these errors.

```
tests/plots/interactive_plotter.py:124: error: Incompatible types in assignment (expression has type "list[float]", variable has type "tuple[Any, ...]")  [assignment]
```
=> reassignment problem (similar to what fixed in #368) => Fixed

```
tests/plots/_utils.py:52: error: Incompatible return value type (got "plotly.graph_objs._figure.Figure", expected "dash.html.Figure.Figure")  [return-value]
```
=> It seems that we used `Figure` from `dash.html` instead of `plotly.graph_objs.Figure` => Fixed

The interactive plotter still works after these changes.