### PR TITLE
test: Add xfail_if_cuda marker

### DIFF
--- a/tests/unit/autogram/test_engine.py
+++ b/tests/unit/autogram/test_engine.py
@@ -157,7 +157,13 @@ def test_compute_gramian(architecture: type[ShapedModule], batch_size: int, batc
 
 @mark.parametrize(
     "architecture",
-    [WithBatchNorm, WithSideEffect, Randomness, WithModuleTrackingRunningStats, WithRNN],
+    [
+        WithBatchNorm,
+        WithSideEffect,
+        Randomness,
+        WithModuleTrackingRunningStats,
+        param(WithRNN, marks=mark.xfail_if_cuda),
+    ],
 )
 @mark.parametrize("batch_size", [1, 3, 32])
 @mark.parametrize("batch_dim", [param(0, marks=mark.xfail), None])

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -37,13 +37,14 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line("markers", "xfail_if_cuda: mark test as xfail if running on cuda")
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--runslow"):
-        return
-
     skip_slow = mark.skip(reason="Slow test. Use --runslow to run it.")
+    xfail_cuda = mark.xfail(reason=f"Test expected to fail on {DEVICE}")
     for item in items:
-        if "slow" in item.keywords:
+        if "slow" in item.keywords and not config.getoption("--runslow"):
             item.add_marker(skip_slow)
+        if "xfail_if_cuda" in item.keywords and str(DEVICE).startswith("cuda"):
+            item.add_marker(xfail_cuda)


### PR DESCRIPTION
This marker allows us to mark some tests as expected failure if they're run on CUDA. Currently, the only example that fails on CUDA but works on CPU is RNN. I thus marked it as xfail_if_cuda. Before this PR, these tests would fail on CUDA on my machine.

* Add possibility to mark test as xfail_if_cuda
* Mark WithRNN as xfail_if_cuda
