### PR TITLE
ci: Install torchjd in editable mode

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies (default with full options & doc)
-        run: uv pip install --python-version=${{ env.PYTHON_VERSION }} '.[full]' --group doc
+        run: uv pip install --python-version=${{ env.PYTHON_VERSION }} -e '.[full]' --group doc
 
       - name: Determine deployment folder
         id: deploy_folder

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install default (with full options) and test dependencies
-        run: uv pip install --python-version=${{ matrix.python-version }} '.[full]' --group test
+        run: uv pip install --python-version=${{ matrix.python-version }} -e '.[full]' --group test
       - name: Run unit and doc tests with coverage report
         run: uv run pytest -W error tests/unit tests/doc --cov=src --cov-report=xml
       - name: Upload results to Codecov
@@ -45,7 +45,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install default (without any option) and test dependencies
-        run: uv pip install --python-version=${{ env.PYTHON_VERSION }} . --group test
+        run: uv pip install --python-version=${{ env.PYTHON_VERSION }} -e . --group test
       - name: Run unit and doc tests with coverage report
         run: |
           uv run pytest -W error tests/unit tests/doc \
@@ -71,7 +71,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies (default with full options & doc)
-        run: uv pip install --python-version=${{ env.PYTHON_VERSION }} '.[full]' --group doc
+        run: uv pip install --python-version=${{ env.PYTHON_VERSION }} -e '.[full]' --group doc
 
       - name: Build Documentation
         working-directory: docs
@@ -90,7 +90,7 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Install dependencies (default with full options & check)
-      run: uv pip install --python-version=${{ env.PYTHON_VERSION }} '.[full]' --group check
+      run: uv pip install --python-version=${{ env.PYTHON_VERSION }} -e '.[full]' --group check
 
     - name: Run mypy
       run: uv run mypy src/torchjd


### PR DESCRIPTION
* pytest-cov does not produce a code coverage report if the project is not installed in editable mode. So this fixes code coverage.
* The -e flag is also added for installations where no code coverage is computed, just in case.