### PR TITLE
ci: Add float64 tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   tests-float64:
-    name: Run tests with on float64 dtype
+    name: Run tests on float64 dtype
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
@PierreQuinton With this we'll automatically test on float64 (but just on ubuntu - python 3.14, I don't think there's a need for other OS or python versions).

I'll also add this new check to the list of required checks to merge a PR.