### PR TITLE
fix(autogram): Type `flat_grad_outputs` to `Tensor | None`

### DIFF
--- a/src/torchjd/autogram/_module_hook_manager.py
+++ b/src/torchjd/autogram/_module_hook_manager.py
@@ -164,7 +164,7 @@ class JacobianAccumulator(torch.autograd.Function):
         return tuple(x.detach() for x in xs)
 
     # For Python version > 3.10, the type of `inputs` should become
-    # tuple[BoolRef, TreeSpec, VJP, PyTree, GramianAccumulator, nn.Module, *tuple[Tensor, ...]]
+    # tuple[BoolRef, VJP, PyTree, GramianAccumulator, nn.Module, *tuple[Tensor, ...]]
     @staticmethod
     def setup_context(
         ctx,

--- a/src/torchjd/autogram/_module_hook_manager.py
+++ b/src/torchjd/autogram/_module_hook_manager.py
@@ -123,11 +123,7 @@ class Hook:
         index = cast(int, preference.argmin().item())
         self.target_edges.register(get_gradient_edge(flat_outputs[index]))
 
-        vjp = (
-            FunctionalVJP(module, output_spec)
-            if self.has_batch_dim
-            else AutogradVJP(module, flat_outputs)
-        )
+        vjp = FunctionalVJP(module) if self.has_batch_dim else AutogradVJP(module, flat_outputs)
 
         autograd_fn_outputs = JacobianAccumulator.apply(
             self.gramian_accumulation_phase,

--- a/src/torchjd/autogram/_module_hook_manager.py
+++ b/src/torchjd/autogram/_module_hook_manager.py
@@ -173,8 +173,10 @@ class JacobianAccumulator(torch.autograd.Function):
         ctx.gramian_accumulator = inputs[3]
         ctx.module = inputs[4]
 
+    # For Python version > 3.10, the return type should become
+    # tuple[None, None, None, None, None, *tuple[Tensor | None, ...]]
     @staticmethod
-    def backward(ctx, *flat_grad_outputs: Tensor):
+    def backward(ctx, *flat_grad_outputs: Tensor | None) -> tuple:
         if not ctx.gramian_accumulation_phase:
             return None, None, None, None, None, *flat_grad_outputs
 
@@ -197,7 +199,7 @@ class AccumulateJacobian(torch.autograd.Function):
         args: PyTree,
         gramian_accumulator: GramianAccumulator,
         module: nn.Module,
-        *flat_grad_outputs: Tensor,
+        *flat_grad_outputs: Tensor | None,
     ) -> None:
         # There is no non-batched dimension
         generalized_jacobians = vjp(flat_grad_outputs, args)
@@ -212,7 +214,7 @@ class AccumulateJacobian(torch.autograd.Function):
         args: PyTree,
         gramian_accumulator: GramianAccumulator,
         module: nn.Module,
-        *flat_jac_outputs: Tensor,
+        *flat_jac_outputs: Tensor | None,
     ) -> tuple[None, None]:
         # There is a non-batched dimension
         # We do not vmap over the args for the non-batched dimension

--- a/src/torchjd/autogram/_vjp.py
+++ b/src/torchjd/autogram/_vjp.py
@@ -68,9 +68,7 @@ class FunctionalVJP(ModuleVJP):
         # an element of a batch. We thus always provide them with batches, just of a
         # different size.
         args_j = tree_map_only(torch.Tensor, lambda x: x.unsqueeze(0), args_j)
-        flat_grad_outputs_j = tree_map_only(
-            torch.Tensor, lambda x: x.unsqueeze(0), flat_grad_outputs_j
-        )
+        flat_grad_outputs_j_ = [x.unsqueeze(0) for x in flat_grad_outputs_j]
 
         def flat_functional_model_call(trainable_params: dict[str, Parameter]) -> list[Tensor]:
             all_state = {
@@ -86,7 +84,7 @@ class FunctionalVJP(ModuleVJP):
         # vjp_func is a function that computes the vjp w.r.t. to the primals (tuple). Here the
         # functional has a single primal which is dict(module.named_parameters()). We therefore take
         # the 0'th element to obtain the dict of gradients w.r.t. the module's named_parameters.
-        return vjp_func(flat_grad_outputs_j)[0]
+        return vjp_func(flat_grad_outputs_j_)[0]
 
 
 class AutogradVJP(ModuleVJP):


### PR DESCRIPTION
Need a test for the case where `JacobianAccumulator.backward` get a None. It would be related to having an output that is either not a Tensor or has no graph.