### PR TITLE
chore: Prepare v0.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ changelog does not include internal changes that do not affect the user.
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-28
+
 ### Added
 
 - Added a new `torchjd.scalarization` package providing the abstract `Scalarizer` base class and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchjd"
-version = "0.11.0"
+version = "0.12.0"
 description = "Library for Jacobian Descent with PyTorch."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Bumps version to `0.12.0` and adds the release header in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)