### PR TITLE
test(autogram): Revert to using always using factory

### DIFF
--- a/tests/unit/autogram/test_engine.py
+++ b/tests/unit/autogram/test_engine.py
@@ -309,7 +309,7 @@ def test_compute_partial_gramian(gramian_module_names: set[str], batch_dim: int 
     the model parameters is specified.
     """
 
-    model = SimpleBranched()
+    model = ModuleFactory(SimpleBranched)()
     batch_size = 64
     inputs, targets = make_inputs_and_targets(model, batch_size)
     loss_fn = make_mse_loss_fn(targets)


### PR DESCRIPTION
* It's needed needed to create model on cuda, so without this, tests are broken on cuda
