### PR TITLE
fix(autogram): Reset even when exception is raised

### DIFF
--- a/src/torchjd/autogram/_engine.py
+++ b/src/torchjd/autogram/_engine.py
@@ -169,11 +169,20 @@ class Engine:
         """
 
         reshaped_output = output.reshape([-1])
-        return self._compute_square_gramian(reshaped_output)
 
-    def _compute_square_gramian(self, output: Tensor) -> Tensor:
         self._module_hook_manager.gramian_accumulation_phase = True
 
+        try:
+            square_gramian = self._compute_square_gramian(reshaped_output)
+        finally:
+            # Reset everything that has a state, even if the previous call raised an exception
+            self._module_hook_manager.gramian_accumulation_phase = False
+            self._gramian_accumulator.reset()
+            self._target_edges.reset()
+
+        return square_gramian
+
+    def _compute_square_gramian(self, output: Tensor) -> Tensor:
         leaf_targets = list(self._target_edges.get_leaf_edges({get_gradient_edge(output)}))
 
         def differentiation(_grad_output: Tensor) -> tuple[Tensor, ...]:
@@ -189,10 +198,5 @@ class Engine:
         # If the gramian were None, then leaf_targets would be empty, so autograd.grad would
         # have failed. So gramian is necessarily a valid Tensor here.
         gramian = cast(Tensor, self._gramian_accumulator.gramian)
-
-        # Reset everything that has a state
-        self._module_hook_manager.gramian_accumulation_phase = False
-        self._gramian_accumulator.reset()
-        self._target_edges.reset()
 
         return gramian


### PR DESCRIPTION
Before this, the following would fail:
```python
import torch
from torch.nn import Linear
from torchjd.autogram import Engine

m = Linear(2, 3)
t = torch.randn([16, 2])
engine = Engine([m])

output = m(t)
g = engine.compute_gramian(output)  # ok
g = engine.compute_gramian(output)  # ValueError because target edges have been reset, as expected

output = m(t)
g = engine.compute_gramian(output)  # ValueError again, but not expected this time, because in the previous call we didn't reset properly the state and thus everything is now fucked.
```

Now, we get:
```python
import torch
from torch.nn import Linear
from torchjd.autogram import Engine

m = Linear(2, 3)
t = torch.randn([16, 2])
engine = Engine([m])

output = m(t)
g = engine.compute_gramian(output)  # ok
g = engine.compute_gramian(output)  # ValueError because target edges have been reset, as expected. Still reset state.

output = m(t)
g = engine.compute_gramian(output)  # ok
```