### PR TITLE
refactor(aggregation): Register state tensors as buffers

### DIFF
--- a/src/torchjd/aggregation/_cr_mogm.py
+++ b/src/torchjd/aggregation/_cr_mogm.py
@@ -105,7 +105,7 @@ class CRMOGMWeighting(Weighting[_T], Stateful):
         self.weighting = weighting
         self.alpha = alpha
         self._initial_weights = initial_weights
-        self._lambda: Tensor | None = None
+        self.register_buffer("_lambda", None)
 
     @property
     def alpha(self) -> float:

--- a/src/torchjd/aggregation/_gradvac.py
+++ b/src/torchjd/aggregation/_gradvac.py
@@ -44,7 +44,7 @@ class GradVacWeighting(_GramianWeighting, Stateful, _NonDifferentiable):
         super().__init__()
         self.beta = beta
         self.eps = eps
-        self._phi_t: Tensor | None = None
+        self.register_buffer("_phi_t", None)
         self._state_key: tuple[int, torch.dtype] | None = None
 
     @property

--- a/src/torchjd/aggregation/_modo.py
+++ b/src/torchjd/aggregation/_modo.py
@@ -133,7 +133,7 @@ class MoDoWeighting(_MatrixWeighting, Stateful, _NonDifferentiable):
         super().__init__()
         self.gamma = gamma
         self.rho = rho
-        self._lambda: Tensor | None = None
+        self.register_buffer("_lambda", None)
         self._state_key: tuple[int, torch.dtype, torch.device] | None = None
 
     @property

--- a/src/torchjd/aggregation/_sdmgrad.py
+++ b/src/torchjd/aggregation/_sdmgrad.py
@@ -107,7 +107,7 @@ class SDMGradWeighting(_MatrixWeighting, Stateful, _NonDifferentiable):
         self.n_iter = n_iter
         self.lambda_ = lambda_
         self.pref_vector = pref_vector
-        self._w: Tensor | None = None
+        self.register_buffer("_w", None)
         self._state_key: tuple[int, torch.dtype, torch.device] | None = None
 
     @property


### PR DESCRIPTION
## Summary

- `GradVacWeighting._phi_t`, `CRMOGMWeighting._lambda`, `MoDoWeighting._lambda`, and `SDMGradWeighting._w` were plain Python attributes initialised to `None`.
- Changed each to `self.register_buffer(...)` so that `nn.Module.to(device="cuda")` (or `.to(dtype=...)`) automatically moves the warm-started state tensor when the user migrates their model to GPU.
- `_NashMTLWeighting` is unchanged — its state is NumPy/cvxpy arrays, not PyTorch tensors.
- `_state_key` tuples are left as plain attributes (not tensors).
- Existing `forward()` and `reset()` assignments (`self._w = w`, `self._w = None`) continue to work: PyTorch's `__setattr__` routes assignments to registered buffer names through `_buffers` automatically.

## Test plan

- [ ] `uv run pytest tests/unit -q` — 3167 passed, 0 failed
- [ ] `uv run ty check` on all five files — 0 new errors (7 pre-existing NashMTL/cvxpy errors unchanged)

Claude Code was used to assist with this task