### PR TITLE
Add an automatic tagger to the CI

### DIFF
--- a/.github/workflows/tagger.yml
+++ b/.github/workflows/tagger.yml
@@ -19,7 +19,7 @@ jobs:
               'src/torchjd/_autogram/': 'package: autogram',
               'src/torchjd/_autojac/': 'package: autojac',
               'src/torchjd/aggregation/': 'package: aggregation',
-              '.github/workflows/': 'CI',
+              '.github/workflows/': 'ci',
               'docs/': 'docs',
               'tests/': 'test'
             };


### PR DESCRIPTION
Note that this does not remove tags if not needed anymore. I think this shouldn't in case we want to manually add a tag, for instance if we change documentation in the docstrings, then this could be tagged with `docs` even though no change happened in `torchjd/docs`.

In a later version, we could have all tags completely decided by the CI, For instance, the title of the PR could give the tag associated to the type of change, then we could do a diff of the built doc with the one on main to see if there are changes and tag as docs in this case etc... Some tags could remain addable such as `breaking change` or `style`.