### PR TITLE
test: Add `ModuleFactory`

### DIFF
--- a/tests/speed/autogram/grad_vs_jac_vs_gram.py
+++ b/tests/speed/autogram/grad_vs_jac_vs_gram.py
@@ -10,10 +10,11 @@ from utils.architectures import (
     GroupNormMobileNetV3Small,
     InstanceNormMobileNetV2,
     InstanceNormResNet18,
+    ModuleFactory,
     NoFreeParam,
-    ShapedModule,
     SqueezeNet,
     WithTransformerLarge,
+    get_in_out_shapes,
 )
 from utils.forward_backwards import (
     autograd_forward_backward,
@@ -28,33 +29,30 @@ from torchjd.aggregation import Mean
 from torchjd.autogram import Engine
 
 PARAMETRIZATIONS = [
-    (WithTransformerLarge, 8),
-    (FreeParam, 64),
-    (NoFreeParam, 64),
-    (Cifar10Model, 64),
-    (AlexNet, 8),
-    (InstanceNormResNet18, 16),
-    (GroupNormMobileNetV3Small, 16),
-    (SqueezeNet, 4),
-    (InstanceNormMobileNetV2, 2),
+    (ModuleFactory(WithTransformerLarge), 8),
+    (ModuleFactory(FreeParam), 64),
+    (ModuleFactory(NoFreeParam), 64),
+    (ModuleFactory(Cifar10Model), 64),
+    (ModuleFactory(AlexNet), 8),
+    (ModuleFactory(InstanceNormResNet18), 16),
+    (ModuleFactory(GroupNormMobileNetV3Small), 16),
+    (ModuleFactory(SqueezeNet), 4),
+    (ModuleFactory(InstanceNormMobileNetV2), 2),
 ]
 
 
-def compare_autograd_autojac_and_autogram_speed(architecture: type[ShapedModule], batch_size: int):
-    input_shapes = architecture.INPUT_SHAPES
-    output_shapes = architecture.OUTPUT_SHAPES
+def compare_autograd_autojac_and_autogram_speed(factory: ModuleFactory, batch_size: int):
+    model = factory()
+    input_shapes, output_shapes = get_in_out_shapes(model)
     inputs = make_tensors(batch_size, input_shapes)
     targets = make_tensors(batch_size, output_shapes)
     loss_fn = make_mse_loss_fn(targets)
-
-    model = architecture().to(device=DEVICE)
 
     A = Mean()
     W = A.weighting
 
     print(
-        f"\nTimes for forward + backward on {architecture.__name__} with BS={batch_size}, A={A}"
-        f" on {DEVICE}."
+        f"\nTimes for forward + backward on {factory} with BS={batch_size}, A={A}" f" on {DEVICE}."
     )
 
     def fn_autograd():
@@ -148,8 +146,8 @@ def time_call(fn, init_fn=noop, pre_fn=noop, post_fn=noop, n_runs: int = 10) -> 
 
 
 def main():
-    for architecture, batch_size in PARAMETRIZATIONS:
-        compare_autograd_autojac_and_autogram_speed(architecture, batch_size)
+    for factory, batch_size in PARAMETRIZATIONS:
+        compare_autograd_autojac_and_autogram_speed(factory, batch_size)
         print("\n")
 
 

--- a/tests/utils/forward_backwards.py
+++ b/tests/utils/forward_backwards.py
@@ -4,6 +4,7 @@ import torch
 from torch import Tensor, nn, vmap
 from torch.nn.functional import mse_loss
 from torch.utils._pytree import PyTree, tree_flatten, tree_map
+from utils.architectures import get_in_out_shapes
 
 from torchjd.aggregation import Aggregator, Weighting
 from torchjd.autogram import Engine
@@ -58,7 +59,8 @@ def _forward_pass(
 ) -> PyTree:
     output = model(inputs)
 
-    assert tree_map(lambda t: t.shape[1:], output) == model.OUTPUT_SHAPES
+    _, expected_output_shapes = get_in_out_shapes(model)
+    assert tree_map(lambda t: t.shape[1:], output) == expected_output_shapes
 
     loss_tensors = loss_fn(output)
     losses = reduce_to_vector(loss_tensors)


### PR DESCRIPTION
* Add ModuleFactory and use it to instantiate models in tests
* Add get_in_out_shapes and use it to obtain input and output shapes in tests

The direct consequence is that we can now test model that have `__init__` arguments. These args will be provided to the `ModuleFactory`, and then each instance created will receive these args.

Another nice consequence is that we can now test nn.Module that are not ShapedModule, simply by adding a line in get_in_out_shapes to indicate the formula to get the input and output shapes. So for instance, to test a Linear, one would have to add:
```python
elif isinstance(module, nn.Linear):
    return (module.in_features,), (module.out_features,)
```
in `get_in_out_shapes`, and:
```python
(ModuleFactory(nn.Linear, in_features=3, out_features=5, bias=False)
```
to the `PARAMETRIZATIONS` of `test_engine.py`.

Note that for example for nn.Conv2d, this would be much more complex, because it depends on all the parameters (maybe there are online code snippets to compute this).

We also don't have to worry about device anymore! The factory imports the `DEVICE` from `conftest.py`, and directly moves the created models to it (similarly as the tensor creation functions from `test.utils.tensors.py`).

Lastly, we don't have to worry about resetting the seed to 0 before creating a model. The factory is in charge of forking the rng and setting the seed to 0 before each model creation. Arguably, we could have a `seed: int | None` parameter to the `__call__` method of `ModuleFactory`, so that we can optionally not do that, but for now this is good enough I think.

The downside is that for now, the pytest summary has the name "factory0", "factory1", etc., for the different parametrizations, but this is easy to fix. I'll make another PR to fix this + other parameter name issues with pytest.
