### PR TITLE
refactor(linalg): Make Matrix and PSDMatrix public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ changelog does not include internal changes that do not affect the user.
 
 ### Added
 
-- Made `WeightedAggregator`, `GramianWeightedAggregator`, `MatrixWeighting`, and `GramianWeighting`
-  public. These abstract base classes are now importable from `torchjd.aggregation` and documented.
-  They can be extended to easily implement custom `Weighting`s and `Aggregator`s.
+- Made `WeightedAggregator` and `GramianWeightedAggregator` public. These abstract base classes are
+  now importable from `torchjd.aggregation` and documented. They can be extended to easily implement
+  custom `Aggregator`s.
+- Made `Matrix` and `PSDMatrix` public. These type annotation classes are now importable from
+  `torchjd.linalg` and documented. Users can now subclass `Weighting[Matrix]` or
+  `Weighting[PSDMatrix]` to implement custom `Weighting`s.
 - Added getters and setters for the constructor parameters of all aggregators and weightings, so
   that they can be changed after initialization. This includes: `pref_vector`,
   `norm_eps` and `reg_eps` in `UPGrad`, `UPGradWeighting`, `DualProj` and `DualProjWeighting`;

--- a/docs/source/docs/aggregation/index.rst
+++ b/docs/source/docs/aggregation/index.rst
@@ -19,12 +19,6 @@ Abstract base classes
 .. autoclass:: torchjd.aggregation.Weighting
     :members: __call__
 
-.. autoclass:: torchjd.aggregation.MatrixWeighting
-    :members: __call__
-
-.. autoclass:: torchjd.aggregation.GramianWeighting
-    :members: __call__
-
 .. autoclass:: torchjd.aggregation.GeneralizedWeighting
     :members: __call__
 

--- a/docs/source/docs/linalg/index.rst
+++ b/docs/source/docs/linalg/index.rst
@@ -1,0 +1,12 @@
+linalg
+======
+
+.. automodule:: torchjd.linalg
+   :no-members:
+
+.. toctree::
+    :hidden:
+    :maxdepth: 1
+
+    matrix.rst
+    psd_matrix.rst

--- a/docs/source/docs/linalg/matrix.rst
+++ b/docs/source/docs/linalg/matrix.rst
@@ -1,0 +1,6 @@
+:hide-toc:
+
+Matrix
+======
+
+.. autoclass:: torchjd.linalg.Matrix

--- a/docs/source/docs/linalg/psd_matrix.rst
+++ b/docs/source/docs/linalg/psd_matrix.rst
@@ -1,0 +1,6 @@
+:hide-toc:
+
+PSDMatrix
+=========
+
+.. autoclass:: torchjd.linalg.PSDMatrix

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -70,3 +70,4 @@ TorchJD is open-source, under MIT License. The source code is available on
     docs/autogram/index.rst
     docs/autojac/index.rst
     docs/aggregation/index.rst
+    docs/linalg/index.rst

--- a/src/torchjd/_linalg/_matrix.py
+++ b/src/torchjd/_linalg/_matrix.py
@@ -8,7 +8,16 @@ from torch import Tensor
 
 
 class Matrix(Tensor):
-    """Tensor with exactly 2 dimensions."""
+    """
+    Tensor with exactly 2 dimensions.
+
+    Common examples include the Jacobian matrix J of shape ``[m, n]``, where m is the number of
+    objectives and n is the number of model parameters, and the Gramian of the Jacobian
+    G = J J^T of shape ``[m, m]``.
+
+    .. note::
+        This class should never be instantiated. It is only used for static type checking.
+    """
 
 
 class PSDTensor(Tensor):
@@ -20,7 +29,15 @@ class PSDTensor(Tensor):
 
 
 class PSDMatrix(PSDTensor, Matrix):
-    """Positive semi-definite matrix."""
+    """
+    Positive semi-definite matrix.
+
+    A common example is the Gramian of the Jacobian G = J J^T of shape ``[m, m]``, where J is a
+    Jacobian matrix of shape ``[m, n]``.
+
+    .. note::
+        This class should never be instantiated. It is only used for static type checking.
+    """
 
 
 def is_matrix(t: Tensor) -> TypeGuard[Matrix]:

--- a/src/torchjd/aggregation/__init__.py
+++ b/src/torchjd/aggregation/__init__.py
@@ -9,8 +9,9 @@ of weights from the Gramian of the Jacobian. The
 
 .. note::
     Most aggregators rely on computing the Gramian of the Jacobian, extracting a vector of weights
-    from this Gramian using a :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]``, and then combining the
-    rows of the Jacobian using these weights. For all of them, we provide both the
+    from this Gramian using a :class:`~torchjd.aggregation.Weighting`
+    [:class:`~torchjd.linalg.PSDMatrix`], and then combining the rows of the Jacobian using these
+    weights. For all of them, we provide both the
     :class:`~torchjd.aggregation.Aggregator` interface (to be used in autojac) and the
     :class:`~torchjd.aggregation.Weighting` interface (to be used in autogram).
     For the rest, we only provide the :class:`~torchjd.aggregation.Aggregator`

--- a/src/torchjd/aggregation/__init__.py
+++ b/src/torchjd/aggregation/__init__.py
@@ -9,7 +9,7 @@ of weights from the Gramian of the Jacobian. The
 
 .. note::
     Most aggregators rely on computing the Gramian of the Jacobian, extracting a vector of weights
-    from this Gramian using a :class:`~torchjd.aggregation.GramianWeighting`, and then combining the
+    from this Gramian using a :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]``, and then combining the
     rows of the Jacobian using these weights. For all of them, we provide both the
     :class:`~torchjd.aggregation.Aggregator` interface (to be used in autojac) and the
     :class:`~torchjd.aggregation.Weighting` interface (to be used in autogram).
@@ -80,7 +80,7 @@ from ._upgrad import UPGrad, UPGradWeighting
 from ._utils.check_dependencies import (
     OptionalDepsNotInstalledError as _OptionalDepsNotInstalledError,
 )
-from ._weighting_bases import GeneralizedWeighting, GramianWeighting, MatrixWeighting, Weighting
+from ._weighting_bases import GeneralizedWeighting, Weighting
 
 __all__ = [
     "Aggregator",
@@ -97,12 +97,10 @@ __all__ = [
     "GradVac",
     "GradVacWeighting",
     "GramianWeightedAggregator",
-    "GramianWeighting",
     "IMTLG",
     "IMTLGWeighting",
     "Krum",
     "KrumWeighting",
-    "MatrixWeighting",
     "Mean",
     "MeanWeighting",
     "MGDA",

--- a/src/torchjd/aggregation/_aggregator_bases.py
+++ b/src/torchjd/aggregation/_aggregator_bases.py
@@ -47,7 +47,7 @@ class Aggregator(nn.Module, ABC):
 class WeightedAggregator(Aggregator):
     """
     Aggregator that combines the rows of the input Jacobian matrix with weights given by applying a
-    :class:`~torchjd.aggregation.Weighting` ``[Matrix]`` to it.
+    :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.Matrix`] to it.
 
     :param weighting: The object responsible for extracting the vector of weights from the matrix.
     """
@@ -75,7 +75,8 @@ class WeightedAggregator(Aggregator):
 class GramianWeightedAggregator(WeightedAggregator):
     """
     :class:`~torchjd.aggregation.WeightedAggregator` that computes the gramian of the input
-    Jacobian matrix before applying a :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` to it.
+    Jacobian matrix before applying a :class:`~torchjd.aggregation.Weighting`
+    [:class:`~torchjd.linalg.PSDMatrix`] to it.
 
     :param gramian_weighting: The object responsible for extracting the vector of weights from the
         gramian.

--- a/src/torchjd/aggregation/_aggregator_bases.py
+++ b/src/torchjd/aggregation/_aggregator_bases.py
@@ -3,9 +3,9 @@ from typing import cast
 
 from torch import Tensor, nn
 
-from torchjd._linalg import Matrix, compute_gramian, is_matrix
+from torchjd._linalg import Matrix, PSDMatrix, compute_gramian, is_matrix
 
-from ._weighting_bases import GramianWeighting, MatrixWeighting
+from ._weighting_bases import Weighting
 
 
 class Aggregator(nn.Module, ABC):
@@ -48,12 +48,12 @@ class Aggregator(nn.Module, ABC):
 class WeightedAggregator(Aggregator):
     """
     Aggregator that combines the rows of the input Jacobian matrix with weights given by applying a
-    :class:`~torchjd.aggregation.MatrixWeighting` to it.
+    :class:`~torchjd.aggregation.Weighting` ``[Matrix]`` to it.
 
     :param weighting: The object responsible for extracting the vector of weights from the matrix.
     """
 
-    def __init__(self, weighting: MatrixWeighting) -> None:
+    def __init__(self, weighting: Weighting[Matrix]) -> None:
         super().__init__()
         self.weighting = weighting
 
@@ -76,12 +76,12 @@ class WeightedAggregator(Aggregator):
 class GramianWeightedAggregator(WeightedAggregator):
     """
     :class:`~torchjd.aggregation.WeightedAggregator` that computes the gramian of the input
-    Jacobian matrix before applying a :class:`~torchjd.aggregation.GramianWeighting` to it.
+    Jacobian matrix before applying a :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` to it.
 
     :param gramian_weighting: The object responsible for extracting the vector of weights from the
         gramian.
     """
 
-    def __init__(self, gramian_weighting: GramianWeighting) -> None:
-        super().__init__(cast(MatrixWeighting, gramian_weighting << compute_gramian))
+    def __init__(self, gramian_weighting: Weighting[PSDMatrix]) -> None:
+        super().__init__(cast(Weighting[Matrix], gramian_weighting << compute_gramian))
         self.gramian_weighting = gramian_weighting

--- a/src/torchjd/aggregation/_aggregator_bases.py
+++ b/src/torchjd/aggregation/_aggregator_bases.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import cast
 
 from torch import Tensor, nn
 
@@ -83,5 +82,5 @@ class GramianWeightedAggregator(WeightedAggregator):
     """
 
     def __init__(self, gramian_weighting: Weighting[PSDMatrix]) -> None:
-        super().__init__(cast(Weighting[Matrix], gramian_weighting << compute_gramian))
+        super().__init__(gramian_weighting << compute_gramian)
         self.gramian_weighting = gramian_weighting

--- a/src/torchjd/aggregation/_aggregator_bases.py
+++ b/src/torchjd/aggregation/_aggregator_bases.py
@@ -2,7 +2,8 @@ from abc import ABC, abstractmethod
 
 from torch import Tensor, nn
 
-from torchjd._linalg import Matrix, PSDMatrix, compute_gramian, is_matrix
+from torchjd._linalg import compute_gramian, is_matrix
+from torchjd.linalg import Matrix, PSDMatrix
 
 from ._weighting_bases import Weighting
 

--- a/src/torchjd/aggregation/_aligned_mtl.py
+++ b/src/torchjd/aggregation/_aligned_mtl.py
@@ -7,7 +7,7 @@ from typing import Literal, TypeAlias
 import torch
 from torch import Tensor
 
-from torchjd._linalg import PSDMatrix
+from torchjd.linalg import PSDMatrix
 
 from ._aggregator_bases import GramianWeightedAggregator
 from ._mean import MeanWeighting

--- a/src/torchjd/aggregation/_aligned_mtl.py
+++ b/src/torchjd/aggregation/_aligned_mtl.py
@@ -19,8 +19,8 @@ SUPPORTED_SCALE_MODE: TypeAlias = Literal["min", "median", "rmse"]
 
 class AlignedMTLWeighting(Weighting[PSDMatrix]):
     r"""
-    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
-    :class:`~torchjd.aggregation.AlignedMTL`.
+    :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
+    giving the weights of :class:`~torchjd.aggregation.AlignedMTL`.
 
     :param pref_vector: The preference vector to use. If not provided, defaults to
         :math:`\begin{bmatrix} \frac{1}{m} & \dots & \frac{1}{m} \end{bmatrix}^T \in \mathbb{R}^m`.

--- a/src/torchjd/aggregation/_aligned_mtl.py
+++ b/src/torchjd/aggregation/_aligned_mtl.py
@@ -12,14 +12,14 @@ from torchjd._linalg import PSDMatrix
 from ._aggregator_bases import GramianWeightedAggregator
 from ._mean import MeanWeighting
 from ._utils.pref_vector import pref_vector_to_str_suffix, pref_vector_to_weighting
-from ._weighting_bases import GramianWeighting
+from ._weighting_bases import Weighting
 
 SUPPORTED_SCALE_MODE: TypeAlias = Literal["min", "median", "rmse"]
 
 
-class AlignedMTLWeighting(GramianWeighting):
+class AlignedMTLWeighting(Weighting[PSDMatrix]):
     r"""
-    :class:`~torchjd.aggregation.GramianWeighting` giving the weights of
+    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
     :class:`~torchjd.aggregation.AlignedMTL`.
 
     :param pref_vector: The preference vector to use. If not provided, defaults to

--- a/src/torchjd/aggregation/_aligned_mtl.py
+++ b/src/torchjd/aggregation/_aligned_mtl.py
@@ -12,12 +12,12 @@ from torchjd._linalg import PSDMatrix
 from ._aggregator_bases import GramianWeightedAggregator
 from ._mean import MeanWeighting
 from ._utils.pref_vector import pref_vector_to_str_suffix, pref_vector_to_weighting
-from ._weighting_bases import Weighting
+from ._weighting_bases import _GramianWeighting
 
 SUPPORTED_SCALE_MODE: TypeAlias = Literal["min", "median", "rmse"]
 
 
-class AlignedMTLWeighting(Weighting[PSDMatrix]):
+class AlignedMTLWeighting(_GramianWeighting):
     r"""
     :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
     giving the weights of :class:`~torchjd.aggregation.AlignedMTL`.

--- a/src/torchjd/aggregation/_cagrad.py
+++ b/src/torchjd/aggregation/_cagrad.py
@@ -1,6 +1,6 @@
 from typing import cast
 
-from torchjd._linalg import PSDMatrix
+from torchjd.linalg import PSDMatrix
 
 from ._utils.check_dependencies import check_dependencies_are_installed
 from ._weighting_bases import _GramianWeighting

--- a/src/torchjd/aggregation/_cagrad.py
+++ b/src/torchjd/aggregation/_cagrad.py
@@ -20,8 +20,8 @@ from ._utils.non_differentiable import raise_non_differentiable_error
 
 class CAGradWeighting(Weighting[PSDMatrix]):
     """
-    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
-    :class:`~torchjd.aggregation.CAGrad`.
+    :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
+    giving the weights of :class:`~torchjd.aggregation.CAGrad`.
 
     :param c: The scale of the radius of the ball constraint.
     :param norm_eps: A small value to avoid division by zero when normalizing.

--- a/src/torchjd/aggregation/_cagrad.py
+++ b/src/torchjd/aggregation/_cagrad.py
@@ -3,7 +3,7 @@ from typing import cast
 from torchjd._linalg import PSDMatrix
 
 from ._utils.check_dependencies import check_dependencies_are_installed
-from ._weighting_bases import Weighting
+from ._weighting_bases import _GramianWeighting
 
 check_dependencies_are_installed(["cvxpy", "clarabel"])
 
@@ -18,7 +18,7 @@ from ._aggregator_bases import GramianWeightedAggregator
 from ._utils.non_differentiable import raise_non_differentiable_error
 
 
-class CAGradWeighting(Weighting[PSDMatrix]):
+class CAGradWeighting(_GramianWeighting):
     """
     :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
     giving the weights of :class:`~torchjd.aggregation.CAGrad`.

--- a/src/torchjd/aggregation/_cagrad.py
+++ b/src/torchjd/aggregation/_cagrad.py
@@ -3,7 +3,7 @@ from typing import cast
 from torchjd._linalg import PSDMatrix
 
 from ._utils.check_dependencies import check_dependencies_are_installed
-from ._weighting_bases import GramianWeighting
+from ._weighting_bases import Weighting
 
 check_dependencies_are_installed(["cvxpy", "clarabel"])
 
@@ -18,9 +18,9 @@ from ._aggregator_bases import GramianWeightedAggregator
 from ._utils.non_differentiable import raise_non_differentiable_error
 
 
-class CAGradWeighting(GramianWeighting):
+class CAGradWeighting(Weighting[PSDMatrix]):
     """
-    :class:`~torchjd.aggregation.GramianWeighting` giving the weights of
+    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
     :class:`~torchjd.aggregation.CAGrad`.
 
     :param c: The scale of the radius of the ball constraint.

--- a/src/torchjd/aggregation/_config.py
+++ b/src/torchjd/aggregation/_config.py
@@ -5,7 +5,7 @@
 import torch
 from torch import Tensor
 
-from torchjd._linalg import Matrix
+from torchjd.linalg import Matrix
 
 from ._aggregator_bases import Aggregator
 from ._sum import SumWeighting

--- a/src/torchjd/aggregation/_constant.py
+++ b/src/torchjd/aggregation/_constant.py
@@ -1,13 +1,15 @@
 from torch import Tensor
 
+from torchjd._linalg import Matrix
+
 from ._aggregator_bases import WeightedAggregator
 from ._utils.str import vector_to_str
-from ._weighting_bases import MatrixWeighting
+from ._weighting_bases import Weighting
 
 
-class ConstantWeighting(MatrixWeighting):
+class ConstantWeighting(Weighting[Matrix]):
     """
-    :class:`~torchjd.aggregation.MatrixWeighting` that returns constant, pre-determined
+    :class:`~torchjd.aggregation.Weighting` ``[Matrix]`` that returns constant, pre-determined
     weights.
 
     :param weights: The weights to return at each call.

--- a/src/torchjd/aggregation/_constant.py
+++ b/src/torchjd/aggregation/_constant.py
@@ -1,13 +1,11 @@
 from torch import Tensor
 
-from torchjd._linalg import Matrix
-
 from ._aggregator_bases import WeightedAggregator
 from ._utils.str import vector_to_str
-from ._weighting_bases import Weighting
+from ._weighting_bases import _MatrixWeighting
 
 
-class ConstantWeighting(Weighting[Matrix]):
+class ConstantWeighting(_MatrixWeighting):
     """
     :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.Matrix`]
     that returns constant, pre-determined weights.

--- a/src/torchjd/aggregation/_constant.py
+++ b/src/torchjd/aggregation/_constant.py
@@ -9,8 +9,8 @@ from ._weighting_bases import Weighting
 
 class ConstantWeighting(Weighting[Matrix]):
     """
-    :class:`~torchjd.aggregation.Weighting` ``[Matrix]`` that returns constant, pre-determined
-    weights.
+    :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.Matrix`]
+    that returns constant, pre-determined weights.
 
     :param weights: The weights to return at each call.
     """

--- a/src/torchjd/aggregation/_dualproj.py
+++ b/src/torchjd/aggregation/_dualproj.py
@@ -1,6 +1,7 @@
 from torch import Tensor
 
-from torchjd._linalg import PSDMatrix, normalize, regularize
+from torchjd._linalg import normalize, regularize
+from torchjd.linalg import PSDMatrix
 
 from ._aggregator_bases import GramianWeightedAggregator
 from ._mean import MeanWeighting

--- a/src/torchjd/aggregation/_dualproj.py
+++ b/src/torchjd/aggregation/_dualproj.py
@@ -7,12 +7,12 @@ from ._mean import MeanWeighting
 from ._utils.dual_cone import SUPPORTED_SOLVER, project_weights
 from ._utils.non_differentiable import raise_non_differentiable_error
 from ._utils.pref_vector import pref_vector_to_str_suffix, pref_vector_to_weighting
-from ._weighting_bases import GramianWeighting
+from ._weighting_bases import Weighting
 
 
-class DualProjWeighting(GramianWeighting):
+class DualProjWeighting(Weighting[PSDMatrix]):
     r"""
-    :class:`~torchjd.aggregation.GramianWeighting` giving the weights of
+    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
     :class:`~torchjd.aggregation.DualProj`.
 
     :param pref_vector: The preference vector to use. If not provided, defaults to

--- a/src/torchjd/aggregation/_dualproj.py
+++ b/src/torchjd/aggregation/_dualproj.py
@@ -12,8 +12,8 @@ from ._weighting_bases import Weighting
 
 class DualProjWeighting(Weighting[PSDMatrix]):
     r"""
-    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
-    :class:`~torchjd.aggregation.DualProj`.
+    :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
+    giving the weights of :class:`~torchjd.aggregation.DualProj`.
 
     :param pref_vector: The preference vector to use. If not provided, defaults to
         :math:`\begin{bmatrix} \frac{1}{m} & \dots & \frac{1}{m} \end{bmatrix}^T \in \mathbb{R}^m`.

--- a/src/torchjd/aggregation/_dualproj.py
+++ b/src/torchjd/aggregation/_dualproj.py
@@ -7,10 +7,10 @@ from ._mean import MeanWeighting
 from ._utils.dual_cone import SUPPORTED_SOLVER, project_weights
 from ._utils.non_differentiable import raise_non_differentiable_error
 from ._utils.pref_vector import pref_vector_to_str_suffix, pref_vector_to_weighting
-from ._weighting_bases import Weighting
+from ._weighting_bases import _GramianWeighting
 
 
-class DualProjWeighting(Weighting[PSDMatrix]):
+class DualProjWeighting(_GramianWeighting):
     r"""
     :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
     giving the weights of :class:`~torchjd.aggregation.DualProj`.

--- a/src/torchjd/aggregation/_graddrop.py
+++ b/src/torchjd/aggregation/_graddrop.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 import torch
 from torch import Tensor
 
-from torchjd._linalg import Matrix
+from torchjd.linalg import Matrix
 
 from ._aggregator_bases import Aggregator
 from ._utils.non_differentiable import raise_non_differentiable_error

--- a/src/torchjd/aggregation/_gradvac.py
+++ b/src/torchjd/aggregation/_gradvac.py
@@ -10,13 +10,13 @@ from torchjd.aggregation._mixins import Stateful
 
 from ._aggregator_bases import GramianWeightedAggregator
 from ._utils.non_differentiable import raise_non_differentiable_error
-from ._weighting_bases import GramianWeighting
+from ._weighting_bases import Weighting
 
 
-class GradVacWeighting(GramianWeighting, Stateful):
+class GradVacWeighting(Weighting[PSDMatrix], Stateful):
     r"""
     :class:`~torchjd.aggregation._mixins.Stateful`
-    :class:`~torchjd.aggregation.GramianWeighting` giving the weights of
+    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
     :class:`~torchjd.aggregation.GradVac`.
 
     All required quantities (gradient norms, cosine similarities, and their updates after the

--- a/src/torchjd/aggregation/_gradvac.py
+++ b/src/torchjd/aggregation/_gradvac.py
@@ -10,10 +10,10 @@ from torchjd.aggregation._mixins import Stateful
 
 from ._aggregator_bases import GramianWeightedAggregator
 from ._utils.non_differentiable import raise_non_differentiable_error
-from ._weighting_bases import Weighting
+from ._weighting_bases import _GramianWeighting
 
 
-class GradVacWeighting(Weighting[PSDMatrix], Stateful):
+class GradVacWeighting(_GramianWeighting, Stateful):
     r"""
     :class:`~torchjd.aggregation._mixins.Stateful`
     :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]

--- a/src/torchjd/aggregation/_gradvac.py
+++ b/src/torchjd/aggregation/_gradvac.py
@@ -5,8 +5,8 @@ from typing import cast
 import torch
 from torch import Tensor
 
-from torchjd._linalg import PSDMatrix
 from torchjd.aggregation._mixins import Stateful
+from torchjd.linalg import PSDMatrix
 
 from ._aggregator_bases import GramianWeightedAggregator
 from ._utils.non_differentiable import raise_non_differentiable_error

--- a/src/torchjd/aggregation/_gradvac.py
+++ b/src/torchjd/aggregation/_gradvac.py
@@ -16,8 +16,8 @@ from ._weighting_bases import Weighting
 class GradVacWeighting(Weighting[PSDMatrix], Stateful):
     r"""
     :class:`~torchjd.aggregation._mixins.Stateful`
-    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
-    :class:`~torchjd.aggregation.GradVac`.
+    :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
+    giving the weights of :class:`~torchjd.aggregation.GradVac`.
 
     All required quantities (gradient norms, cosine similarities, and their updates after the
     vaccine correction) are derived purely from the Gramian, without needing the full Jacobian.

--- a/src/torchjd/aggregation/_imtl_g.py
+++ b/src/torchjd/aggregation/_imtl_g.py
@@ -5,10 +5,10 @@ from torchjd._linalg import PSDMatrix
 
 from ._aggregator_bases import GramianWeightedAggregator
 from ._utils.non_differentiable import raise_non_differentiable_error
-from ._weighting_bases import Weighting
+from ._weighting_bases import _GramianWeighting
 
 
-class IMTLGWeighting(Weighting[PSDMatrix]):
+class IMTLGWeighting(_GramianWeighting):
     """
     :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
     giving the weights of :class:`~torchjd.aggregation.IMTLG`.

--- a/src/torchjd/aggregation/_imtl_g.py
+++ b/src/torchjd/aggregation/_imtl_g.py
@@ -1,7 +1,7 @@
 import torch
 from torch import Tensor
 
-from torchjd._linalg import PSDMatrix
+from torchjd.linalg import PSDMatrix
 
 from ._aggregator_bases import GramianWeightedAggregator
 from ._utils.non_differentiable import raise_non_differentiable_error

--- a/src/torchjd/aggregation/_imtl_g.py
+++ b/src/torchjd/aggregation/_imtl_g.py
@@ -10,8 +10,8 @@ from ._weighting_bases import Weighting
 
 class IMTLGWeighting(Weighting[PSDMatrix]):
     """
-    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
-    :class:`~torchjd.aggregation.IMTLG`.
+    :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
+    giving the weights of :class:`~torchjd.aggregation.IMTLG`.
     """
 
     def forward(self, gramian: PSDMatrix, /) -> Tensor:

--- a/src/torchjd/aggregation/_imtl_g.py
+++ b/src/torchjd/aggregation/_imtl_g.py
@@ -5,12 +5,12 @@ from torchjd._linalg import PSDMatrix
 
 from ._aggregator_bases import GramianWeightedAggregator
 from ._utils.non_differentiable import raise_non_differentiable_error
-from ._weighting_bases import GramianWeighting
+from ._weighting_bases import Weighting
 
 
-class IMTLGWeighting(GramianWeighting):
+class IMTLGWeighting(Weighting[PSDMatrix]):
     """
-    :class:`~torchjd.aggregation.GramianWeighting` giving the weights of
+    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
     :class:`~torchjd.aggregation.IMTLG`.
     """
 

--- a/src/torchjd/aggregation/_krum.py
+++ b/src/torchjd/aggregation/_krum.py
@@ -10,8 +10,8 @@ from ._weighting_bases import Weighting
 
 class KrumWeighting(Weighting[PSDMatrix]):
     """
-    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
-    :class:`~torchjd.aggregation.Krum`.
+    :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
+    giving the weights of :class:`~torchjd.aggregation.Krum`.
 
     :param n_byzantine: The number of rows of the input matrix that can come from an adversarial
         source.

--- a/src/torchjd/aggregation/_krum.py
+++ b/src/torchjd/aggregation/_krum.py
@@ -5,12 +5,12 @@ from torch.nn import functional as F
 from torchjd._linalg import PSDMatrix
 
 from ._aggregator_bases import GramianWeightedAggregator
-from ._weighting_bases import GramianWeighting
+from ._weighting_bases import Weighting
 
 
-class KrumWeighting(GramianWeighting):
+class KrumWeighting(Weighting[PSDMatrix]):
     """
-    :class:`~torchjd.aggregation.GramianWeighting` giving the weights of
+    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
     :class:`~torchjd.aggregation.Krum`.
 
     :param n_byzantine: The number of rows of the input matrix that can come from an adversarial

--- a/src/torchjd/aggregation/_krum.py
+++ b/src/torchjd/aggregation/_krum.py
@@ -5,10 +5,10 @@ from torch.nn import functional as F
 from torchjd._linalg import PSDMatrix
 
 from ._aggregator_bases import GramianWeightedAggregator
-from ._weighting_bases import Weighting
+from ._weighting_bases import _GramianWeighting
 
 
-class KrumWeighting(Weighting[PSDMatrix]):
+class KrumWeighting(_GramianWeighting):
     """
     :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
     giving the weights of :class:`~torchjd.aggregation.Krum`.

--- a/src/torchjd/aggregation/_krum.py
+++ b/src/torchjd/aggregation/_krum.py
@@ -2,7 +2,7 @@ import torch
 from torch import Tensor
 from torch.nn import functional as F
 
-from torchjd._linalg import PSDMatrix
+from torchjd.linalg import PSDMatrix
 
 from ._aggregator_bases import GramianWeightedAggregator
 from ._weighting_bases import _GramianWeighting

--- a/src/torchjd/aggregation/_mean.py
+++ b/src/torchjd/aggregation/_mean.py
@@ -9,7 +9,7 @@ from ._weighting_bases import Weighting
 
 class MeanWeighting(Weighting[Matrix]):
     r"""
-    :class:`~torchjd.aggregation.Weighting` ``[Matrix]`` that gives the weights
+    :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.Matrix`] that gives the weights
     :math:`\begin{bmatrix} \frac{1}{m} & \dots & \frac{1}{m} \end{bmatrix}^T \in
     \mathbb{R}^m`.
     """

--- a/src/torchjd/aggregation/_mean.py
+++ b/src/torchjd/aggregation/_mean.py
@@ -1,13 +1,15 @@
 import torch
 from torch import Tensor
 
+from torchjd._linalg import Matrix
+
 from ._aggregator_bases import WeightedAggregator
-from ._weighting_bases import MatrixWeighting
+from ._weighting_bases import Weighting
 
 
-class MeanWeighting(MatrixWeighting):
+class MeanWeighting(Weighting[Matrix]):
     r"""
-    :class:`~torchjd.aggregation.MatrixWeighting` that gives the weights
+    :class:`~torchjd.aggregation.Weighting` ``[Matrix]`` that gives the weights
     :math:`\begin{bmatrix} \frac{1}{m} & \dots & \frac{1}{m} \end{bmatrix}^T \in
     \mathbb{R}^m`.
     """

--- a/src/torchjd/aggregation/_mean.py
+++ b/src/torchjd/aggregation/_mean.py
@@ -1,13 +1,11 @@
 import torch
 from torch import Tensor
 
-from torchjd._linalg import Matrix
-
 from ._aggregator_bases import WeightedAggregator
-from ._weighting_bases import Weighting
+from ._weighting_bases import _MatrixWeighting
 
 
-class MeanWeighting(Weighting[Matrix]):
+class MeanWeighting(_MatrixWeighting):
     r"""
     :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.Matrix`] that gives the weights
     :math:`\begin{bmatrix} \frac{1}{m} & \dots & \frac{1}{m} \end{bmatrix}^T \in

--- a/src/torchjd/aggregation/_mgda.py
+++ b/src/torchjd/aggregation/_mgda.py
@@ -4,12 +4,12 @@ from torch import Tensor
 from torchjd._linalg import PSDMatrix
 
 from ._aggregator_bases import GramianWeightedAggregator
-from ._weighting_bases import GramianWeighting
+from ._weighting_bases import Weighting
 
 
-class MGDAWeighting(GramianWeighting):
+class MGDAWeighting(Weighting[PSDMatrix]):
     r"""
-    :class:`~torchjd.aggregation.GramianWeighting` giving the weights of
+    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
     :class:`~torchjd.aggregation.MGDA`.
 
     :param epsilon: The value of :math:`\hat{\gamma}` below which we stop the optimization.

--- a/src/torchjd/aggregation/_mgda.py
+++ b/src/torchjd/aggregation/_mgda.py
@@ -4,10 +4,10 @@ from torch import Tensor
 from torchjd._linalg import PSDMatrix
 
 from ._aggregator_bases import GramianWeightedAggregator
-from ._weighting_bases import Weighting
+from ._weighting_bases import _GramianWeighting
 
 
-class MGDAWeighting(Weighting[PSDMatrix]):
+class MGDAWeighting(_GramianWeighting):
     r"""
     :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
     giving the weights of :class:`~torchjd.aggregation.MGDA`.

--- a/src/torchjd/aggregation/_mgda.py
+++ b/src/torchjd/aggregation/_mgda.py
@@ -9,8 +9,8 @@ from ._weighting_bases import Weighting
 
 class MGDAWeighting(Weighting[PSDMatrix]):
     r"""
-    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
-    :class:`~torchjd.aggregation.MGDA`.
+    :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
+    giving the weights of :class:`~torchjd.aggregation.MGDA`.
 
     :param epsilon: The value of :math:`\hat{\gamma}` below which we stop the optimization.
     :param max_iters: The maximum number of iterations of the optimization loop.

--- a/src/torchjd/aggregation/_mgda.py
+++ b/src/torchjd/aggregation/_mgda.py
@@ -1,7 +1,7 @@
 import torch
 from torch import Tensor
 
-from torchjd._linalg import PSDMatrix
+from torchjd.linalg import PSDMatrix
 
 from ._aggregator_bases import GramianWeightedAggregator
 from ._weighting_bases import _GramianWeighting

--- a/src/torchjd/aggregation/_nash_mtl.py
+++ b/src/torchjd/aggregation/_nash_mtl.py
@@ -1,11 +1,10 @@
 # Partly adapted from https://github.com/AvivNavon/nash-mtl — MIT License, Copyright (c) 2022 Aviv Navon.
 # See NOTICES for the full license text.
 
-from torchjd._linalg import Matrix
 from torchjd.aggregation._mixins import Stateful
 
 from ._utils.check_dependencies import check_dependencies_are_installed
-from ._weighting_bases import Weighting
+from ._weighting_bases import _MatrixWeighting
 
 check_dependencies_are_installed(["cvxpy", "ecos"])
 
@@ -19,7 +18,7 @@ from ._aggregator_bases import WeightedAggregator
 from ._utils.non_differentiable import raise_non_differentiable_error
 
 
-class _NashMTLWeighting(Weighting[Matrix], Stateful):
+class _NashMTLWeighting(_MatrixWeighting, Stateful):
     """
     :class:`~torchjd.aggregation._mixins.Stateful`
     :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.Matrix`] that

--- a/src/torchjd/aggregation/_nash_mtl.py
+++ b/src/torchjd/aggregation/_nash_mtl.py
@@ -21,7 +21,8 @@ from ._utils.non_differentiable import raise_non_differentiable_error
 
 class _NashMTLWeighting(Weighting[Matrix], Stateful):
     """
-    :class:`~torchjd.aggregation._mixins.Stateful` :class:`~torchjd.aggregation.Weighting` ``[Matrix]`` that
+    :class:`~torchjd.aggregation._mixins.Stateful`
+    :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.Matrix`] that
     extracts weights using the step decision of Algorithm 1 of `Multi-Task Learning as a Bargaining
     Game <https://arxiv.org/pdf/2202.01017.pdf>`_.
 

--- a/src/torchjd/aggregation/_nash_mtl.py
+++ b/src/torchjd/aggregation/_nash_mtl.py
@@ -1,10 +1,11 @@
 # Partly adapted from https://github.com/AvivNavon/nash-mtl — MIT License, Copyright (c) 2022 Aviv Navon.
 # See NOTICES for the full license text.
 
+from torchjd._linalg import Matrix
 from torchjd.aggregation._mixins import Stateful
 
 from ._utils.check_dependencies import check_dependencies_are_installed
-from ._weighting_bases import MatrixWeighting
+from ._weighting_bases import Weighting
 
 check_dependencies_are_installed(["cvxpy", "ecos"])
 
@@ -18,9 +19,9 @@ from ._aggregator_bases import WeightedAggregator
 from ._utils.non_differentiable import raise_non_differentiable_error
 
 
-class _NashMTLWeighting(MatrixWeighting, Stateful):
+class _NashMTLWeighting(Weighting[Matrix], Stateful):
     """
-    :class:`~torchjd.aggregation._mixins.Stateful` :class:`~torchjd.aggregation.MatrixWeighting` that
+    :class:`~torchjd.aggregation._mixins.Stateful` :class:`~torchjd.aggregation.Weighting` ``[Matrix]`` that
     extracts weights using the step decision of Algorithm 1 of `Multi-Task Learning as a Bargaining
     Game <https://arxiv.org/pdf/2202.01017.pdf>`_.
 

--- a/src/torchjd/aggregation/_pcgrad.py
+++ b/src/torchjd/aggregation/_pcgrad.py
@@ -12,8 +12,8 @@ from ._weighting_bases import Weighting
 
 class PCGradWeighting(Weighting[PSDMatrix]):
     """
-    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
-    :class:`~torchjd.aggregation.PCGrad`.
+    :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
+    giving the weights of :class:`~torchjd.aggregation.PCGrad`.
     """
 
     def forward(self, gramian: PSDMatrix, /) -> Tensor:

--- a/src/torchjd/aggregation/_pcgrad.py
+++ b/src/torchjd/aggregation/_pcgrad.py
@@ -3,7 +3,7 @@ from typing import cast
 import torch
 from torch import Tensor
 
-from torchjd._linalg import PSDMatrix
+from torchjd.linalg import PSDMatrix
 
 from ._aggregator_bases import GramianWeightedAggregator
 from ._utils.non_differentiable import raise_non_differentiable_error

--- a/src/torchjd/aggregation/_pcgrad.py
+++ b/src/torchjd/aggregation/_pcgrad.py
@@ -7,12 +7,12 @@ from torchjd._linalg import PSDMatrix
 
 from ._aggregator_bases import GramianWeightedAggregator
 from ._utils.non_differentiable import raise_non_differentiable_error
-from ._weighting_bases import GramianWeighting
+from ._weighting_bases import Weighting
 
 
-class PCGradWeighting(GramianWeighting):
+class PCGradWeighting(Weighting[PSDMatrix]):
     """
-    :class:`~torchjd.aggregation.GramianWeighting` giving the weights of
+    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
     :class:`~torchjd.aggregation.PCGrad`.
     """
 

--- a/src/torchjd/aggregation/_pcgrad.py
+++ b/src/torchjd/aggregation/_pcgrad.py
@@ -7,10 +7,10 @@ from torchjd._linalg import PSDMatrix
 
 from ._aggregator_bases import GramianWeightedAggregator
 from ._utils.non_differentiable import raise_non_differentiable_error
-from ._weighting_bases import Weighting
+from ._weighting_bases import _GramianWeighting
 
 
-class PCGradWeighting(Weighting[PSDMatrix]):
+class PCGradWeighting(_GramianWeighting):
     """
     :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
     giving the weights of :class:`~torchjd.aggregation.PCGrad`.

--- a/src/torchjd/aggregation/_random.py
+++ b/src/torchjd/aggregation/_random.py
@@ -2,13 +2,11 @@ import torch
 from torch import Tensor
 from torch.nn import functional as F
 
-from torchjd._linalg import Matrix
-
 from ._aggregator_bases import WeightedAggregator
-from ._weighting_bases import Weighting
+from ._weighting_bases import _MatrixWeighting
 
 
-class RandomWeighting(Weighting[Matrix]):
+class RandomWeighting(_MatrixWeighting):
     """
     :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.Matrix`]
     that generates positive random weights at each call.

--- a/src/torchjd/aggregation/_random.py
+++ b/src/torchjd/aggregation/_random.py
@@ -10,8 +10,8 @@ from ._weighting_bases import Weighting
 
 class RandomWeighting(Weighting[Matrix]):
     """
-    :class:`~torchjd.aggregation.Weighting` ``[Matrix]`` that generates positive random weights
-    at each call.
+    :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.Matrix`]
+    that generates positive random weights at each call.
     """
 
     def forward(self, matrix: Tensor, /) -> Tensor:

--- a/src/torchjd/aggregation/_random.py
+++ b/src/torchjd/aggregation/_random.py
@@ -2,13 +2,15 @@ import torch
 from torch import Tensor
 from torch.nn import functional as F
 
+from torchjd._linalg import Matrix
+
 from ._aggregator_bases import WeightedAggregator
-from ._weighting_bases import MatrixWeighting
+from ._weighting_bases import Weighting
 
 
-class RandomWeighting(MatrixWeighting):
+class RandomWeighting(Weighting[Matrix]):
     """
-    :class:`~torchjd.aggregation.MatrixWeighting` that generates positive random weights
+    :class:`~torchjd.aggregation.Weighting` ``[Matrix]`` that generates positive random weights
     at each call.
     """
 

--- a/src/torchjd/aggregation/_sum.py
+++ b/src/torchjd/aggregation/_sum.py
@@ -9,7 +9,7 @@ from ._weighting_bases import Weighting
 
 class SumWeighting(Weighting[Matrix]):
     r"""
-    :class:`~torchjd.aggregation.Weighting` ``[Matrix]`` that gives the weights
+    :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.Matrix`] that gives the weights
     :math:`\begin{bmatrix} 1 & \dots & 1 \end{bmatrix}^T \in \mathbb{R}^m`.
     """
 

--- a/src/torchjd/aggregation/_sum.py
+++ b/src/torchjd/aggregation/_sum.py
@@ -1,13 +1,11 @@
 import torch
 from torch import Tensor
 
-from torchjd._linalg import Matrix
-
 from ._aggregator_bases import WeightedAggregator
-from ._weighting_bases import Weighting
+from ._weighting_bases import _MatrixWeighting
 
 
-class SumWeighting(Weighting[Matrix]):
+class SumWeighting(_MatrixWeighting):
     r"""
     :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.Matrix`] that gives the weights
     :math:`\begin{bmatrix} 1 & \dots & 1 \end{bmatrix}^T \in \mathbb{R}^m`.

--- a/src/torchjd/aggregation/_sum.py
+++ b/src/torchjd/aggregation/_sum.py
@@ -1,13 +1,15 @@
 import torch
 from torch import Tensor
 
+from torchjd._linalg import Matrix
+
 from ._aggregator_bases import WeightedAggregator
-from ._weighting_bases import MatrixWeighting
+from ._weighting_bases import Weighting
 
 
-class SumWeighting(MatrixWeighting):
+class SumWeighting(Weighting[Matrix]):
     r"""
-    :class:`~torchjd.aggregation.MatrixWeighting` that gives the weights
+    :class:`~torchjd.aggregation.Weighting` ``[Matrix]`` that gives the weights
     :math:`\begin{bmatrix} 1 & \dots & 1 \end{bmatrix}^T \in \mathbb{R}^m`.
     """
 

--- a/src/torchjd/aggregation/_upgrad.py
+++ b/src/torchjd/aggregation/_upgrad.py
@@ -1,7 +1,8 @@
 import torch
 from torch import Tensor
 
-from torchjd._linalg import PSDMatrix, normalize, regularize
+from torchjd._linalg import normalize, regularize
+from torchjd.linalg import PSDMatrix
 
 from ._aggregator_bases import GramianWeightedAggregator
 from ._mean import MeanWeighting

--- a/src/torchjd/aggregation/_upgrad.py
+++ b/src/torchjd/aggregation/_upgrad.py
@@ -8,10 +8,10 @@ from ._mean import MeanWeighting
 from ._utils.dual_cone import SUPPORTED_SOLVER, project_weights
 from ._utils.non_differentiable import raise_non_differentiable_error
 from ._utils.pref_vector import pref_vector_to_str_suffix, pref_vector_to_weighting
-from ._weighting_bases import Weighting
+from ._weighting_bases import _GramianWeighting
 
 
-class UPGradWeighting(Weighting[PSDMatrix]):
+class UPGradWeighting(_GramianWeighting):
     r"""
     :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
     giving the weights of :class:`~torchjd.aggregation.UPGrad`.

--- a/src/torchjd/aggregation/_upgrad.py
+++ b/src/torchjd/aggregation/_upgrad.py
@@ -13,8 +13,8 @@ from ._weighting_bases import Weighting
 
 class UPGradWeighting(Weighting[PSDMatrix]):
     r"""
-    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
-    :class:`~torchjd.aggregation.UPGrad`.
+    :class:`~torchjd.aggregation.Weighting` [:class:`~torchjd.linalg.PSDMatrix`]
+    giving the weights of :class:`~torchjd.aggregation.UPGrad`.
 
     :param pref_vector: The preference vector to use. If not provided, defaults to
         :math:`\begin{bmatrix} \frac{1}{m} & \dots & \frac{1}{m} \end{bmatrix}^T \in \mathbb{R}^m`.

--- a/src/torchjd/aggregation/_upgrad.py
+++ b/src/torchjd/aggregation/_upgrad.py
@@ -8,12 +8,12 @@ from ._mean import MeanWeighting
 from ._utils.dual_cone import SUPPORTED_SOLVER, project_weights
 from ._utils.non_differentiable import raise_non_differentiable_error
 from ._utils.pref_vector import pref_vector_to_str_suffix, pref_vector_to_weighting
-from ._weighting_bases import GramianWeighting
+from ._weighting_bases import Weighting
 
 
-class UPGradWeighting(GramianWeighting):
+class UPGradWeighting(Weighting[PSDMatrix]):
     r"""
-    :class:`~torchjd.aggregation.GramianWeighting` giving the weights of
+    :class:`~torchjd.aggregation.Weighting` ``[PSDMatrix]`` giving the weights of
     :class:`~torchjd.aggregation.UPGrad`.
 
     :param pref_vector: The preference vector to use. If not provided, defaults to

--- a/src/torchjd/aggregation/_utils/pref_vector.py
+++ b/src/torchjd/aggregation/_utils/pref_vector.py
@@ -1,8 +1,8 @@
 from torch import Tensor
 
-from torchjd._linalg import Matrix
 from torchjd.aggregation._constant import ConstantWeighting
 from torchjd.aggregation._weighting_bases import Weighting
+from torchjd.linalg import Matrix
 
 from .str import vector_to_str
 

--- a/src/torchjd/aggregation/_weighting_bases.py
+++ b/src/torchjd/aggregation/_weighting_bases.py
@@ -6,7 +6,8 @@ from typing import Generic, TypeVar
 
 from torch import Tensor, nn
 
-from torchjd._linalg import Matrix, PSDMatrix, PSDTensor, is_psd_tensor
+from torchjd._linalg import PSDTensor, is_psd_tensor
+from torchjd.linalg import Matrix, PSDMatrix
 
 _T = TypeVar("_T", contravariant=True, bound=Tensor)
 _FnInputT = TypeVar("_FnInputT", bound=Tensor)

--- a/src/torchjd/aggregation/_weighting_bases.py
+++ b/src/torchjd/aggregation/_weighting_bases.py
@@ -6,7 +6,7 @@ from typing import Generic, TypeVar
 
 from torch import Tensor, nn
 
-from torchjd._linalg import Matrix, PSDMatrix, PSDTensor, is_psd_tensor
+from torchjd._linalg import PSDTensor, is_psd_tensor
 
 _T = TypeVar("_T", contravariant=True, bound=Tensor)
 _FnInputT = TypeVar("_FnInputT", bound=Tensor)
@@ -34,8 +34,6 @@ class Weighting(nn.Module, ABC, Generic[_T]):
         :param stat: The stat from which the weights must be extracted.
         """
 
-        # The value of _T (e.g. PSDMatrix) is not public, so we need the user-facing type hint of
-        # stat to be Tensor.
         return super().__call__(stat)
 
     def _compose(self, fn: Callable[[_FnInputT], _T]) -> Weighting[_FnInputT]:
@@ -84,31 +82,3 @@ class GeneralizedWeighting(nn.Module, ABC):
 
         assert is_psd_tensor(generalized_gramian)
         return super().__call__(generalized_gramian)
-
-
-# Subclasses used only to redefine the __call__ method with more specific parameter names and
-# docstrings. Note that MatrixWeighting <: Weighting[Matrix] <: Weighting[PSDMatrix], because
-# PSDMatrix <: Matrix and Weighting[_T] is contravariant with _T.
-# Also note that we don't have: MatrixWeighting <: GramianWeighting. GramianWeighting is not
-# just an alias of Weighting[PSDMatrix], it's a subtype of it. So the type Weighting[PSDMatrix]
-# should still be used when we expect a Weighting that works at least on PSD matrices.
-
-
-class MatrixWeighting(Weighting[Matrix]):
-    def __call__(self, matrix: Tensor, /) -> Tensor:
-        """
-        Computes the vector of weights from the input matrix and applies all registered hooks.
-
-        :param matrix: The matrix from which the weights must be extracted.
-        """
-        return super().__call__(matrix)
-
-
-class GramianWeighting(Weighting[PSDMatrix]):
-    def __call__(self, gramian: Tensor, /) -> Tensor:
-        """
-        Computes the vector of weights from the input gramian and applies all registered hooks.
-
-        :param gramian: The gramian from which the weights must be extracted.
-        """
-        return super().__call__(gramian)

--- a/src/torchjd/aggregation/_weighting_bases.py
+++ b/src/torchjd/aggregation/_weighting_bases.py
@@ -6,7 +6,7 @@ from typing import Generic, TypeVar
 
 from torch import Tensor, nn
 
-from torchjd._linalg import PSDTensor, is_psd_tensor
+from torchjd._linalg import Matrix, PSDMatrix, PSDTensor, is_psd_tensor
 
 _T = TypeVar("_T", contravariant=True, bound=Tensor)
 _FnInputT = TypeVar("_FnInputT", bound=Tensor)
@@ -55,6 +55,26 @@ class _Composition(Weighting[_T]):
 
     def forward(self, stat: _T, /) -> Tensor:
         return self.weighting(self.fn(stat))
+
+
+class _MatrixWeighting(Weighting[Matrix]):
+    def __call__(self, matrix: Tensor, /) -> Tensor:
+        """
+        Computes the vector of weights from the input matrix and applies all registered hooks.
+
+        :param matrix: The matrix from which the weights must be extracted.
+        """
+        return super().__call__(matrix)
+
+
+class _GramianWeighting(Weighting[PSDMatrix]):
+    def __call__(self, gramian: Tensor, /) -> Tensor:
+        """
+        Computes the vector of weights from the input Gramian and applies all registered hooks.
+
+        :param gramian: The Gramian from which the weights must be extracted.
+        """
+        return super().__call__(gramian)
 
 
 class GeneralizedWeighting(nn.Module, ABC):

--- a/src/torchjd/autogram/_engine.py
+++ b/src/torchjd/autogram/_engine.py
@@ -4,7 +4,8 @@ import torch
 from torch import Tensor, nn, vmap
 from torch.autograd.graph import get_gradient_edge
 
-from torchjd._linalg import PSDMatrix, movedim, reshape
+from torchjd._linalg import movedim, reshape
+from torchjd.linalg import PSDMatrix
 
 from ._edge_registry import EdgeRegistry
 from ._gramian_accumulator import GramianAccumulator

--- a/src/torchjd/autogram/_gramian_accumulator.py
+++ b/src/torchjd/autogram/_gramian_accumulator.py
@@ -1,4 +1,4 @@
-from torchjd._linalg import PSDMatrix
+from torchjd.linalg import PSDMatrix
 
 
 class GramianAccumulator:

--- a/src/torchjd/autogram/_gramian_computer.py
+++ b/src/torchjd/autogram/_gramian_computer.py
@@ -4,8 +4,9 @@ from typing import cast
 from torch import Tensor
 from torch.utils._pytree import PyTree
 
-from torchjd._linalg import Matrix, PSDMatrix, compute_gramian
+from torchjd._linalg import compute_gramian
 from torchjd.autogram._jacobian_computer import JacobianComputer
+from torchjd.linalg import Matrix, PSDMatrix
 
 
 class GramianComputer(ABC):

--- a/src/torchjd/autogram/_jacobian_computer.py
+++ b/src/torchjd/autogram/_jacobian_computer.py
@@ -8,7 +8,7 @@ from torch.nn import Parameter
 from torch.overrides import is_tensor_like
 from torch.utils._pytree import PyTree, tree_flatten, tree_map, tree_map_only
 
-from torchjd._linalg import Matrix
+from torchjd.linalg import Matrix
 
 # Note about import from protected _pytree module:
 # PyTorch maintainers plan to make pytree public (see

--- a/src/torchjd/autojac/_jac_to_grad.py
+++ b/src/torchjd/autojac/_jac_to_grad.py
@@ -5,13 +5,14 @@ from typing import TypeGuard, cast, overload
 import torch
 from torch import Tensor, nn
 
-from torchjd._linalg import Matrix, PSDMatrix, compute_gramian
+from torchjd._linalg import compute_gramian
 from torchjd.aggregation import (
     Aggregator,
     GramianWeightedAggregator,
     WeightedAggregator,
     Weighting,
 )
+from torchjd.linalg import Matrix, PSDMatrix
 
 from ._accumulation import TensorWithJac, accumulate_grads, is_tensor_with_jac
 from ._utils import check_consistent_first_dimension

--- a/src/torchjd/linalg/__init__.py
+++ b/src/torchjd/linalg/__init__.py
@@ -1,0 +1,29 @@
+"""
+This module provides type annotation classes representing tensors with specific structural
+properties.
+
+:class:`Matrix` represents any 2D tensor. A common example in the context of Jacobian descent
+is the Jacobian matrix J of shape ``[m, n]``, where m is the number of objectives and n is the
+number of model parameters.
+
+:class:`PSDMatrix` represents a symmetric positive semi-definite square matrix. A common
+example is the Gramian of the Jacobian G = J J^T of shape ``[m, m]``.
+
+.. note::
+    :class:`Matrix` and :class:`PSDMatrix` extend :class:`~torch.Tensor` for type-checking
+    purposes only and should never be directly instantiated.
+
+>>> import torch
+>>> # Jacobian matrix of shape [m, n] = [2, 3]
+>>> J = torch.tensor([[-4., 1., 1.], [6., 1., 1.]])
+>>> J.ndim
+2
+>>> # Gramian of the Jacobian, of shape [m, m] = [2, 2]
+>>> G = J @ J.T
+>>> G.shape
+torch.Size([2, 2])
+"""
+
+from torchjd._linalg._matrix import Matrix, PSDMatrix
+
+__all__ = ["Matrix", "PSDMatrix"]

--- a/src/torchjd/linalg/__init__.py
+++ b/src/torchjd/linalg/__init__.py
@@ -1,27 +1,6 @@
 """
 This module provides type annotation classes representing tensors with specific structural
 properties.
-
-:class:`Matrix` represents any 2D tensor. A common example in the context of Jacobian descent
-is the Jacobian matrix J of shape ``[m, n]``, where m is the number of objectives and n is the
-number of model parameters.
-
-:class:`PSDMatrix` represents a symmetric positive semi-definite square matrix. A common
-example is the Gramian of the Jacobian G = J J^T of shape ``[m, m]``.
-
-.. note::
-    :class:`Matrix` and :class:`PSDMatrix` extend :class:`~torch.Tensor` for type-checking
-    purposes only and should never be directly instantiated.
-
->>> import torch
->>> # Jacobian matrix of shape [m, n] = [2, 3]
->>> J = torch.tensor([[-4., 1., 1.], [6., 1., 1.]])
->>> J.ndim
-2
->>> # Gramian of the Jacobian, of shape [m, m] = [2, 2]
->>> G = J @ J.T
->>> G.shape
-torch.Size([2, 2])
 """
 
 from torchjd._linalg._matrix import Matrix, PSDMatrix


### PR DESCRIPTION
## Summary

- Introduces a new public `torchjd.linalg` package exposing `Matrix` and `PSDMatrix` (the rest of `_linalg` stays protected)
- Makes `MatrixWeighting` and `GramianWeighting` protected. These classes are still used to specify the docstring of the `__call__` methods of the aggregators, but the user only sees those aggregators as `Weighting[Matrix]` and `Weighting[PSDMatrix]`, respectively. The `MatrixWeighting` and `GramianWeighting` classes really just bring updated docstrings, that's all.
- Makes the public type of the gramian_weighting of GramianWeightedAggregator be Weighting[PSDMatrix] instead of GramianWeighting, so that #669 can work. Similar with weighting of WeightedAggregator being Weighting[Matrix].
- Expands docstrings on `Matrix` and `PSDMatrix` with Jacobian and Gramian examples; adds Sphinx documentation under a new **linalg** section in the API Reference
