### PR TITLE
refactor(aggregation): Fix typing issue in `Weighting`

### DIFF
--- a/src/torchjd/aggregation/_weighting_bases.py
+++ b/src/torchjd/aggregation/_weighting_bases.py
@@ -8,9 +8,9 @@ from torch import Tensor, nn
 
 from torchjd._linalg import PSDTensor, is_psd_tensor
 
-_T = TypeVar("_T", contravariant=True)
-_FnInputT = TypeVar("_FnInputT")
-_FnOutputT = TypeVar("_FnOutputT")
+_T = TypeVar("_T", contravariant=True, bound=Tensor)
+_FnInputT = TypeVar("_FnInputT", bound=Tensor)
+_FnOutputT = TypeVar("_FnOutputT", bound=Tensor)
 
 
 class Weighting(Generic[_T], nn.Module, ABC):
@@ -27,9 +27,11 @@ class Weighting(Generic[_T], nn.Module, ABC):
     def forward(self, stat: _T) -> Tensor:
         """Computes the vector of weights from the input stat."""
 
-    def __call__(self, stat: _T) -> Tensor:
+    def __call__(self, stat: Tensor) -> Tensor:
         """Computes the vector of weights from the input stat and applies all registered hooks."""
 
+        # The value of _T (e.g. PSDMatrix) is not public, so we need the user-facing type hint of
+        # stat to be Tensor.
         return super().__call__(stat)
 
     def _compose(self, fn: Callable[[_FnInputT], _T]) -> Weighting[_FnInputT]:


### PR DESCRIPTION
Since #522, we don't use type annotations anymore, so a new (user-facing) typing issue that we already had for a long time is now visible: in autogram usage examples, we call `weighting(gramian)` where `gramian` is a `Tensor` (but not a `PSDMatrix`), but `weighting.__call__` expects a `PSDMatrix`.

I changed `weighting.__call__` to rather expect a `Tensor` (like `Aggregator.__call__` expects a `Tensor` and not a `Matrix`). I thus also made the `_T` type variable bound to `Tensor`.

This fixes the issue, but it also doesn't seem to be a very good long-term solution. I don't really like that the user-facing types "lie" to the user. Maybe we could make those types (`Matrix` and `PSDMatrix`) public at some point?