### PR TITLE
docs: Fix installation suggestion for optional deps 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,9 +106,9 @@ changelog does not include internal changes that do not affect the user.
 ### Changed
 
 - **BREAKING**: Changed the dependencies of `CAGrad` and `NashMTL` to be optional when installing
-  TorchJD. Users of these aggregators will have to use `pip install torchjd[cagrad]`, `pip install
-  torchjd[nash_mtl]` or `pip install torchjd[full]` to install TorchJD alongside those dependencies.
-  This should make TorchJD more lightweight.
+  TorchJD. Users of these aggregators will have to use `pip install "torchjd[cagrad]"`, `pip install
+  "torchjd[nash_mtl]"` or `pip install "torchjd[full]"` to install TorchJD alongside those
+  dependencies. This should make TorchJD more lightweight.
 - **BREAKING**: Made the aggregator modules and the `autojac` package protected. The aggregators
   must now always be imported via their package (e.g.
   `from torchjd.aggregation.upgrad import UPGrad` must be changed to

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -10,13 +10,13 @@ Note that `torchjd` requires Python 3.10, 3.11, 3.12, 3.13 or 3.14 and `torch>=2
 Some aggregators (CAGrad and Nash-MTL) have additional dependencies that are not included by default
 when installing `torchjd`. To install them, you can use:
 ```
-pip install torchjd[cagrad]
+pip install "torchjd[cagrad]"
 ```
 ```
-pip install torchjd[nash_mtl]
+pip install "torchjd[nash_mtl]"
 ```
 
 To install `torchjd` with all of its optional dependencies, you can also use:
 ```
-pip install torchjd[full]
+pip install "torchjd[full]"
 ```

--- a/src/torchjd/aggregation/_cagrad.py
+++ b/src/torchjd/aggregation/_cagrad.py
@@ -31,7 +31,7 @@ class CAGrad(GramianWeightedAggregator):
         This aggregator is not installed by default. When not installed, trying to import it should
         result in the following error:
         ``ImportError: cannot import name 'CAGrad' from 'torchjd.aggregation'``.
-        To install it, use ``pip install torchjd[cagrad]``.
+        To install it, use ``pip install "torchjd[cagrad]"``.
     """
 
     def __init__(self, c: float, norm_eps: float = 0.0001):

--- a/src/torchjd/aggregation/_nash_mtl.py
+++ b/src/torchjd/aggregation/_nash_mtl.py
@@ -59,7 +59,7 @@ class NashMTL(WeightedAggregator):
         This aggregator is not installed by default. When not installed, trying to import it should
         result in the following error:
         ``ImportError: cannot import name 'NashMTL' from 'torchjd.aggregation'``.
-        To install it, use ``pip install torchjd[nash_mtl]``.
+        To install it, use ``pip install "torchjd[nash_mtl]"``.
 
     .. warning::
         This implementation was adapted from the `official implementation


### PR DESCRIPTION
Maybe it's specific to zsh, but with `pip install torchjd[full]` I get `zsh: no matches found: torchjd[full]`. With the quotes it works both with `pip install` and `uv pip install`.