### PR TITLE
test: Fix `test_mtl_backward` warnings

### DIFF
--- a/tests/unit/autojac/test_mtl_backward.py
+++ b/tests/unit/autojac/test_mtl_backward.py
@@ -496,7 +496,7 @@ def test_tasks_params_overlap():
     assert_close(p1.grad, f * p12)
     assert_close(p12.grad, f * p1 + f * p2)
 
-    J = tensor_([[-p1 * p12, p1 * p12], [-p2 * p12, p2 * p12]])
+    J = tensor_([[-8.0, 8.0], [-12.0, 12.0]])
     assert_close(p0.grad, aggregator(J))
 
 
@@ -515,7 +515,7 @@ def test_tasks_params_are_the_same():
 
     assert_close(p1.grad, f + 1)
 
-    J = tensor_([[-p1, p1], [-1.0, 1.0]])
+    J = tensor_([[-2.0, 2.0], [-1.0, 1.0]])
     assert_close(p0.grad, aggregator(J))
 
 
@@ -539,7 +539,7 @@ def test_task_params_is_subset_of_other_task_params():
     assert_close(p2.grad, y1)
     assert_close(p1.grad, p2 * f + f)
 
-    J = tensor_([[-p1, p1], [-p1 * p2, p1 * p2]])
+    J = tensor_([[-2.0, 2.0], [-6.0, 6.0]])
     assert_close(p0.grad, aggregator(J))
 
 


### PR DESCRIPTION
* Before this, we had UserWarning: Converting a tensor with requires_grad=True to a scalar may lead to unexpected behavior.
