### PR TITLE
chore: Make Python 3.14 support official

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   UV_NO_SYNC: 1
-  PYTHON_VERSION: '3.13'
+  PYTHON_VERSION: '3.14'
 
 jobs:
   build-deploy-doc:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  PYTHON_VERSION: 3.13
+  PYTHON_VERSION: 3.14
 
 jobs:
   pypi-publish:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   UV_NO_SYNC: 1
-  PYTHON_VERSION: 3.13
+  PYTHON_VERSION: 3.14
 
 jobs:
   tests-full-install:
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false  # Ensure matrix jobs keep running even if one fails
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ changes that do not affect the user.
 - Added usage example for IWRM with autogram.
 - Added usage example for IWRM with partial autogram.
 - Added usage example for IWMTL with autogram.
+- Added Python 3.14 classifier in pyproject.toml (we now also run tests on Python 3.14 in the CI).
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ mandatory, we only provide installation steps with this tool. You can install it
 1) Pre-requisites: Use `uv` to install a Python version compatible with TorchJD and to pin it to the
   `torchjd` folder. From the root of the `torchjd` repo, run:
    ```bash
-   uv python install 3.13.3
-   uv python pin 3.13.3
+   uv python install 3.14.0
+   uv python pin 3.14.0
    ```
 
 2) Create a virtual environment and install the project in it. From the root of `torchjd`, run:

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -5,7 +5,7 @@
 :end-before: <!-- end installation -->
 ```
 
-Note that `torchjd` requires Python 3.10, 3.11, 3.12 or 3.13 and `torch>=2.0`.
+Note that `torchjd` requires Python 3.10, 3.11, 3.12, 3.13 or 3.14 and `torch>=2.0`.
 
 Some aggregators (CAGrad and Nash-MTL) have additional dependencies that are not included by default
 when installing `torchjd`. To install them, you can use:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]


### PR DESCRIPTION
* Add 3.14 to the matrix of tested python versions in tests.yml
* Run build-deploy-docs.yml, release.yml, tests.yml:build-doc and tests.yml:mypy on 3.14
* Say torchjd is compatible with 3.14 in installation.md and add 3.14 classifier in pyproject.toml
* Suggest 3.14 in CONTRIBUTING.md
* Add changelog entry

---

- The badge in README.md will be updated whenever we release. It's based on the classifiers in pyproject.toml.
- Status of python version can be found [here](https://devguide.python.org/versions/). 3.14 was released on october 7, and 3.9 is end of life this month, so torchjd is now compatible with all current python versions (3.10 to 3.14).