### PR TITLE
refactor(autojac): Stop cloning in Accumulate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ changelog does not include internal changes that do not affect the user.
 
 ## [Unreleased]
 
+### Changed
+
+- Removed an unnecessary internal cloning of gradient. This should slightly improve the memory
+  efficiency of `autojac`.
+
 ## [0.8.1] - 2026-01-07
 
 ### Added

--- a/tests/unit/autojac/_transform/test_accumulate.py
+++ b/tests/unit/autojac/_transform/test_accumulate.py
@@ -45,11 +45,12 @@ def test_multiple_accumulation(iterations: int):
     value1 = ones_([])
     value2 = ones_([1])
     value3 = ones_([2, 3])
-    input = {key1: value1, key2: value2, key3: value3}
 
     accumulate = Accumulate()
 
     for i in range(iterations):
+        # Clone values to ensure that we accumulate values that are not ever used afterwards
+        input = {key1: value1.clone(), key2: value2.clone(), key3: value3.clone()}
         accumulate(input)
 
     grads = {key1: key1.grad, key2: key2.grad, key3: key3.grad}


### PR DESCRIPTION
This follows our discussion on whether we should clone or not in Accumulate. The change alone made a test fail, but this test was precisely a very weird usage of Accumulate, where the same tensor dict is accumulated multiple times. So I also changed the test. I think this could have a benefit on memory usage, but not sure if this benefit can happen when memory is at its peak usage (at this point, the Jacobian should be aggregated already, so not in memory anymore, so maybe we don't care that much about an extra gradient in memory there until the completion of this function). But I remember correctly, we used to have some out of memory errors during the Accumulate call, so I might be wrong about this.

Anyway, it seems like a strict improvement.
