### PR TITLE
refactor(autogram): Fix outdated list of incompatible modules

### DIFF
--- a/src/torchjd/autogram/_engine.py
+++ b/src/torchjd/autogram/_engine.py
@@ -19,11 +19,6 @@ _MODULES_INCOMPATIBLE_WITH_BATCHED = (
     nn.LazyBatchNorm3d,
     nn.SyncBatchNorm,
     nn.RNNBase,
-    nn.Transformer,
-    nn.TransformerEncoder,
-    nn.TransformerDecoder,
-    nn.TransformerEncoderLayer,
-    nn.TransformerDecoderLayer,
 )
 
 _TRACK_RUNNING_STATS_MODULE_TYPES = (


### PR DESCRIPTION
* Transformer and helper modules are now compatible with batched engine. It somehow worked even with those modules in the list because Transformer and helper modules do not have direct params and thus do not get hooked themselves anyway.
