### PR TITLE
chore: Ignore ruff rule COM812 to avoid formatter conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ ignore = [
     "RUF010",  # Use explicit conversion flag
     "RUF012",  # Mutable default value for class attribute (a bit tedious to fix)
     "RET504",  # Unnecessary assignment return statement
+    "COM812",  # Trailing comma missing (conflicts with formatter, see https://github.com/astral-sh/ruff/issues/9216)
 ]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
Add COM812 to the ruff ignore list as it conflicts with the formatter.
See https://github.com/astral-sh/ruff/issues/9216 for details.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
