### PR TITLE
fix(autogram): Type `args` as `tuple[PyTree, ...]`

### DIFF
--- a/src/torchjd/autogram/_module_hook_manager.py
+++ b/src/torchjd/autogram/_module_hook_manager.py
@@ -101,7 +101,7 @@ class Hook:
         self.gramian_accumulator = gramian_accumulator
         self.has_batch_dim = has_batch_dim
 
-    def __call__(self, module: nn.Module, args: PyTree, output: PyTree) -> PyTree:
+    def __call__(self, module: nn.Module, args: tuple[PyTree, ...], output: PyTree) -> PyTree:
         if self.gramian_accumulation_phase:
             return output
 
@@ -154,7 +154,7 @@ class JacobianAccumulator(torch.autograd.Function):
         gramian_accumulation_phase: BoolRef,
         output_spec: TreeSpec,
         vjp: VJP,
-        args: PyTree,
+        args: tuple[PyTree, ...],
         gramian_accumulator: GramianAccumulator,
         module: nn.Module,
         *xs: Tensor,
@@ -199,7 +199,7 @@ class AccumulateJacobian(torch.autograd.Function):
     def forward(
         output_spec: TreeSpec,
         vjp: VJP,
-        args: PyTree,
+        args: tuple[PyTree, ...],
         gramian_accumulator: GramianAccumulator,
         module: nn.Module,
         *flat_grad_outputs: Tensor,
@@ -216,7 +216,7 @@ class AccumulateJacobian(torch.autograd.Function):
         in_dims: PyTree,
         output_spec: TreeSpec,
         vjp: VJP,
-        args: PyTree,
+        args: tuple[PyTree, ...],
         gramian_accumulator: GramianAccumulator,
         module: nn.Module,
         *flat_jac_outputs: Tensor,

--- a/src/torchjd/autogram/_vjp.py
+++ b/src/torchjd/autogram/_vjp.py
@@ -19,7 +19,7 @@ class VJP(ABC):
     """Represents an abstract VJP function."""
 
     @abstractmethod
-    def __call__(self, grad_outputs: PyTree, args: PyTree) -> dict[str, Tensor]:
+    def __call__(self, grad_outputs: PyTree, args: tuple[PyTree, ...]) -> dict[str, Tensor]:
         """
         Computes and returns the dictionary of parameter names to their gradients for the given
         grad_outputs (cotangents) and at the given inputs.
@@ -56,7 +56,7 @@ class FunctionalVJP(ModuleVJP):
         super().__init__(module)
         self.vmapped_vjp = torch.vmap(self._call_on_one_instance)
 
-    def __call__(self, grad_outputs: PyTree, args: PyTree) -> dict[str, Tensor]:
+    def __call__(self, grad_outputs: PyTree, args: tuple[PyTree, ...]) -> dict[str, Tensor]:
         return self.vmapped_vjp(grad_outputs, args)
 
     def _call_on_one_instance(self, grad_outputs_j: PyTree, args_j: PyTree) -> dict[str, Tensor]:


### PR DESCRIPTION
to highlight both the fact that it is a tuple and has recursive structure.