### PR TITLE
docs: Fix linkcode_resolve

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,8 +97,7 @@ def linkcode_resolve(domain: str, info: dict[str, str]) -> str | None:
     try:
         obj = _get_obj(info)
     except AttributeError:
-        # This can happen when trying to get a field typed at the class level, e.g. the
-        # gramian_weighting attribute of GramianWeightedAggregator.
+        # This can happen when trying to get a field typed at the class level.
         return None
     file_name = _get_file_name(obj)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,7 +94,12 @@ def linkcode_resolve(domain: str, info: dict[str, str]) -> str | None:
     if domain != "py" or not info["module"]:
         return None
 
-    obj = _get_obj(info)
+    try:
+        obj = _get_obj(info)
+    except AttributeError:
+        # This can happen when trying to get a field typed at the class level, e.g. the
+        # gramian_weighting attribute of GramianWeightedAggregator.
+        return None
     file_name = _get_file_name(obj)
 
     if not file_name:


### PR DESCRIPTION
When tinkering in another PR, I realized that `linkcode_resolve` doesn't work when a field is type-hinted at the class level, e.g.
```python
class MyClass:
    my_field: MyType

    def __init__(self, value: MyType) -> None:
        self.my_field = value
```

This PR fixes this.
