### PR TITLE
test: Silence `SyntaxWarning` when importing `highspy`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import random as rand
+import warnings
 from contextlib import nullcontext
 
 import torch
@@ -6,6 +7,12 @@ from pytest import RaisesExc, fixture, mark
 from settings import DEVICE
 from torch import Tensor
 from utils.architectures import ModuleFactory
+
+# Because of a SyntaxWarning raised when compiling highspy, we have to filter SyntaxWarning here.
+# It seems that the standard ways of ignoring warnings in pytest do not work, because the problem
+# is already triggered in the conftest.py itself. This line could be removed when
+# https://github.com/ERGO-Code/HiGHS/issues/2777 is fixed and the fix is released.
+warnings.filterwarnings("ignore", category=SyntaxWarning)
 
 from torchjd.aggregation import Aggregator, Weighting
 


### PR DESCRIPTION
Today, [highspy](https://github.com/ERGO-Code/HiGHS) became a core dependency of [cvxpy](https://github.com/cvxpy/cvxpy), which is one of our optional dependencies (installed when specifying `[nashmtl]`, `[cagrad]` or `[full]` optional dependencies when installing torchjd). Most of the CI tests are done with `[full]` install, so they include `cvxpy`, and thus they include `highspy`. Coincidentally, it's actually `qpsolvers` that imports `highspy`, because `highspy` was also already an optional dependency of `qpsolvers`. Now that it's installed (because of `cvxpy`), `qpsolvers` imports it.

The problem is that there's a line of code in `highspy` that triggers a `SyntaxWarning` on python 3.14 (because of [this](https://peps.python.org/pep-0765/) new PEP) when compiling the python file to bytecode (when first importing it). This warning is then transformed into an error by our pytest flag `-W error`. So the CI failed on python 3.14 except in the run using `none` optional dependencies.

Users should barely notice anything:
- If they don't use python 3.14 they won't ever see the warning.
- The warning is only triggered the first time `highs.py` is compiled to bytecode. When using pip, it happens when installing `highspy`. When using `uv`, it happens when importing it for the very first time. The warning should thus appear only once, even if they restart python. In a CI environment where everything is reinstalled, it could appear every time though.
- It's only a warning for them unless they also treat warnings as errors.

This PR silences the warning in our tests so that CI doesn't break (without this, tests will fail at the next scheduled testing tomorrow). I think it's the only way to fix this. I tried adding an option to `pyproject.toml` telling `pytest` to filter out those warnings, but since the warning is raised as early as the `conftest.py` (which imports from `torchjd`, and thus from `qpsolvers` and `highspy`), it didn't work.

Note that when https://github.com/ERGO-Code/HiGHS/issues/2777 gets fixed, we'll be able to remove this warning filterning.

@PierreQuinton FYI