### PR TITLE
chore: Prepare v0.14.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ changelog does not include internal changes that do not affect the user.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-10
+
 ### Added
 
 - Added `IMTL-L` (the loss-balancing variant of Impartial Multi-Task Learning) from [Towards

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchjd"
-version = "0.13.0"
+version = "0.14.0"
 description = "Library for Jacobian Descent with PyTorch."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Prepares the v0.14.0 release:

- Added the `[0.14.0] - 2026-06-10` header in the changelog below `[Unreleased]`.
- Bumped the version in `pyproject.toml` to `0.14.0`.

Changes included since v0.13.0: `IMTL-L` (#725) and `UW` (#721).

🤖 Generated with [Claude Code](https://claude.com/claude-code)