### PR TITLE
chore: Remove stale CUBLAS_WORKSPACE_CONFIG requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ uv run pre-commit install
 
    - If you have access to a cuda-enabled GPU, you should also check that the unit tests pass on it:
      ```bash
-     CUBLAS_WORKSPACE_CONFIG=:4096:8 PYTEST_TORCH_DEVICE=cuda:0 uv run pytest tests/unit
+     PYTEST_TORCH_DEVICE=cuda:0 uv run pytest tests/unit
      ```
 
    - To check that the usage examples from docstrings and `.rst` files are correct, run:

--- a/tests/profiling/run_profiler.py
+++ b/tests/profiling/run_profiler.py
@@ -136,6 +136,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    # To test this on cuda, add the following environment variables when running this:
-    # CUBLAS_WORKSPACE_CONFIG=:4096:8;PYTEST_TORCH_DEVICE=cuda:0
+    # To test this on cuda, set the following environment variable when running this:
+    # PYTEST_TORCH_DEVICE=cuda:0
     main()

--- a/tests/profiling/speed_grad_vs_jac_vs_gram.py
+++ b/tests/profiling/speed_grad_vs_jac_vs_gram.py
@@ -154,6 +154,6 @@ def print_times(name: str, times: Tensor) -> None:
 
 
 if __name__ == "__main__":
-    # To test this on cuda, add the following environment variables when running this:
-    # CUBLAS_WORKSPACE_CONFIG=:4096:8;PYTEST_TORCH_DEVICE=cuda:0
+    # To test this on cuda, set the following environment variable when running this:
+    # PYTEST_TORCH_DEVICE=cuda:0
     main()


### PR DESCRIPTION
## Summary

`CUBLAS_WORKSPACE_CONFIG=:4096:8` appeared in three places (`CONTRIBUTING.md`, `tests/profiling/run_profiler.py`, `tests/profiling/speed_grad_vs_jac_vs_gram.py`) but is no longer needed. This PR removes it.

## History

- **Initial squashed commit (June 2024):** `tests/unit/conftest.py` called `torch.use_deterministic_algorithms(True)` unconditionally for all devices. `CUBLAS_WORKSPACE_CONFIG=:4096:8` is required by cuBLAS when deterministic mode is enabled on CUDA, so the variable was necessary.

- **Commit `83d2e046`** ("Add command for cuda unit tests in CONTRIBUTING.md"): Added the `CUBLAS_WORKSPACE_CONFIG=:4096:8` instruction to `CONTRIBUTING.md` for running unit tests on CUDA — correct at the time.

- **PR #387 / commit `d1594301`** ("feat: add `autogram.Engine` (batched)", Aug 2025): Changed `conftest.py` to only call `torch.use_deterministic_algorithms(True)` on CPU, with an explicit comment explaining why ("we also use GPU to benchmark algorithms, and we would rather have them use non-deterministic but faster algorithms"). The commit message even lists "Force using deterministic algorithms only on CPU" under the Testing section. However, `CUBLAS_WORKSPACE_CONFIG` was left behind in all three places — an oversight.

Since PR #387, `CUBLAS_WORKSPACE_CONFIG` has been unnecessary:
- **Tests on CUDA:** deterministic algorithms are not enabled → cuBLAS does not require the workspace config.
- **Profiling on CUDA:** same, and non-deterministic algorithms are preferable for benchmarking.
- **`tests/trajectories/optimize.py`:** does call `use_deterministic_algorithms(True)` unconditionally, but all its tensors are CPU-only (the script ends with `.numpy()` calls), so cuBLAS is never involved.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)