### PR TITLE
ci: Add title checker action

### DIFF
--- a/.github/workflows/title-checker.yml
+++ b/.github/workflows/title-checker.yml
@@ -1,7 +1,7 @@
 name: PR Title Checker
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened]
 
 jobs:
@@ -75,6 +75,7 @@ jobs:
               owner,
               repo,
               issue_number: pr_number,
+              per_page: 100,
             });
             const managedPrefixes = ['cc: ', 'package: '];
             const labelsToRemove = prLabels.data


### PR DESCRIPTION
A rule that is not enforced is not a rule.

This checks
- that the title is at most 72 chars long
- that it is a conventional commit (from label list with format `cc: *`)
- it can have optional `(*)` where `*` has associated label of the form `package: *`
- it can have optional `!` with associated label `breaking-change`
- then follows `: ` and a capital letter followed by the rest of the description.

It cleans up labels of those types, then adds all the associated labels to the PR and is run on edits of the PR. We could improve messages but this is not needed yet.