### PR TITLE
ci: Check title length before skipping already-formatted titles

### DIFF
--- a/.github/workflows/title-formatter.yml
+++ b/.github/workflows/title-formatter.yml
@@ -53,16 +53,16 @@ jobs:
             if (isBreaking) newTitle += '!';
             newTitle += `: ${description}`;
 
-            if (rawTitle === newTitle) {
-              console.log("Title is already correctly formatted. Skipping update.");
-              return;
-            }
-
             const displayTitle = `${newTitle} (#${pr_number})`;
             if (displayTitle.length > 72) {
               core.setFailed(
                 `Formatted title is too long by ${displayTitle.length - 72} characters: "${displayTitle}"`
               );
+              return;
+            }
+
+            if (rawTitle === newTitle) {
+              console.log("Title is already correctly formatted. Skipping update.");
               return;
             }
 


### PR DESCRIPTION
Done with claude but I wanted to do the same change.

- The length check was placed *after* the early-return guard that exits when `rawTitle === newTitle`
- A PR whose title was already in the correct format but exceeded 72 characters would pass the workflow without error (false negative) => https://github.com/SimplexLab/TorchJD/commit/eeff844b57939755f48a23b4c0c05351ed02afdb
- Fix: move the length check before the early-return guard so it always runs regardless of whether the title needs updating
