### PR TITLE
ci: Avoid pre-release numpy in torch nightly job

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -54,5 +54,5 @@ runs:
       if: ${{ inputs.torch_channel == 'nightly' }}
       shell: bash
       run: |
-        uv pip install --pre --upgrade torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
+        uv pip install --pre torch torchvision -P torch -P torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cpu
         uv run python -c "import torch, torchvision; print('torch:', torch.__version__, '| torchvision:', torchvision.__version__)"


### PR DESCRIPTION
The torch nightly install step used `--pre --upgrade torch torchvision --index-url <nightly>`. `--index-url` replaced PyPI with the pre-release-only nightly channel and `--upgrade` re-resolved every dependency, so numpy was pulled in as a pre-release.

Now the upgrade is scoped to torch/torchvision (`-P torch -P torchvision`) and `--extra-index-url` keeps PyPI reachable, so numpy stays on its release version.

This is the nightly failure seen in #721.

🤖 Generated with [Claude Code](https://claude.com/claude-code)