### PR TITLE
docs: Simplify autoclass in docs

### DIFF
--- a/docs/source/docs/aggregation/aligned_mtl.rst
+++ b/docs/source/docs/aggregation/aligned_mtl.rst
@@ -4,11 +4,5 @@ Aligned-MTL
 ===========
 
 .. autoclass:: torchjd.aggregation.AlignedMTL
-    :members:
-    :undoc-members:
-    :exclude-members: forward
 
 .. autoclass:: torchjd.aggregation.AlignedMTLWeighting
-    :members:
-    :undoc-members:
-    :exclude-members: forward

--- a/docs/source/docs/aggregation/cagrad.rst
+++ b/docs/source/docs/aggregation/cagrad.rst
@@ -4,11 +4,5 @@ CAGrad
 ======
 
 .. autoclass:: torchjd.aggregation.CAGrad
-    :members:
-    :undoc-members:
-    :exclude-members: forward
 
 .. autoclass:: torchjd.aggregation.CAGradWeighting
-    :members:
-    :undoc-members:
-    :exclude-members: forward

--- a/docs/source/docs/aggregation/config.rst
+++ b/docs/source/docs/aggregation/config.rst
@@ -4,6 +4,3 @@ ConFIG
 ======
 
 .. autoclass:: torchjd.aggregation.ConFIG
-    :members:
-    :undoc-members:
-    :exclude-members: forward

--- a/docs/source/docs/aggregation/constant.rst
+++ b/docs/source/docs/aggregation/constant.rst
@@ -4,11 +4,5 @@ Constant
 ========
 
 .. autoclass:: torchjd.aggregation.Constant
-    :members:
-    :undoc-members:
-    :exclude-members: forward
 
 .. autoclass:: torchjd.aggregation.ConstantWeighting
-    :members:
-    :undoc-members:
-    :exclude-members: forward

--- a/docs/source/docs/aggregation/dualproj.rst
+++ b/docs/source/docs/aggregation/dualproj.rst
@@ -4,11 +4,5 @@ DualProj
 ========
 
 .. autoclass:: torchjd.aggregation.DualProj
-    :members:
-    :undoc-members:
-    :exclude-members: forward
 
 .. autoclass:: torchjd.aggregation.DualProjWeighting
-    :members:
-    :undoc-members:
-    :exclude-members: forward

--- a/docs/source/docs/aggregation/flattening.rst
+++ b/docs/source/docs/aggregation/flattening.rst
@@ -4,6 +4,3 @@ Flattening
 ==========
 
 .. autoclass:: torchjd.aggregation.Flattening
-    :members:
-    :undoc-members:
-    :exclude-members: forward

--- a/docs/source/docs/aggregation/graddrop.rst
+++ b/docs/source/docs/aggregation/graddrop.rst
@@ -4,6 +4,3 @@ GradDrop
 ========
 
 .. autoclass:: torchjd.aggregation.GradDrop
-    :members:
-    :undoc-members:
-    :exclude-members: forward

--- a/docs/source/docs/aggregation/gradvac.rst
+++ b/docs/source/docs/aggregation/gradvac.rst
@@ -4,11 +4,7 @@ GradVac
 =======
 
 .. autoclass:: torchjd.aggregation.GradVac
-    :members:
-    :undoc-members:
-    :exclude-members: forward, eps, beta
+    :members: reset
 
 .. autoclass:: torchjd.aggregation.GradVacWeighting
-    :members:
-    :undoc-members:
-    :exclude-members: forward, eps, beta
+    :members: reset

--- a/docs/source/docs/aggregation/imtl_g.rst
+++ b/docs/source/docs/aggregation/imtl_g.rst
@@ -4,11 +4,5 @@ IMTL-G
 ======
 
 .. autoclass:: torchjd.aggregation.IMTLG
-    :members:
-    :undoc-members:
-    :exclude-members: forward
 
 .. autoclass:: torchjd.aggregation.IMTLGWeighting
-    :members:
-    :undoc-members:
-    :exclude-members: forward

--- a/docs/source/docs/aggregation/index.rst
+++ b/docs/source/docs/aggregation/index.rst
@@ -8,23 +8,13 @@ Abstract base classes
 ---------------------
 
 .. autoclass:: torchjd.aggregation.Aggregator
-    :members:
-    :undoc-members:
-    :exclude-members: forward
 
 .. autoclass:: torchjd.aggregation.Weighting
-    :members:
-    :undoc-members:
-    :exclude-members: forward
 
 .. autoclass:: torchjd.aggregation.GeneralizedWeighting
-    :members:
-    :undoc-members:
-    :exclude-members: forward
 
 .. autoclass:: torchjd.aggregation.Stateful
-    :members:
-    :undoc-members:
+    :members: reset
 
 
 .. toctree::

--- a/docs/source/docs/aggregation/krum.rst
+++ b/docs/source/docs/aggregation/krum.rst
@@ -4,11 +4,5 @@ Krum
 ====
 
 .. autoclass:: torchjd.aggregation.Krum
-    :members:
-    :undoc-members:
-    :exclude-members: forward
 
 .. autoclass:: torchjd.aggregation.KrumWeighting
-    :members:
-    :undoc-members:
-    :exclude-members: forward

--- a/docs/source/docs/aggregation/mean.rst
+++ b/docs/source/docs/aggregation/mean.rst
@@ -4,11 +4,5 @@ Mean
 ====
 
 .. autoclass:: torchjd.aggregation.Mean
-    :members:
-    :undoc-members:
-    :exclude-members: forward
 
 .. autoclass:: torchjd.aggregation.MeanWeighting
-    :members:
-    :undoc-members:
-    :exclude-members: forward

--- a/docs/source/docs/aggregation/mgda.rst
+++ b/docs/source/docs/aggregation/mgda.rst
@@ -4,11 +4,5 @@ MGDA
 ====
 
 .. autoclass:: torchjd.aggregation.MGDA
-    :members:
-    :undoc-members:
-    :exclude-members: forward
 
 .. autoclass:: torchjd.aggregation.MGDAWeighting
-    :members:
-    :undoc-members:
-    :exclude-members: forward

--- a/docs/source/docs/aggregation/nash_mtl.rst
+++ b/docs/source/docs/aggregation/nash_mtl.rst
@@ -4,6 +4,4 @@ Nash-MTL
 ========
 
 .. autoclass:: torchjd.aggregation.NashMTL
-    :members:
-    :undoc-members:
-    :exclude-members: forward
+    :members: reset

--- a/docs/source/docs/aggregation/pcgrad.rst
+++ b/docs/source/docs/aggregation/pcgrad.rst
@@ -4,11 +4,5 @@ PCGrad
 ======
 
 .. autoclass:: torchjd.aggregation.PCGrad
-    :members:
-    :undoc-members:
-    :exclude-members: forward
 
 .. autoclass:: torchjd.aggregation.PCGradWeighting
-    :members:
-    :undoc-members:
-    :exclude-members: forward

--- a/docs/source/docs/aggregation/random.rst
+++ b/docs/source/docs/aggregation/random.rst
@@ -4,11 +4,5 @@ Random
 ======
 
 .. autoclass:: torchjd.aggregation.Random
-    :members:
-    :undoc-members:
-    :exclude-members: forward
 
 .. autoclass:: torchjd.aggregation.RandomWeighting
-    :members:
-    :undoc-members:
-    :exclude-members: forward

--- a/docs/source/docs/aggregation/sum.rst
+++ b/docs/source/docs/aggregation/sum.rst
@@ -4,11 +4,5 @@ Sum
 ===
 
 .. autoclass:: torchjd.aggregation.Sum
-    :members:
-    :undoc-members:
-    :exclude-members: forward
 
 .. autoclass:: torchjd.aggregation.SumWeighting
-    :members:
-    :undoc-members:
-    :exclude-members: forward

--- a/docs/source/docs/aggregation/trimmed_mean.rst
+++ b/docs/source/docs/aggregation/trimmed_mean.rst
@@ -4,6 +4,3 @@ Trimmed Mean
 ============
 
 .. autoclass:: torchjd.aggregation.TrimmedMean
-    :members:
-    :undoc-members:
-    :exclude-members: forward

--- a/docs/source/docs/aggregation/upgrad.rst
+++ b/docs/source/docs/aggregation/upgrad.rst
@@ -4,11 +4,5 @@ UPGrad
 ======
 
 .. autoclass:: torchjd.aggregation.UPGrad
-    :members:
-    :undoc-members:
-    :exclude-members: forward
 
 .. autoclass:: torchjd.aggregation.UPGradWeighting
-    :members:
-    :undoc-members:
-    :exclude-members: forward


### PR DESCRIPTION
The idea here is to stop using a bare `:members:` (that asks to document every member) and then opt out members that we don't want to appear, and instead add `:member:` with only members that we want to appear. So this doesn't change anything but makes things easier to maintain (do not have to opt out for every little member that no one should care about).

In a future PR I'll add `__call__` to `:members:` so that we can also have a doc entry for this very important function.
