### PR TITLE
chore: Add governance documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# These owners will be the default owners for everything in the repo.
-*       @ValerianRey @PierreQuinton

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# These owners will be the default owners for everything in the repo.
+*       @ValerianRey @PierreQuinton

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,6 +11,9 @@
 #
 # Note: Ownership for new packages should be decided by the maintainers and SimplexLab.
 
+# Default owners for the entire repository
+*    @SimplexLab/maintainers
+
 # CI workflows
 /.github/workflows/    @PierreQuinton @ValerianRey
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,15 @@
 # Each line contains a pattern followed by one or more owners (GitHub usernames or team names).
 # Patterns use gitignore-style glob patterns.
 #
-# For more information, see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# For more information, see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customifying-your-repository/about-code-owners
+#
+# Note: Ownership for new packages should be decided by the maintainers and SimplexLab.
 
-# All Python source files are owned by Pierre Quinton and Valérian Rey
-/src/**/*.py    @PierreQuinton @ValerianRey
+# CI workflows
+/.github/workflows/    @PierreQuinton @ValerianRey
+
+# Python packages in src/torchjd
+/src/torchjd/_linalg/    @PierreQuinton @ValerianRey
+/src/torchjd/aggregation/    @PierreQuinton @ValerianRey
+/src/torchjd/autogram/    @PierreQuinton @ValerianRey
+/src/torchjd/autojac/    @PierreQuinton @ValerianRey

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# Code Owners for TorchJD
+#
+# This file defines the code owners for the repository. When a pull request is opened,
+# GitHub automatically requests reviews from the appropriate code owners based on the
+# files changed.
+#
+# Each line contains a pattern followed by one or more owners (GitHub usernames or team names).
+# Patterns use gitignore-style glob patterns.
+#
+# For more information, see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# All Python source files are owned by Pierre Quinton and Valérian Rey
+/src/**/*.py    @PierreQuinton @ValerianRey

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,7 @@
+# Code of Conduct
+
+TorchJD follows the [Linux Foundation Code of Conduct](https://lfprojects.org/policies/code-of-conduct/).
+
+## Changes to this Code of Conduct
+
+Changes to this Code of Conduct require approval from all maintainers.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@ TorchJD follows the [Linux Foundation Code of Conduct](https://lfprojects.org/po
 
 ## Project Ownership
 
-The TorchJD project is the property of SimplexLab. SimplexLab has full authority over theproject and its governance, while maintainers are responsible for day-to-day operations and technical decisions. Maintainers are typically members of SimplexLab.
+The TorchJD project is the property of SimplexLab. SimplexLab has full authority over the project and its governance, while maintainers are responsible for day-to-day operations and technical decisions. Maintainers are typically members of SimplexLab.
 
 ## Changes to this Code of Conduct
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,6 +2,10 @@
 
 TorchJD follows the [Linux Foundation Code of Conduct](https://lfprojects.org/policies/code-of-conduct/).
 
+## Project Ownership
+
+The TorchJD project is the property of SimplexLab. SimplexLab has full authority over theproject and its governance, while maintainers are responsible for day-to-day operations and technical decisions. Maintainers are typically members of SimplexLab.
+
 ## Changes to this Code of Conduct
 
-Changes to this Code of Conduct require approval from all maintainers.
+Changes to this Code of Conduct can only be made upon request from SimplexLab, which defines when and how such changes are possible.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,10 +2,6 @@
 
 TorchJD follows the [Linux Foundation Code of Conduct](https://lfprojects.org/policies/code-of-conduct/).
 
-## Project Ownership
-
-The TorchJD project is the property of SimplexLab. SimplexLab has full authority over the project and its governance, while maintainers are responsible for day-to-day operations and technical decisions. Maintainers are typically members of SimplexLab.
-
 ## Changes to this Code of Conduct
 
 Changes to this Code of Conduct can only be made upon request from SimplexLab, which defines when and how such changes are possible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,11 @@
 # Contributing to TorchJD
 
-This document explains how to contribute to TorchJD. Please use issues or discussions to communicate
-with maintainers before implementing major changes.
+This document explains how to contribute to TorchJD.
+
+## Getting Started
+
+- **Minor changes** (bug fixes, documentation, small improvements): Open a pull request directly following the guidelines in this document.
+- **Significant or major changes** (new features, API changes, architectural decisions): Join the [SimplexLab Discord server](https://discord.gg/76KkRnb3nk), introduce yourself and your idea, and discuss it with the community to determine if and how it fits within the project's goals before implementing.
 
 ## Code Ownership
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,16 @@
 This document explains how to contribute to TorchJD. Please use issues or discussions to communicate
 with maintainers before implementing major changes.
 
+## Code Ownership
+
+This project uses a [CODEOWNERS](CODEOWNERS) file to automatically assign reviewers to pull requests
+based on which files are changed. The code owners are the people or groups who created or maintain
+specific parts of the codebase.
+
+When you open a pull request, GitHub will automatically request reviews from the relevant code owners
+for the files you've modified. This ensures that changes are reviewed by the people most familiar
+with the affected code.
+
 ## Installation
 
 To work with TorchJD, we suggest you to use [uv](https://docs.astral.sh/uv/). While this is not

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,7 +4,7 @@ This document defines the governance structure and decision-making process for t
 
 ## Project Ownership
 
-The TorchJD project is the property of SimplexLab. SimplexLab has full authority over the project, including itsdirection, governance structure, and major decisions. Maintainers are typically members of SimplexLab and are responsible for day-to-day operations, code reviews, and technical decisions.
+The TorchJD project is the property of SimplexLab. SimplexLab has full authority over the project, including its direction, governance structure, and major decisions. Maintainers are typically members of SimplexLab and are responsible for day-to-day operations, code reviews, and technical decisions.
 
 ## Maintainers
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,73 @@
+# TorchJD Governance
+
+This document defines the governance structure and decision-making process for the TorchJD project.
+
+## Maintainers
+
+TorchJD is maintained by:
+
+- **Valérian Rey** ([@ValerianRey](https://github.com/ValerianRey))
+- **Pierre Quinton** ([@PierreQuinton](https://github.com/PierreQuinton))
+
+Maintainers are responsible for:
+- Reviewing and merging pull requests
+- Managing releases
+- Setting project direction and priorities
+- Ensuring code quality and consistency
+
+## Decision Making
+
+### Technical Decisions
+
+Most technical decisions are made through the pull request process:
+
+1. **Minor changes** (bug fixes, documentation, small improvements): Require approval from at least one maintainer
+2. **Significant changes** (new features, API changes, refactoring): Should be discussed in an issue first, then require approval from at least one maintainer
+3. **Major changes** (breaking changes, architectural decisions): Should be discussed in an issue or discussion thread and require consensus from all maintainers
+
+### Pull Request Process
+
+1. Contributors submit pull requests following the guidelines in [CONTRIBUTING.md](CONTRIBUTING.md)
+2. Maintainers review the code for correctness, style, and alignment with project goals
+3. Once approved, any maintainer can merge the pull request
+4. All pull requests must pass CI checks before being merged
+
+### Consensus
+
+For major decisions, maintainers aim for consensus. If consensus cannot be reached:
+- The decision may be postponed for further discussion
+- If a decision must be made, the maintainer with the most relevant expertise in the area makes the final call
+
+## Release Process
+
+Releases are managed by maintainers following the process described in [CONTRIBUTING.md](CONTRIBUTING.md):
+
+1. Ensure all tests pass
+2. Update the changelog
+3. Update the version number
+4. Create a release on GitHub
+5. Verify deployment to PyPI
+
+## Adding Maintainers
+
+New maintainers may be added when:
+- They have made significant, sustained contributions to the project
+- They demonstrate understanding of the project's goals and coding standards
+- They are committed to the long-term maintenance of the project
+
+New maintainers must be approved by all existing maintainers.
+
+## Conflict Resolution
+
+Conflicts are resolved through discussion:
+1. Issues should first be discussed in the relevant issue or pull request
+2. If unresolved, maintainers discuss privately to reach consensus
+3. The goal is always to find the best solution for the project and its users
+
+## Code of Conduct
+
+This project follows the [Linux Foundation Code of Conduct](https://lfprojects.org/policies/code-of-conduct/).
+
+## Changes to Governance
+
+Changes to this governance document require approval from all maintainers.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,6 +2,10 @@
 
 This document defines the governance structure and decision-making process for the TorchJD project.
 
+## Project Ownership
+
+The TorchJD project is the property of SimplexLab. SimplexLab has full authority over the project, including itsdirection, governance structure, and major decisions. Maintainers are typically members of SimplexLab and are responsible for day-to-day operations, code reviews, and technical decisions.
+
 ## Maintainers
 
 TorchJD is maintained by:
@@ -34,9 +38,9 @@ Most technical decisions are made through the pull request process:
 
 ### Consensus
 
-For major decisions, maintainers aim for consensus. If consensus cannot be reached:
+For major decisions, maintainers aim for consensus. SimplexLab operates as a democratic decision-making body. If consensus among maintainers cannot be reached:
 - The decision may be postponed for further discussion
-- If a decision must be made, the maintainer with the most relevant expertise in the area makes the final call
+- If a decision must be made, SimplexLab resolves the consensus based on the expertise of all maintainers relevant to the discussion as well as all people involved in the discussion
 
 ## Release Process
 
@@ -55,14 +59,15 @@ New maintainers may be added when:
 - They demonstrate understanding of the project's goals and coding standards
 - They are committed to the long-term maintenance of the project
 
-New maintainers must be approved by all existing maintainers.
+New maintainers must be approved by SimplexLab, based on the report and recommendation of all existing maintainers.
 
 ## Conflict Resolution
 
 Conflicts are resolved through discussion:
 1. Issues should first be discussed in the relevant issue or pull request
 2. If unresolved, maintainers discuss privately to reach consensus
-3. The goal is always to find the best solution for the project and its users
+3. If maintainers cannot reach consensus, SimplexLab has the final authority to resolve the conflict
+4. The goal is always to find the best solution for the project and its users
 
 ## Code of Conduct
 
@@ -70,4 +75,4 @@ This project follows the [Linux Foundation Code of Conduct](https://lfprojects.o
 
 ## Changes to Governance
 
-Changes to this governance document require approval from all maintainers.
+Changes to this governance document can only be made upon request from SimplexLab, which defines when and how such changes are possible.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -29,6 +29,8 @@ Most technical decisions are made through the pull request process:
 2. **Significant changes** (new features, API changes, refactoring): Should be discussed in an issue first, then require approval from at least one maintainer
 3. **Major changes** (breaking changes, architectural decisions): Should be discussed in an issue or discussion thread and require consensus from all maintainers
 
+For significant or major changes, contributors should join the [SimplexLab Discord server](https://discord.gg/76KkRnb3nk), introduce themselves and their idea, and discuss it with the community to determine if and how it fits within the project's goals.
+
 ### Pull Request Process
 
 1. Contributors submit pull requests following the guidelines in [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
- Add GOVERNANCE.md documenting technical governance structure
- Add CODEOWNERS file defining project maintainers
- Add CODE_OF_CONDUCT.md referencing Linux Foundation CoC

These files are required for PyTorch Ecosystem membership.