### PR TITLE
fix(autogram): Remove reference cycles

### DIFF
--- a/src/torchjd/autogram/_engine.py
+++ b/src/torchjd/autogram/_engine.py
@@ -170,13 +170,13 @@ class Engine:
 
         reshaped_output = output.reshape([-1])
 
-        self._module_hook_manager.gramian_accumulation_phase = True
+        self._module_hook_manager.gramian_accumulation_phase.value = True
 
         try:
             square_gramian = self._compute_square_gramian(reshaped_output)
         finally:
             # Reset everything that has a state, even if the previous call raised an exception
-            self._module_hook_manager.gramian_accumulation_phase = False
+            self._module_hook_manager.gramian_accumulation_phase.value = False
             self._gramian_accumulator.reset()
             self._target_edges.reset()
 

--- a/src/torchjd/autogram/_module_hook_manager.py
+++ b/src/torchjd/autogram/_module_hook_manager.py
@@ -1,4 +1,5 @@
 import weakref
+from collections.abc import Callable
 from typing import cast
 
 import torch
@@ -85,7 +86,13 @@ class AccumulateJacobian(torch.autograd.Function):
 
     @staticmethod
     def forward(
-        ctx, tree_spec: TreeSpec, vjp, args, gramian_accumulator, module, *flat_grad_outputs: Tensor
+        ctx,
+        tree_spec: TreeSpec,
+        vjp: Callable[[PyTree, PyTree], dict[str, Tensor]],
+        args: PyTree,
+        gramian_accumulator: GramianAccumulator,
+        module: nn.Module,
+        *flat_grad_outputs: Tensor,
     ) -> None:
         grad_outputs = tree_unflatten(flat_grad_outputs, tree_spec)
         jacobians = vjp(grad_outputs, args)
@@ -112,11 +119,11 @@ class JacobianAccumulator(torch.autograd.Function):
     def forward(
         ctx,
         gramian_accumulation_phase: BoolRef,
-        tree_spec,
-        vjp,
-        args,
-        gramian_accumulator,
-        module,
+        tree_spec: TreeSpec,
+        vjp: Callable[[PyTree, PyTree], dict[str, Tensor]],
+        args: PyTree,
+        gramian_accumulator: GramianAccumulator,
+        module: nn.Module,
         *xs: Tensor,
     ) -> tuple[Tensor, ...]:
         ctx.gramian_accumulation_phase = gramian_accumulation_phase

--- a/tests/unit/autogram/test_engine.py
+++ b/tests/unit/autogram/test_engine.py
@@ -96,12 +96,12 @@ PARAMETRIZATIONS = [
     (FreeParam, 32),
     (NoFreeParam, 32),
     param(Randomness, 32, marks=mark.xfail),
-    param(Cifar10Model, 16, marks=[mark.slow, mark.garbage_collect]),
-    param(AlexNet, 2, marks=[mark.slow, mark.garbage_collect]),
-    param(InstanceNormResNet18, 4, marks=[mark.slow, mark.garbage_collect]),
-    param(GroupNormMobileNetV3Small, 3, marks=[mark.slow, mark.garbage_collect]),
-    param(SqueezeNet, 8, marks=[mark.slow, mark.garbage_collect]),
-    param(InstanceNormMobileNetV2, 2, marks=[mark.slow, mark.garbage_collect]),
+    param(Cifar10Model, 16, marks=[mark.slow]),
+    param(AlexNet, 2, marks=[mark.slow]),
+    param(InstanceNormResNet18, 4, marks=[mark.slow]),
+    param(GroupNormMobileNetV3Small, 3, marks=[mark.slow]),
+    param(SqueezeNet, 8, marks=[mark.slow]),
+    param(InstanceNormMobileNetV2, 2, marks=[mark.slow]),
 ]
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,3 @@
-import gc
 import os
 import random as rand
 
@@ -32,28 +31,12 @@ def fix_randomness() -> None:
         torch.use_deterministic_algorithms(True)
 
 
-@fixture(autouse=True)
-def garbage_collect_if_marked(request):
-    """
-    Since garbage collection takes some time, we only do it when needed (when the test or the
-    parametrization of the test is marked with mark.garbage_collect). This is currently useful for
-    freeing CUDA memory after a lot has been allocated.
-    """
-
-    yield
-    if request.node.get_closest_marker("garbage_collect"):
-        if DEVICE.type == "cuda":
-            torch.cuda.empty_cache()
-        gc.collect()
-
-
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
-    config.addinivalue_line("markers", "garbage_collect: do garbage collection after test")
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
- Fixes #423 

* Refactor ModuleHookManager
* Refactor autograd Functions
* Add finalizer in ModuleHookManager to unhook
* Remove manual garbage collection

There will be some conflicts with #411 but I think we still want to merge this, and basically re-code this from scratch in #411 (it's quite easy now that we know what to do, maybe 1h work).
