### PR TITLE
ci: Test with torch nightly

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -54,5 +54,5 @@ runs:
       if: ${{ inputs.torch_channel == 'nightly' }}
       shell: bash
       run: |
-        uv pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
+        uv pip install --pre --upgrade torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
         uv run python -c "import torch, torchvision; print('torch:', torch.__version__, '| torchvision:', torchvision.__version__)"

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'Dependency groups to install (space-separated, e.g., "test doc")'
     required: false
     default: ''
+  torch_channel:
+    description: 'PyTorch channel to use. Use "nightly" to upgrade torch and torchvision to the latest nightly build.'
+    required: false
+    default: 'stable'
 
 runs:
   using: composite
@@ -45,3 +49,8 @@ runs:
         # Print and execute the command
         echo $cmd
         eval $cmd
+
+    - name: Upgrade to torch nightly
+      if: ${{ inputs.torch_channel == 'nightly' }}
+      shell: bash
+      run: uv pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -53,4 +53,6 @@ runs:
     - name: Upgrade to torch nightly
       if: ${{ inputs.torch_channel == 'nightly' }}
       shell: bash
-      run: uv pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
+      run: |
+        uv pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
+        uv run python -c "import torch, torchvision; print('torch:', torch.__version__, '| torchvision:', torchvision.__version__)"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,7 +17,7 @@ jobs:
   tests:
     # Default config: py3.14, ubuntu-latest, float32, full options.
     # The idea is to make each of those params vary one by one, to limit the number of tests to run.
-    name: Tests (py${{ matrix.python-version || '3.14' }}, ${{ matrix.os || 'ubuntu-latest' }}, ${{ matrix.dtype || 'float32' }}, ${{ matrix.options || 'full' }}${{ matrix.extra_groups && format(', {0}', matrix.extra_groups) || '' }})
+    name: Tests (py${{ matrix.python-version || '3.14' }}, ${{ matrix.os || 'ubuntu-latest' }}, ${{ matrix.dtype || 'float32' }}, ${{ matrix.options || 'full' }}${{ matrix.extra_groups && format(', {0}', matrix.extra_groups) || '' }}${{ matrix.torch_channel == 'nightly' && ', torch-nightly' || '' }})
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
@@ -39,6 +39,8 @@ jobs:
           # Lower-bounds of all dependencies and Python version.
           - python-version: '3.10.0'
             extra_groups: 'lower_bounds'
+          # Upper-bounds: torch nightly build.
+          - torch_channel: 'nightly'
 
     steps:
       - name: Checkout repository
@@ -53,6 +55,7 @@ jobs:
         with:
           options: ${{ matrix.options || 'full' }}
           groups: test ${{ matrix.extra_groups }}
+          torch_channel: ${{ matrix.torch_channel || 'stable' }}
 
       - name: Run unit tests
         run: uv run pytest -W error tests/unit --cov=src --cov-report=xml

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,7 +39,7 @@ jobs:
           # Lower-bounds of all dependencies and Python version.
           - python-version: '3.10.0'
             extra_groups: 'lower_bounds'
-          # Upper-bounds: torch nightly build.
+          # Latest: torch nightly build.
           - torch_channel: 'nightly'
 
     steps:


### PR DESCRIPTION
Add a CI matrix entry that installs the torch nightly build and runs the unit test suite against it.

The `install-deps` action gains a `torch_channel` input (default: `stable`); when set to `nightly`, it upgrades `torch` and `torchvision` from the PyTorch nightly CPU index after the normal install step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)