### PR TITLE
chore: Prepare v0.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ changelog does not include internal changes that do not affect the user.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-06-22
+
 ### Added
 
 - Added `COSMOS` from [Scalable Pareto Front Approximation for Deep Multi-Objective

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchjd"
-version = "0.15.0"
+version = "0.16.0"
 description = "Library for Jacobian Descent with PyTorch."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
- Adds `## [0.16.0] - 2026-06-22` version header to `CHANGELOG.md`
- Bumps version in `pyproject.toml` from `0.15.0` to `0.16.0`