### PR TITLE
test(linalg): Add more tests for `compute_gramian`

### DIFF
--- a/tests/unit/linalg/test_gramian.py
+++ b/tests/unit/linalg/test_gramian.py
@@ -74,7 +74,7 @@ def test_compute_gramian_matrix_input_1():
 def test_compute_gramian_matrix_input_2():
     t = tensor_([[1.0, 2.0], [3.0, 4.0]])
     gramian = compute_gramian(t, contracted_dims=2)
-    expected = tensor_(29.0)
+    expected = tensor_(30.0)
 
     assert_close(gramian, expected)
 


### PR DESCRIPTION
We have a problem in `test_compute_gramian_matrix_input_2`. It's basically computing `tensordot(t, t, dims=2)` instead of `tensordot(t, t.T, dims=2)`. I think there is an error in the logic of `compute_gramian` in:
```python
    indices_source = list(range(t.ndim - contracted_dims))
    indices_dest = list(range(t.ndim - 1, contracted_dims - 1, -1))
```
=> This gives `indices_source=[]` and `indices_dest=[]` for the example of `test_compute_gramian_matrix_input_2` (matrix input, 2 contracted dims) => No transposition.