### PR TITLE
test(autogram): Add extra test for batched equivalance

### DIFF
--- a/tests/unit/autogram/test_engine.py
+++ b/tests/unit/autogram/test_engine.py
@@ -562,3 +562,33 @@ def test_batched_non_batched_equivalence(shape: list[int], batch_dim: int):
     gramian2 = engine2.compute_gramian(output)
 
     assert_close(gramian1, gramian2)
+
+
+@mark.parametrize(["architecture", "batch_size"], PARAMETRIZATIONS)
+def test_batched_non_batched_equivalence_2(architecture: ShapedModule, batch_size: int):
+    """
+    Same as test_batched_non_batched_equivalence but on real architectures, and thus only between
+    batch_size=0 and batch_size=None.
+    """
+
+    input_shapes = architecture.INPUT_SHAPES
+    output_shapes = architecture.OUTPUT_SHAPES
+
+    torch.manual_seed(0)
+    model = architecture().to(device=DEVICE)
+
+    engine_0 = Engine(model.modules(), batch_dim=0)
+    engine_none = Engine(model.modules(), batch_dim=None)
+
+    inputs = make_tensors(batch_size, input_shapes)
+    targets = make_tensors(batch_size, output_shapes)
+    loss_fn = make_mse_loss_fn(targets)
+
+    torch.random.manual_seed(0)  # Fix randomness for random models
+    output = model(inputs)
+    losses = reduce_to_vector(loss_fn(output))
+
+    gramian_0 = engine_0.compute_gramian(losses)
+    gramian_none = engine_none.compute_gramian(losses)
+
+    assert_close(gramian_0, gramian_none, rtol=1e-4, atol=1e-5)


### PR DESCRIPTION
This test can be quite practical, to check that both engines do give the same results. For instance, when working on Transformer, autogram is not equivalent to autograd_gramian yet, but both engines (autogram with batch_dim=None and autogram with batch_dim=0) are equivalent.

It seems that this test does not pass for FreeParam. This is weird, considering that both should be equivalent to autograd_gramian. We may have a bug here.
