### PR TITLE
chore: Add ARG rule to ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ select = [
     "W",    # pycodestyle Warning
     "I",    # isort
     "UP",   # pyupgrade
+    "ARG",  # flake8-unused-arguments
     "B",    # flake8-bugbear
     "C4",   # flake8-comprehensions
     "FIX",  # flake8-fixme
@@ -156,6 +157,10 @@ ignore = [
     "RET504",  # Unnecessary assignment return statement
     "COM812",  # Trailing comma missing (conflicts with formatter, see https://github.com/astral-sh/ruff/issues/9216)
 ]
+
+[tool.ruff.lint.per-file-ignores]
+"**/conftest.py" = ["ARG"]  # Can't change argument names in the functions pytest expects
+"tests/doc/test_rst.py" = ["ARG"]  # For the lightning example
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/torchjd/autogram/_module_hook_manager.py
+++ b/src/torchjd/autogram/_module_hook_manager.py
@@ -101,7 +101,7 @@ class Hook:
 
     def __call__(
         self,
-        module: nn.Module,
+        _module: nn.Module,
         args: tuple[PyTree, ...],
         kwargs: dict[str, PyTree],
         outputs: PyTree,
@@ -157,11 +157,11 @@ class AutogramNode(torch.autograd.Function):
 
     @staticmethod
     def forward(
-        gramian_accumulation_phase: BoolRef,
-        gramian_computer: GramianComputer,
-        args: tuple[PyTree, ...],
-        kwargs: dict[str, PyTree],
-        gramian_accumulator: GramianAccumulator,
+        _gramian_accumulation_phase: BoolRef,
+        _gramian_computer: GramianComputer,
+        _args: tuple[PyTree, ...],
+        _kwargs: dict[str, PyTree],
+        _gramian_accumulator: GramianAccumulator,
         *rg_tensors: Tensor,
     ) -> tuple[Tensor, ...]:
         return tuple(t.detach() for t in rg_tensors)

--- a/src/torchjd/autojac/_jac_to_grad.py
+++ b/src/torchjd/autojac/_jac_to_grad.py
@@ -75,7 +75,7 @@ def jac_to_grad(
 
     jacobian_matrix = _unite_jacobians(jacobians)
     gradient_vector = aggregator(jacobian_matrix)
-    gradients = _disunite_gradient(gradient_vector, jacobians, tensors_)
+    gradients = _disunite_gradient(gradient_vector, tensors_)
     accumulate_grads(tensors_, gradients)
 
 
@@ -87,7 +87,6 @@ def _unite_jacobians(jacobians: list[Tensor]) -> Tensor:
 
 def _disunite_gradient(
     gradient_vector: Tensor,
-    jacobians: list[Tensor],
     tensors: list[TensorWithJac],
 ) -> list[Tensor]:
     gradient_vectors = gradient_vector.split([t.numel() for t in tensors])

--- a/src/torchjd/autojac/_transform/_accumulate.py
+++ b/src/torchjd/autojac/_transform/_accumulate.py
@@ -18,7 +18,7 @@ class AccumulateGrad(Transform):
         accumulate_grads(gradients.keys(), gradients.values())
         return {}
 
-    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+    def check_keys(self, _input_keys: set[Tensor], /) -> set[Tensor]:
         return set()
 
 
@@ -35,5 +35,5 @@ class AccumulateJac(Transform):
         accumulate_jacs(jacobians.keys(), jacobians.values())
         return {}
 
-    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+    def check_keys(self, _input_keys: set[Tensor], /) -> set[Tensor]:
         return set()

--- a/src/torchjd/autojac/_transform/_base.py
+++ b/src/torchjd/autojac/_transform/_base.py
@@ -43,7 +43,7 @@ class Transform(ABC):
         """Applies the transform to the input."""
 
     @abstractmethod
-    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+    def check_keys(self, input_keys: set[Tensor], /) -> set[Tensor]:
         """
         Checks that the provided input_keys satisfy the transform's requirements and returns the
         corresponding output keys for recursion.
@@ -78,7 +78,7 @@ class Composition(Transform):
         intermediate = self.inner(input)
         return self.outer(intermediate)
 
-    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+    def check_keys(self, input_keys: set[Tensor], /) -> set[Tensor]:
         intermediate_keys = self.inner.check_keys(input_keys)
         output_keys = self.outer.check_keys(intermediate_keys)
         return output_keys
@@ -111,7 +111,7 @@ class Conjunction(Transform):
             union |= transform(tensor_dict)
         return union
 
-    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+    def check_keys(self, input_keys: set[Tensor], /) -> set[Tensor]:
         output_keys_list = [key for t in self.transforms for key in t.check_keys(input_keys)]
         output_keys = set(output_keys_list)
 

--- a/src/torchjd/autojac/_transform/_diagonalize.py
+++ b/src/torchjd/autojac/_transform/_diagonalize.py
@@ -69,7 +69,7 @@ class Diagonalize(Transform):
         }
         return diagonalized_tensors
 
-    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+    def check_keys(self, input_keys: set[Tensor], /) -> set[Tensor]:
         if not set(self.key_order) == input_keys:
             raise RequirementError(
                 f"The input_keys must match the key_order. Found input_keys {input_keys} and"

--- a/src/torchjd/autojac/_transform/_differentiate.py
+++ b/src/torchjd/autojac/_transform/_differentiate.py
@@ -55,7 +55,7 @@ class Differentiate(Transform, ABC):
         tensor_outputs should be.
         """
 
-    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+    def check_keys(self, input_keys: set[Tensor], /) -> set[Tensor]:
         outputs = set(self.outputs)
         if not outputs == input_keys:
             raise RequirementError(

--- a/src/torchjd/autojac/_transform/_init.py
+++ b/src/torchjd/autojac/_transform/_init.py
@@ -16,10 +16,10 @@ class Init(Transform):
     def __init__(self, values: AbstractSet[Tensor]):
         self.values = values
 
-    def __call__(self, input: TensorDict, /) -> TensorDict:
+    def __call__(self, _input: TensorDict, /) -> TensorDict:
         return {value: torch.ones_like(value) for value in self.values}
 
-    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+    def check_keys(self, input_keys: set[Tensor], /) -> set[Tensor]:
         if not input_keys == set():
             raise RequirementError(
                 f"The input_keys should be the empty set. Found input_keys {input_keys}.",

--- a/src/torchjd/autojac/_transform/_select.py
+++ b/src/torchjd/autojac/_transform/_select.py
@@ -19,7 +19,7 @@ class Select(Transform):
         output = {key: tensor_dict[key] for key in self.keys}
         return type(tensor_dict)(output)
 
-    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+    def check_keys(self, input_keys: set[Tensor], /) -> set[Tensor]:
         keys = set(self.keys)
         if not keys.issubset(input_keys):
             raise RequirementError(

--- a/src/torchjd/autojac/_transform/_stack.py
+++ b/src/torchjd/autojac/_transform/_stack.py
@@ -28,7 +28,7 @@ class Stack(Transform):
         result = _stack(results)
         return result
 
-    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+    def check_keys(self, input_keys: set[Tensor], /) -> set[Tensor]:
         return {key for transform in self.transforms for key in transform.check_keys(input_keys)}
 
 

--- a/tests/unit/autojac/_transform/test_base.py
+++ b/tests/unit/autojac/_transform/test_base.py
@@ -17,12 +17,12 @@ class FakeTransform(Transform):
     def __str__(self):
         return "T"
 
-    def __call__(self, input: TensorDict, /) -> TensorDict:
+    def __call__(self, _input: TensorDict, /) -> TensorDict:
         # Ignore the input, create a dictionary with the right keys as an output.
         output_dict = {key: empty_(0) for key in self._output_keys}
         return output_dict
 
-    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+    def check_keys(self, input_keys: set[Tensor], /) -> set[Tensor]:
         # Arbitrary requirement for testing purposes.
         if not input_keys == self._required_keys:
             raise RequirementError()

--- a/tests/unit/autojac/_transform/test_stack.py
+++ b/tests/unit/autojac/_transform/test_stack.py
@@ -15,10 +15,10 @@ class FakeGradientsTransform(Transform):
     def __init__(self, keys: Iterable[Tensor]):
         self.keys = set(keys)
 
-    def __call__(self, input: TensorDict, /) -> TensorDict:
+    def __call__(self, _input: TensorDict, /) -> TensorDict:
         return {key: torch.ones_like(key) for key in self.keys}
 
-    def check_keys(self, input_keys: set[Tensor]) -> set[Tensor]:
+    def check_keys(self, _input_keys: set[Tensor], /) -> set[Tensor]:
         return self.keys
 
 


### PR DESCRIPTION
* Add ARG rule to ruff
* Add [tool.ruff.lint.per-file-ignores] to ignore the ARG rule in `conftest.py` and `test_rst.py`
* Add `_` in front of unused parameter names that we have to keep
* Remove unused `jacobians` parameter of `_disunite_gradient`
* Make the `input_keys` parameter of `check_keys` positional-only, so that we can rename it in subclasses

@PierreQuinton FYI
