### PR TITLE
ci: Remove unused YAML anchor

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,8 +52,7 @@ jobs:
         env:
           PYTEST_TORCH_DTYPE: ${{ matrix.dtype || 'float32' }}
 
-      - &upload-codecov
-        name: Upload results to Codecov
+      - name: Upload results to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove the unused `&upload-codecov` YAML anchor from the tests workflow

The anchor was defined but never referenced (no `*upload-codecov` alias), making it useless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)